### PR TITLE
Asynchronous Performance Speedups

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Extensions/MySqlEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Extensions/MySqlEntityFrameworkServicesBuilderExtensions.cs
@@ -12,7 +12,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
-using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -33,9 +32,10 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Check.NotNull(services, nameof(services));
 
-            services.AddRelational()
-                .AddScoped<IRelationalCommandBuilderFactory, MySqlCommandBuilderFactory>()
-                .AddScoped<IIncludeExpressionVisitorFactory, MySqlIncludeExpressionVisitorFactory>();
+	        services.AddRelational()
+		        .AddScoped<IRelationalCommandBuilderFactory, MySqlCommandBuilderFactory>()
+		        .AddScoped<IIncludeExpressionVisitorFactory, MySqlIncludeExpressionVisitorFactory>()
+		        .AddScoped<RelationalQueryContextFactory, MySqlQueryContextFactory>();
 
             services.TryAddEnumerable(ServiceDescriptor
                 .Singleton<IDatabaseProvider, DatabaseProvider<MySqlDatabaseProviderServices, MySqlOptionsExtension>>());

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlAsyncQueryMethodProvider.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlAsyncQueryMethodProvider.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Query
+{
+	public class MySqlAsyncQueryMethodProvider : AsyncQueryMethodProvider
+	{
+
+		private static readonly MethodInfo _baseShapedQuery =
+			typeof(AsyncQueryMethodProvider).GetTypeInfo().GetDeclaredMethod("_ShapedQuery");
+
+		private static readonly MethodInfo _baseDefaultIfEmptyShapedQuery =
+			typeof(AsyncQueryMethodProvider).GetTypeInfo().GetDeclaredMethod("_DefaultIfEmptyShapedQuery");
+
+		private static readonly MethodInfo _baseQuery =
+			typeof(AsyncQueryMethodProvider).GetTypeInfo().GetDeclaredMethod("_Query");
+
+		private static readonly MethodInfo _baseInclude =
+			typeof(AsyncQueryMethodProvider).GetTypeInfo().GetDeclaredMethod("_Include");
+
+
+		public override MethodInfo ShapedQueryMethod => _shapedQueryMethodInfo;
+
+		private static readonly MethodInfo _shapedQueryMethodInfo
+			= typeof(MySqlAsyncQueryMethodProvider).GetTypeInfo()
+				.GetDeclaredMethod(nameof(_ShapedQuery));
+
+		private static IAsyncEnumerable<T> _ShapedQuery<T>(
+			QueryContext queryContext,
+			ShaperCommandContext shaperCommandContext,
+			IShaper<T> shaper)
+		{
+			return new MySqlAsyncQueryingEnumerable<T>(queryContext as MySqlQueryContext,
+				(IAsyncEnumerable<T>) _baseShapedQuery.MakeGenericMethod(typeof(T))
+					.Invoke(null, new object[] {queryContext, shaperCommandContext, shaper}));
+		}
+
+
+		public override MethodInfo DefaultIfEmptyShapedQueryMethod => _defaultIfEmptyShapedQueryMethodInfo;
+
+		private static readonly MethodInfo _defaultIfEmptyShapedQueryMethodInfo
+			= typeof(MySqlAsyncQueryMethodProvider).GetTypeInfo()
+				.GetDeclaredMethod(nameof(_DefaultIfEmptyShapedQuery));
+
+		[UsedImplicitly]
+		private static IAsyncEnumerable<T> _DefaultIfEmptyShapedQuery<T>(
+			QueryContext queryContext,
+			ShaperCommandContext shaperCommandContext,
+			IShaper<T> shaper)
+		{
+			return new MySqlAsyncQueryingEnumerable<T>(queryContext as MySqlQueryContext,
+				(IAsyncEnumerable<T>) _baseDefaultIfEmptyShapedQuery.MakeGenericMethod(typeof(T))
+				.Invoke(null, new object[] {queryContext, shaperCommandContext, shaper}));
+		}
+
+
+		public override MethodInfo QueryMethod => _queryMethodInfo;
+
+		private static readonly MethodInfo _queryMethodInfo
+			= typeof(MySqlAsyncQueryMethodProvider).GetTypeInfo()
+				.GetDeclaredMethod(nameof(_Query));
+
+		private static IAsyncEnumerable<ValueBuffer> _Query(
+			QueryContext queryContext,
+			ShaperCommandContext shaperCommandContext,
+			int? queryIndex)
+		{
+			return new MySqlAsyncQueryingEnumerable<ValueBuffer>(queryContext as MySqlQueryContext,
+				(IAsyncEnumerable<ValueBuffer>) _baseQuery.Invoke(null, new object[] {queryContext, shaperCommandContext, queryIndex}));
+		}
+
+
+		public override MethodInfo IncludeMethod => _includeMethodInfo;
+
+		private static readonly MethodInfo _includeMethodInfo
+			= typeof(MySqlAsyncQueryMethodProvider).GetTypeInfo()
+				.GetDeclaredMethod(nameof(_Include));
+
+		private static IAsyncEnumerable<T> _Include<T>(
+			RelationalQueryContext queryContext,
+			IAsyncEnumerable<T> innerResults,
+			Func<T, object> entityAccessor,
+			IReadOnlyList<INavigation> navigationPath,
+			IReadOnlyList<Func<QueryContext, IAsyncRelatedEntitiesLoader>> relatedEntitiesLoaderFactories,
+			bool querySourceRequiresTracking)
+		{
+			// ReSharper disable once PossibleNullReferenceException
+			(queryContext as MySqlQueryContext).HasInclude = true;
+			return (IAsyncEnumerable<T>) _baseInclude.MakeGenericMethod(typeof(T))
+				.Invoke(null, new object[] {queryContext, innerResults, entityAccessor, navigationPath, relatedEntitiesLoaderFactories, querySourceRequiresTracking});
+		}
+
+	}
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlAsyncQueryingEnumerable.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlAsyncQueryingEnumerable.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+
+	/// Wraps an AsyncQueryingEnumerable in an enumerable that opens a RepeatableRead transaction when querying with Includes
+	/// This way every statement within the Includes gets a consistent snapshot of the database
+	public class MySqlAsyncQueryingEnumerable<T> : IAsyncEnumerable<T>
+	{
+		private readonly MySqlQueryContext _queryContext;
+		private readonly IAsyncEnumerable<T> _source;
+
+		public MySqlAsyncQueryingEnumerable(MySqlQueryContext queryContext, IAsyncEnumerable<T> source)
+        {
+	        _queryContext = queryContext;
+	        _source = source;
+        }
+
+        public IAsyncEnumerator<T> GetEnumerator()
+            => new MySqlAsyncEnumerator(_queryContext, _source.GetEnumerator());
+
+        private sealed class MySqlAsyncEnumerator : IAsyncEnumerator<T>
+        {
+            private readonly IAsyncEnumerator<T> _enumerator;
+	        private readonly MySqlQueryContext _queryContext;
+	        private MySqlRelationalTransaction _transaction;
+	        private bool _tryInitTransaction;
+
+	        public MySqlAsyncEnumerator(MySqlQueryContext queryContext, IAsyncEnumerator<T> enumerator)
+            {
+	            _queryContext = queryContext;
+	            _enumerator = enumerator;
+            }
+
+            public async Task<bool> MoveNext(CancellationToken cancellationToken)
+            {
+	            if (!_tryInitTransaction)
+	            {
+		            if (_queryContext.HasInclude && _queryContext.Connection.CurrentTransaction == null)
+		            {
+			            _transaction = await _queryContext.Connection.BeginTransactionAsync(IsolationLevel.RepeatableRead, cancellationToken).ConfigureAwait(false) as MySqlRelationalTransaction;
+		            }
+		            _tryInitTransaction = true;
+	            }
+                if (!await _enumerator.MoveNext(cancellationToken).ConfigureAwait(false))
+                {
+	                if (_transaction != null)
+	                {
+		                await _transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+	                }
+                    return false;
+                }
+                return true;
+            }
+
+            public T Current => _enumerator.Current;
+
+	        public void Dispose()
+	        {
+		        _enumerator.Dispose();
+		        _transaction?.Dispose();
+	        }
+		}
+
+	}
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryCompilationContextFactory.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryCompilationContextFactory.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     EntityQueryModelVisitorFactory,
                     RequiresMaterializationExpressionVisitorFactory,
                     new AsyncLinqOperatorProvider(),
-                    new AsyncQueryMethodProvider(),
+                    new MySqlAsyncQueryMethodProvider(),
                     ContextType,
                     TrackQueryResults)
                 : new MySqlQueryCompilationContext(
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     EntityQueryModelVisitorFactory,
                     RequiresMaterializationExpressionVisitorFactory,
                     new LinqOperatorProvider(),
-                    new QueryMethodProvider(),
+                    new MySqlQueryMethodProvider(),
                     ContextType,
                     TrackQueryResults);
     }

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryContext.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryContext.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Query
+{
+	public class MySqlQueryContext : RelationalQueryContext
+	{
+		public bool HasInclude = false;
+
+		public MySqlQueryContext(
+			[NotNull] Func<IQueryBuffer> queryBufferFactory,
+			[NotNull] IRelationalConnection connection,
+			[NotNull] IStateManager stateManager,
+			[NotNull] IConcurrencyDetector concurrencyDetector)
+			: base(queryBufferFactory, connection, stateManager, concurrencyDetector)
+		{
+		}
+	}
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryContextFactory.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryContextFactory.cs
@@ -1,0 +1,26 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+	public class MySqlQueryContextFactory : RelationalQueryContextFactory
+	{
+		private readonly IRelationalConnection _connection;
+
+		public MySqlQueryContextFactory(
+			[NotNull] IStateManager stateManager,
+			[NotNull] IConcurrencyDetector concurrencyDetector,
+			[NotNull] IRelationalConnection connection,
+			[NotNull] IChangeDetector changeDetector)
+			: base(stateManager, concurrencyDetector, connection, changeDetector)
+		{
+			_connection = connection;
+		}
+
+		public override QueryContext Create()
+			=> new MySqlQueryContext(CreateQueryBuffer, _connection, StateManager, ConcurrencyDetector);
+	}
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryMethodProvider.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryMethodProvider.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Query
+{
+	public class MySqlQueryMethodProvider : QueryMethodProvider
+	{
+
+		private static readonly MethodInfo _baseShapedQuery =
+			typeof(QueryMethodProvider).GetTypeInfo().GetDeclaredMethod("_ShapedQuery");
+
+		private static readonly MethodInfo _baseDefaultIfEmptyShapedQuery =
+			typeof(QueryMethodProvider).GetTypeInfo().GetDeclaredMethod("_DefaultIfEmptyShapedQuery");
+
+		private static readonly MethodInfo _baseQuery =
+			typeof(QueryMethodProvider).GetTypeInfo().GetDeclaredMethod("_Query");
+
+		private static readonly MethodInfo _baseInclude =
+			typeof(QueryMethodProvider).GetTypeInfo().GetDeclaredMethod("_Include");
+
+
+		public override MethodInfo ShapedQueryMethod => _shapedQueryMethodInfo;
+
+		private static readonly MethodInfo _shapedQueryMethodInfo
+			= typeof(MySqlQueryMethodProvider).GetTypeInfo()
+				.GetDeclaredMethod(nameof(_ShapedQuery));
+
+		private static IEnumerable<T> _ShapedQuery<T>(
+			QueryContext queryContext,
+			ShaperCommandContext shaperCommandContext,
+			IShaper<T> shaper)
+		{
+			return new MySqlQueryingEnumerable<T>(queryContext as MySqlQueryContext,
+				(IEnumerable<T>) _baseShapedQuery.MakeGenericMethod(typeof(T))
+					.Invoke(null, new object[] {queryContext, shaperCommandContext, shaper}));
+		}
+
+
+		public override MethodInfo DefaultIfEmptyShapedQueryMethod => _defaultIfEmptyShapedQueryMethodInfo;
+
+		private static readonly MethodInfo _defaultIfEmptyShapedQueryMethodInfo
+			= typeof(MySqlQueryMethodProvider).GetTypeInfo()
+				.GetDeclaredMethod(nameof(_DefaultIfEmptyShapedQuery));
+
+		[UsedImplicitly]
+		private static IEnumerable<T> _DefaultIfEmptyShapedQuery<T>(
+			QueryContext queryContext,
+			ShaperCommandContext shaperCommandContext,
+			IShaper<T> shaper)
+		{
+			return new MySqlQueryingEnumerable<T>(queryContext as MySqlQueryContext,
+				(IEnumerable<T>) _baseDefaultIfEmptyShapedQuery.MakeGenericMethod(typeof(T))
+					.Invoke(null, new object[] {queryContext, shaperCommandContext, shaper}));
+		}
+
+
+		public override MethodInfo QueryMethod => _queryMethodInfo;
+
+		private static readonly MethodInfo _queryMethodInfo
+			= typeof(MySqlQueryMethodProvider).GetTypeInfo()
+				.GetDeclaredMethod(nameof(_Query));
+
+		private static IEnumerable<ValueBuffer> _Query(
+			QueryContext queryContext,
+			ShaperCommandContext shaperCommandContext,
+			int? queryIndex)
+		{
+			return new MySqlQueryingEnumerable<ValueBuffer>(queryContext as MySqlQueryContext,
+				(IEnumerable<ValueBuffer>)
+				_baseQuery.Invoke(null, new object[] {queryContext, shaperCommandContext, queryIndex}));
+		}
+
+
+		public override MethodInfo IncludeMethod => _includeMethodInfo;
+
+		private static readonly MethodInfo _includeMethodInfo
+			= typeof(MySqlQueryMethodProvider).GetTypeInfo()
+				.GetDeclaredMethod(nameof(_Include));
+
+		private static IEnumerable<T> _Include<T>(
+			RelationalQueryContext queryContext,
+			IEnumerable<T> innerResults,
+			Func<T, object> entityAccessor,
+			IReadOnlyList<INavigation> navigationPath,
+			IReadOnlyList<Func<QueryContext, IRelatedEntitiesLoader>> relatedEntitiesLoaderFactories,
+			bool querySourceRequiresTracking)
+		{
+			// ReSharper disable once PossibleNullReferenceException
+			(queryContext as MySqlQueryContext).HasInclude = true;
+			return (IEnumerable<T>) _baseInclude.MakeGenericMethod(typeof(T))
+				.Invoke(null, new object[] {queryContext, innerResults, entityAccessor, navigationPath, relatedEntitiesLoaderFactories, querySourceRequiresTracking});
+		}
+
+	}
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryingEnumerable.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryingEnumerable.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+
+	/// Wraps an QueryingEnumerable in an enumerable that opens a RepeatableRead transaction when querying with Includes
+	/// This way every statement within the Includes gets a consistent snapshot of the database
+	public class MySqlQueryingEnumerable<T> : IEnumerable<T>
+	{
+		private readonly MySqlQueryContext _queryContext;
+		private readonly IEnumerable<T> _source;
+
+		public MySqlQueryingEnumerable(MySqlQueryContext queryContext, IEnumerable<T> source)
+		{
+			_queryContext = queryContext;
+			_source = source;
+		}
+
+		public IEnumerator<T> GetEnumerator()
+			=> new MySqlEnumerator(_queryContext, _source.GetEnumerator());
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		private sealed class MySqlEnumerator : IEnumerator<T>
+		{
+			private readonly IEnumerator<T> _enumerator;
+			private readonly MySqlQueryContext _queryContext;
+			private MySqlRelationalTransaction _transaction;
+			private bool _tryInitTransaction;
+
+			public MySqlEnumerator(MySqlQueryContext queryContext, IEnumerator<T> enumerator)
+			{
+				_queryContext = queryContext;
+				_enumerator = enumerator;
+			}
+
+			public bool MoveNext()
+			{
+				if (!_tryInitTransaction)
+				{
+					if (_queryContext.HasInclude && _queryContext.Connection.CurrentTransaction == null)
+					{
+						_transaction = _queryContext.Connection.BeginTransaction(IsolationLevel.RepeatableRead) as MySqlRelationalTransaction;
+					}
+					_tryInitTransaction = true;
+				}
+				if (!_enumerator.MoveNext())
+				{
+					_transaction?.Commit();
+					return false;
+				}
+				return true;
+			}
+
+			public void Reset() => _enumerator.Reset();
+
+			public T Current => _enumerator.Current;
+
+			object IEnumerator.Current => _enumerator.Current;
+
+			public void Dispose()
+			{
+				_enumerator.Dispose();
+				_transaction?.Dispose();
+			}
+		}
+
+	}
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -1,48 +1,377 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
+using System.Data;
 using System.Data.Common;
 using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 using MySql.Data.MySqlClient;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
-    public class MySqlRelationalConnection : RelationalConnection
+    public class MySqlRelationalConnection : IRelationalConnection
     {
-        public MySqlRelationalConnection(
-            [NotNull] IDbContextOptions options,
-            // ReSharper disable once SuggestBaseTypeForParameter
-            [NotNull] ILogger<MySqlConnection> logger)
-            : base(options, logger)
-        {
-        }
-
-        private MySqlRelationalConnection(
-            [NotNull] IDbContextOptions options, [NotNull] ILogger logger)
-            : base(options, logger)
-        {
-        }
+        private readonly string _connectionString;
+        private MySqlConnection _connection;
+        private readonly bool _connectionOwned;
+        private int _openedCount;
+        private bool _openedInternally;
+        private int? _commandTimeout;
 
         public readonly SemaphoreSlim Lock = new SemaphoreSlim(1);
+        private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1);
 
-        // TODO: Consider using DbProviderFactory to create connection instance
-        // Issue #774
-        protected override DbConnection CreateDbConnection() => new MySqlConnection(ConnectionString);
+        public MySqlRelationalConnection([NotNull] IDbContextOptions options)
+        {
+            Check.NotNull(options, nameof(options));
+
+            var relationalOptions = RelationalOptionsExtension.Extract(options);
+            _commandTimeout = relationalOptions.CommandTimeout;
+            if (relationalOptions.Connection != null)
+            {
+                if (!string.IsNullOrWhiteSpace(relationalOptions.ConnectionString))
+                {
+                    throw new InvalidOperationException(RelationalStrings.ConnectionAndConnectionString);
+                }
+                _connection = relationalOptions.Connection as MySqlConnection;
+                _connectionOwned = false;
+            }
+            else if (!string.IsNullOrWhiteSpace(relationalOptions.ConnectionString))
+            {
+                _connectionString = relationalOptions.ConnectionString;
+                _connectionOwned = true;
+            }
+            else
+            {
+                throw new InvalidOperationException(RelationalStrings.NoConnectionOrConnectionString);
+            }
+        }
+
+        public DbConnection DbConnection {
+            get
+            {
+                if (_connection == null)
+                {
+                    _connection = new MySqlConnection(ConnectionString);
+                }
+                return _connection;
+            }
+        }
+
+	    private MySqlConnection MySqlDbConnection => DbConnection as MySqlConnection;
 
         public MySqlRelationalConnection CreateMasterConnection()
         {
-            var csb = new MySqlConnectionStringBuilder(ConnectionString) {
+            var csb = new MySqlConnectionStringBuilder(ConnectionString)
+            {
                 Database = "mysql",
                 Pooling = false
             };
-            
+
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseMySql(csb.ConnectionString);
-            return new MySqlRelationalConnection(optionsBuilder.Options, Logger);
+            return new MySqlRelationalConnection(optionsBuilder.Options);
         }
+
+	    private MySqlConnectionStringBuilder _connectionStringBuilder;
+
+	    protected MySqlConnectionStringBuilder ConnectionStringBuilder
+		    => _connectionStringBuilder ?? (_connectionStringBuilder = new MySqlConnectionStringBuilder(ConnectionString));
+
+        public string ConnectionString => _connectionString ?? _connection.ConnectionString;
+
+        public IDbContextTransaction CurrentTransaction { get; [param: CanBeNull] protected set; }
+
+        public virtual int? CommandTimeout
+        {
+            get { return _commandTimeout; }
+            set
+            {
+                if (value.HasValue
+                    && (value < 0))
+                {
+                    throw new ArgumentException(RelationalStrings.InvalidCommandTimeout);
+                }
+
+                _commandTimeout = value;
+            }
+        }
+
+        public IDbContextTransaction BeginTransaction() => BeginTransaction(IsolationLevel.Unspecified);
+
+        public async Task<IDbContextTransaction> BeginTransactionAsync(
+                CancellationToken cancellationToken = default(CancellationToken))
+            => await BeginTransactionAsync(IsolationLevel.Unspecified, cancellationToken).ConfigureAwait(false);
+
+        public IDbContextTransaction BeginTransaction(IsolationLevel isolationLevel)
+        {
+            if (CurrentTransaction != null)
+            {
+                throw new InvalidOperationException(RelationalStrings.TransactionAlreadyStarted);
+            }
+            DoOpen();
+            return BeginTransactionWithNoPreconditions(isolationLevel);
+        }
+
+        public async Task<IDbContextTransaction> BeginTransactionAsync(
+            IsolationLevel isolationLevel,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (CurrentTransaction != null)
+            {
+                throw new InvalidOperationException(RelationalStrings.TransactionAlreadyStarted);
+            }
+            await DoOpenAsync(cancellationToken).ConfigureAwait(false);
+            return await BeginTransactionWithNoPreconditionsAsync(isolationLevel, cancellationToken).ConfigureAwait(false);
+        }
+
+        private IDbContextTransaction BeginTransactionWithNoPreconditions(IsolationLevel isolationLevel)
+        {
+            CurrentTransaction
+                = new MySqlRelationalTransaction(
+                    this,
+                    // ReSharper disable once AssignNullToNotNullAttribute
+                    MySqlDbConnection.BeginTransaction(isolationLevel) as MySqlTransaction, true);
+
+            return CurrentTransaction;
+        }
+
+	    private async Task<IDbContextTransaction> BeginTransactionWithNoPreconditionsAsync(
+		    IsolationLevel isolationLevel,
+		    CancellationToken cancellationToken = default(CancellationToken)
+	    )
+	    {
+		    CurrentTransaction = new MySqlRelationalTransaction(this, await MySqlDbConnection.BeginTransactionAsync(isolationLevel, cancellationToken).ConfigureAwait(false), true);
+		    return CurrentTransaction;
+	    }
+
+	    public IDbContextTransaction UseTransaction(DbTransaction transaction)
+	    {
+		    if (transaction == null)
+		    {
+			    if (CurrentTransaction != null)
+			    {
+				    CurrentTransaction = null;
+				    DoClose();
+			    }
+		    }
+            else
+            {
+	            var mySqlTransaction = transaction as MySqlTransaction;
+	            if (mySqlTransaction == null)
+	            {
+		            throw new InvalidCastException("transaction must be of the type MySqlTransaction");
+	            }
+	            if (CurrentTransaction != null)
+                {
+                    throw new InvalidOperationException(RelationalStrings.TransactionAlreadyStarted);
+                }
+                DoOpen();
+                CurrentTransaction = new MySqlRelationalTransaction(this, mySqlTransaction, false);
+            }
+            return CurrentTransaction;
+        }
+
+        public void CommitTransaction()
+        {
+            if (CurrentTransaction == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+            }
+
+            CurrentTransaction.Commit();
+        }
+
+        public void RollbackTransaction()
+        {
+            if (CurrentTransaction == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+            }
+
+            CurrentTransaction.Rollback();
+        }
+
+	    protected void DoOpen()
+	    {
+		    _connectionLock.Wait();
+		    try
+		    {
+			    if (_openedCount == 0 && DbConnection.State != ConnectionState.Open)
+			    {
+				    DbConnection.Open();
+				    _openedInternally = true;
+			    }
+			    _openedCount++;
+		    }
+		    finally
+		    {
+			    _connectionLock.Release();
+		    }
+	    }
+
+	    protected async Task DoOpenAsync(CancellationToken cancellationToken = default(CancellationToken))
+	    {
+		    cancellationToken.ThrowIfCancellationRequested();
+		    await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+		    try
+		    {
+			    if (_openedCount == 0 && DbConnection.State != ConnectionState.Open)
+			    {
+				    await DbConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+				    _openedInternally = true;
+			    }
+			    _openedCount++;
+		    }
+		    finally
+		    {
+			    _connectionLock.Release();
+		    }
+	    }
+
+	    protected void DoClose()
+	    {
+		    _connectionLock.Wait();
+		    try
+		    {
+			    if (_openedCount > 0 && --_openedCount == 0 && _openedInternally)
+			    {
+				    DbConnection.Close();
+				    _openedInternally = false;
+			    }
+		    }
+		    finally
+		    {
+			    _connectionLock.Release();
+		    }
+	    }
+
+	    // Optomizations have been added to return connections to the pool faster
+	    // Prefer PoolingOpen/Close functions when Connection Pooling is enabled
+
+	    public void PoolingOpen()
+	    {
+		    if (ConnectionStringBuilder.Pooling)
+		    {
+			    DoOpen();
+		    }
+	    }
+
+	    public async Task PoolingOpenAsync(CancellationToken cancellationToken = default(CancellationToken))
+	    {
+		    if (ConnectionStringBuilder.Pooling)
+		    {
+			    await DoOpenAsync(cancellationToken).ConfigureAwait(false);
+		    }
+	    }
+
+	    public void PoolingClose()
+	    {
+		    if (ConnectionStringBuilder.Pooling)
+		    {
+			    DoClose();
+		    }
+	    }
+
+	    // Use normal Open/Close functions when Connection Pooling is disabled
+	    // These calls are used by Microsoft.EntityFrameworkCore
+
+	    public void Open()
+        {
+	        if (!ConnectionStringBuilder.Pooling)
+	        {
+		        DoOpen();
+	        }
+	        else
+	        {
+		        // extarnal libraries can still try to open.  execute it but don't count it
+		        _connectionLock.Wait();
+		        try
+		        {
+			        if (DbConnection.State != ConnectionState.Open)
+			        {
+				        DbConnection.Open();
+				        _openedInternally = true;
+			        }
+		        }
+		        finally
+		        {
+			        _connectionLock.Release();
+		        }
+	        }
+        }
+
+        public async Task OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+	        if (!ConnectionStringBuilder.Pooling)
+	        {
+		        await DoOpenAsync(cancellationToken).ConfigureAwait(false);
+	        }
+	        else
+	        {
+		        // extarnal libraries can still try to open.  execute it but don't count it
+		        await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+		        try
+		        {
+			        if (DbConnection.State != ConnectionState.Open)
+			        {
+				        await DbConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+				        _openedInternally = true;
+			        }
+		        }
+		        finally
+		        {
+			        _connectionLock.Release();
+		        }
+	        }
+        }
+
+        public void Close()
+        {
+	        if (!ConnectionStringBuilder.Pooling)
+	        {
+		        DoClose();
+	        }
+	        else
+	        {
+		        // extarnal libraries can still try to close.  close it if we manage it and count == 0
+		        _connectionLock.Wait();
+		        try
+		        {
+			        if (_openedCount == 0 && _openedInternally)
+			        {
+				        DbConnection.Close();
+				        _openedInternally = false;
+			        }
+		        }
+		        finally
+		        {
+			        _connectionLock.Release();
+		        }
+	        }
+        }
+
+        public bool IsMultipleActiveResultSetsEnabled => false;
+
+        public IValueBufferCursor ActiveCursor { get; set; }
+
+        public virtual void Dispose()
+        {
+            CurrentTransaction?.Dispose();
+            if (_connectionOwned && _connection != null)
+            {
+                _connection.Dispose();
+                _connection = null;
+                _openedCount = 0;
+            }
+        }
+
     }
 }

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalTransaction.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalTransaction.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using MySql.Data.MySqlClient;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    public class MySqlRelationalTransaction : IDbContextTransaction, IInfrastructure<DbTransaction>
+    {
+        private readonly IRelationalConnection _relationalConnection;
+        private readonly MySqlTransaction _dbTransaction;
+        private readonly bool _transactionOwned;
+
+        private bool _disposed;
+
+        public MySqlRelationalTransaction(
+            [NotNull] IRelationalConnection connection,
+            [NotNull] MySqlTransaction transaction,
+            bool transactionOwned)
+        {
+            Check.NotNull(connection, nameof(connection));
+            Check.NotNull(transaction, nameof(transaction));
+
+            if (connection.DbConnection != transaction.Connection)
+            {
+                throw new InvalidOperationException(RelationalStrings.TransactionAssociatedWithDifferentConnection);
+            }
+
+            _relationalConnection = connection;
+
+            _dbTransaction = transaction;
+            _transactionOwned = transactionOwned;
+        }
+
+        public void Commit()
+        {
+            _dbTransaction.Commit();
+            ClearTransaction();
+        }
+
+	    public async Task CommitAsync(CancellationToken cancellationToken = default(CancellationToken))
+	    {
+		    await _dbTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+		    ClearTransaction();
+	    }
+
+        public void Rollback()
+        {
+            _dbTransaction.Rollback();
+            ClearTransaction();
+        }
+
+	    public async Task RollbackAsync(CancellationToken cancellationToken = default(CancellationToken))
+	    {
+		    await _dbTransaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+		    ClearTransaction();
+	    }
+
+	    public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                if (_transactionOwned)
+                {
+                    _dbTransaction.Dispose();
+                }
+                ClearTransaction();
+            }
+        }
+
+        private void ClearTransaction()
+        {
+            Debug.Assert((_relationalConnection.CurrentTransaction == null) ||
+                         (_relationalConnection.CurrentTransaction == this));
+            _relationalConnection.UseTransaction(null);
+        }
+
+        DbTransaction IInfrastructure<DbTransaction>.Instance => _dbTransaction;
+    }
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Update/Internal/MySqlBatchExecutor.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Update/Internal/MySqlBatchExecutor.cs
@@ -5,83 +5,78 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Update.Internal
 {
-  /// <summary>
-  ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-  ///     directly from your code. This API may change or be removed in future releases.
-  /// </summary>
-  public class MySqlBatchExecutor : IBatchExecutor
-  {
-    /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-    ///     directly from your code. This API may change or be removed in future releases.
-    /// </summary>
-    public virtual int Execute(
-      IEnumerable<ModificationCommandBatch> commandBatches,
-      IRelationalConnection connection)
+
+    public class MySqlBatchExecutor : IBatchExecutor
     {
-      var rowsAffected = 0;
-      connection.Open();
-      IDbContextTransaction startedTransaction = null;
-      try
-      {
-        if (connection.CurrentTransaction == null)
+
+        public int Execute(
+            IEnumerable<ModificationCommandBatch> commandBatches,
+            IRelationalConnection connection)
         {
-          startedTransaction = connection.BeginTransaction();
+            var rowsAffected = 0;
+            connection.Open();
+            IDbContextTransaction startedTransaction = null;
+            try
+            {
+                if (connection.CurrentTransaction == null)
+                {
+                	startedTransaction = connection.BeginTransaction();
+                }
+
+                foreach (var commandbatch in commandBatches)
+                {
+                    commandbatch.Execute(connection);
+                    rowsAffected += commandbatch.ModificationCommands.Count;
+                }
+                startedTransaction?.Commit();
+            }
+            finally
+            {
+                startedTransaction?.Dispose();
+                connection.Close();
+            }
+
+            return rowsAffected;
         }
 
-        foreach (var commandbatch in commandBatches)
+        public async Task<int> ExecuteAsync(
+            IEnumerable<ModificationCommandBatch> commandBatches,
+            IRelationalConnection connection,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            commandbatch.Execute(connection);
-            rowsAffected += commandbatch.ModificationCommands.Count;
-        }
-        startedTransaction?.Commit();
-      }
-      finally
-      {
-        startedTransaction?.Dispose();
-        connection.Close();
-      }
+            var rowsAffected = 0;
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            MySqlRelationalTransaction startedTransaction = null;
+            try
+            {
+                if (connection.CurrentTransaction == null)
+                {
+                    // ReSharper disable once PossibleNullReferenceException
+                    startedTransaction = await (connection as MySqlRelationalConnection).BeginTransactionAsync(cancellationToken).ConfigureAwait(false) as MySqlRelationalTransaction;
+                }
 
-      return rowsAffected;
+                foreach (var commandbatch in commandBatches)
+                {
+                    await commandbatch.ExecuteAsync(connection, cancellationToken).ConfigureAwait(false);
+                    rowsAffected += commandbatch.ModificationCommands.Count;
+                }
+
+                if (startedTransaction != null)
+                {
+                  await startedTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                startedTransaction?.Dispose();
+                connection.Close();
+            }
+
+            return rowsAffected;
+        }
     }
-
-    /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-    ///     directly from your code. This API may change or be removed in future releases.
-    /// </summary>
-    public virtual async Task<int> ExecuteAsync(
-      IEnumerable<ModificationCommandBatch> commandBatches,
-      IRelationalConnection connection,
-      CancellationToken cancellationToken = default(CancellationToken))
-    {
-      var rowsAffected = 0;
-      await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-      IDbContextTransaction startedTransaction = null;
-      try
-      {
-        if (connection.CurrentTransaction == null)
-        {
-          startedTransaction = await connection.BeginTransactionAsync().ConfigureAwait(false);
-        }
-
-        foreach (var commandbatch in commandBatches)
-        {
-          await commandbatch.ExecuteAsync(connection, cancellationToken).ConfigureAwait(false);
-          rowsAffected += commandbatch.ModificationCommands.Count;
-        }
-
-        startedTransaction?.Commit();
-      }
-      finally
-      {
-        startedTransaction?.Dispose();
-        connection.Close();
-      }
-
-      return rowsAffected;
-    }
-  }
 }

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/AppConfig.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/AppConfig.cs
@@ -57,7 +57,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.PerfTests
             foreach (var filePath in Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), "Migrations"))){
                 if (filePath.EndsWith(".cs")){
                     var data = File.ReadAllText(filePath);
-                    File.WriteAllText(filePath, "using System.Collections.Generic;" + Environment.NewLine + data);
+	                if (!data.Contains("using System.Collections.Generic;"))
+	                {
+		                File.WriteAllText(filePath, "using System.Collections.Generic;" + Environment.NewLine + data);
+	                }
                 }
             }
 

--- a/test/Pomelo.EntityFrameworkCore.MySql.Tests/MysqlRelationalConnectionTest.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.Tests/MysqlRelationalConnectionTest.cs
@@ -13,7 +13,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests
         [Fact]
         public void Creates_Mysql_Server_connection_string()
         {
-            using (var connection = new MySqlRelationalConnection(CreateOptions(), new Logger<MySqlConnection>(new LoggerFactory())))
+            using (var connection = new MySqlRelationalConnection(CreateOptions()))
             {
                 Assert.IsType<MySqlConnection>(connection.DbConnection);
             }
@@ -22,7 +22,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests
         [Fact]
         public void Can_create_master_connection_string()
         {
-            using (var connection = new MySqlRelationalConnection(CreateOptions(), new Logger<MySqlConnection>(new LoggerFactory())))
+            using (var connection = new MySqlRelationalConnection(CreateOptions()))
             {
                 using (var master = connection.CreateMasterConnection())
                 {


### PR DESCRIPTION
This PR focuses on achieving maximum Asynchronous method throughput.  It implements the following speedups:

- Connection Pooling Open/Close methods to free up connections quicker (when connection pooling is used)
- Asynchronous Transaction Commit/Rollback (requires [MySqlConnector/0.1.0-alpha23](https://www.nuget.org/packages/MySqlConnector/0.1.0-alpha23))
- Methods to close DbDataReaders once they are used up instead of waiting for Garbage Collection
- Multi-Select statements that use `Include` are now wrapped in RepeatableRead transactions so that they get a consistent snapshot of the database

With this PR, Async behavior scales well without lock-ups.  I am able to hit 500RPS in the performance tests and maintain under a 1s response time.