### PR TITLE
update oracle's driver for perf tests

### DIFF
--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/AppDb.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/AppDb.cs
@@ -54,17 +54,48 @@ namespace Pomelo.EntityFrameworkCore.MySql.PerfTests
 		protected override void OnModelCreating(ModelBuilder modelBuilder)
 		{
 			base.OnModelCreating(modelBuilder);
+
+			// Shorten key length for Identity
 			modelBuilder.Entity<AppIdentityUser>(entity => entity.Property(m => m.Id).HasMaxLength(127));
 			modelBuilder.Entity<IdentityRole>(entity => entity.Property(m => m.Id).HasMaxLength(127));
-			modelBuilder.Entity<IdentityUserLogin<string>>(entity => entity.Property(m => m.LoginProvider).HasMaxLength(127));
-			modelBuilder.Entity<IdentityUserLogin<string>>(entity => entity.Property(m => m.ProviderKey).HasMaxLength(127));
-			modelBuilder.Entity<IdentityUserRole<string>>(entity => entity.Property(m => m.UserId).HasMaxLength(127));
-			modelBuilder.Entity<IdentityUserRole<string>>(entity => entity.Property(m => m.RoleId).HasMaxLength(127));
-			modelBuilder.Entity<IdentityUserToken<string>>(entity => entity.Property(m => m.UserId).HasMaxLength(127));
-			modelBuilder.Entity<IdentityUserToken<string>>(entity => entity.Property(m => m.LoginProvider).HasMaxLength(127));
-			modelBuilder.Entity<IdentityUserToken<string>>(entity => entity.Property(m => m.Name).HasMaxLength(127));
+			modelBuilder.Entity<IdentityUserLogin<string>>(entity =>
+			{
+				entity.Property(m => m.LoginProvider).HasMaxLength(127);
+				entity.Property(m => m.ProviderKey).HasMaxLength(127);
+			});
+			modelBuilder.Entity<IdentityUserRole<string>>(entity =>
+			{
+				entity.Property(m => m.UserId).HasMaxLength(127);
+				entity.Property(m => m.RoleId).HasMaxLength(127);
+			});
+			modelBuilder.Entity<IdentityUserToken<string>>(entity =>
+			{
+				entity.Property(m => m.UserId).HasMaxLength(127);
+				entity.Property(m => m.LoginProvider).HasMaxLength(127);
+				entity.Property(m => m.Name).HasMaxLength(127);
+
+			});
+
+			// Add our models fluent APIs
 			CrmMeta.OnModelCreating(modelBuilder);
 			GeneratedContactMeta.OnModelCreating(modelBuilder);
+
+			if (AppConfig.EfProvider == "oracle")
+			{
+				// Oracle's driver does not support JsonObject
+				modelBuilder.Entity<DataTypesVariable>(entity =>
+				{
+					entity.Ignore(m => m.TypeJsonArray);
+					entity.Ignore(m => m.TypeJsonArrayN);
+					entity.Ignore(m => m.TypeJsonObject);
+					entity.Ignore(m => m.TypeJsonObjectN);
+				});
+				modelBuilder.Entity<GeneratedContact>(entity =>
+				{
+					entity.Ignore(m => m.Names);
+					entity.Ignore(m => m.ContactInfo);
+				});
+			}
 		}
 
 	}

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/project.json
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/project.json
@@ -17,7 +17,7 @@
       "version": "1.0.0-preview2-final",
       "type": "build"
     },
-    "MySql.Data.EntityFrameworkCore": "7.0.5-*",
+    "MySql.Data.EntityFrameworkCore": "7.0.6-*",
     "Pomelo.EntityFrameworkCore.MySql": {
       "target": "project"
     },


### PR DESCRIPTION
Updated Oracle's driver to their [MySql.Data.EntityFrameworkCore/7.0.6-IR31](https://www.nuget.org/packages/MySql.Data.EntityFrameworkCore/7.0.6-IR31) prerelease.

It still has too many internal bugs to work with our performance tests.  I am unable to get performance numbers on it yet.