### PR TITLE
Getting datetime(6) to work

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -336,6 +336,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     case "int2":
                         type = "short AUTO_INCREMENT";
                         break;
+                    case "datetime(6)":
+                        defaultValueSql = "CURRENT_TIMESTAMP(6)";
+                        break;
                     case "datetime":
                     case "timestamp":
                         defaultValueSql = "CURRENT_TIMESTAMP";
@@ -350,6 +353,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 switch (type)
                 {
+                    case "datetime(6)":
+                        if (string.IsNullOrWhiteSpace(defaultValueSql) && defaultValue == null)
+                            defaultValueSql = "CURRENT_TIMESTAMP(6)";
+                        onUpdateSql = "CURRENT_TIMESTAMP(6)";
+                        break;
                     case "datetime":
                     case "timestamp":
                         if (string.IsNullOrWhiteSpace(defaultValueSql) && defaultValue == null)

--- a/test/Pomelo.EntityFrameworkCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -32,6 +32,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
             }
         }
 
+        [Fact]
         public override void AddColumnOperation_with_defaultValue()
         {
             base.AddColumnOperation_with_defaultValue();
@@ -41,15 +42,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
                 Sql);
         }
 
-        public override void AddColumnOperation_with_defaultValueSql()
-        {
-            base.AddColumnOperation_with_defaultValueSql();
-
-            Assert.Equal(
-                "ALTER TABLE `People` ADD `Birthday` date DEFAULT CURRENT_TIMESTAMP;" + EOL,
-                Sql);
-        }
-
+     
         [Fact]
         public override void AddColumnOperation_with_computed_column_SQL()
         {
@@ -57,6 +50,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
 
             Assert.Equal(
                 "ALTER TABLE `People` ADD `Birthday` date;" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public override void AddDefaultDatetimeOperation_with_valueOnUpdate()
+        {
+            base.AddDefaultDatetimeOperation_with_valueOnUpdate();
+
+            Assert.Equal(
+                "ALTER TABLE `People` ADD `Birthday` datetime(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);" + EOL,
                 Sql);
         }
 

--- a/test/Pomelo.EntityFrameworkCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -42,14 +42,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
                 Sql);
         }
 
-     
         [Fact]
-        public override void AddColumnOperation_with_computed_column_SQL()
+        public override void AddColumnOperation_with_defaultValueSql()
         {
-            base.AddColumnOperation_with_computed_column_SQL();
+            base.AddColumnOperation_with_defaultValueSql();
 
             Assert.Equal(
-                "ALTER TABLE `People` ADD `Birthday` date;" + EOL,
+                "ALTER TABLE `People` ADD `Birthday` date DEFAULT CURRENT_TIMESTAMP;" + EOL,
                 Sql);
         }
 
@@ -60,6 +59,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
 
             Assert.Equal(
                 "ALTER TABLE `People` ADD `Birthday` datetime(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public override void AddColumnOperation_with_computed_column_SQL()
+        {
+            base.AddColumnOperation_with_computed_column_SQL();
+
+            Assert.Equal(
+                "ALTER TABLE `People` ADD `Birthday` date;" + EOL,
                 Sql);
         }
 

--- a/test/Pomelo.EntityFrameworkCore.MySql.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using System;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
@@ -59,6 +60,22 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
                     ColumnType = "date",
                     IsNullable = true,
                     ComputedColumnSql = "CURRENT_TIMESTAMP"
+                });
+        }
+
+        [Fact]
+        public virtual void AddDefaultDatetimeOperation_with_valueOnUpdate()
+        {
+            Generate(
+                new AddColumnOperation
+                {
+                    Table = "People",
+                    Name = "Birthday",
+                    ClrType = typeof(DateTime),
+                    ColumnType = "datetime(6)",
+                    IsNullable = true,
+                    DefaultValueSql = "CURRENT_TIMESTAMP(6)",
+                    [MySqlAnnotationNames.Prefix + MySqlAnnotationNames.ValueGeneratedOnAddOrUpdate] = true
                 });
         }
 


### PR DESCRIPTION
Hi.

I have had problems using `datetime(6)` with pomelo. Our standard datetime migrations always create columns with `datetime(6)` and we like that as it is very accurate. I think this is now the new standard behaviour of Pomelo Mysql, or am I wrong?
However there are two issues

1. The default value is choosen wrong for this type of column `datetime(6)` and needs to be set similar to `property.Relational().DefaultValueSql = "CURRENT_TIMESTAMP(6)"`

2. `ValueGeneratedOnAddOrUpdate` is ignored for the column type `datetime(6)`

To help with fixing the issue I created some tests to show how I imagine it to work and a solution. 

The diff in the tests is misleading.

Thanks for your great project. Any help is appreciated.