### PR TITLE
bump dotnet and ef to 1.1.0-preview1

### DIFF
--- a/.travis.sources.list
+++ b/.travis.sources.list
@@ -1,0 +1,42 @@
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial main restricted
+deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial universe
+deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial universe
+deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial-updates universe
+deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu 
+## team, and may not be under a free licence. Please satisfy yourself as to 
+## your rights to use the software. Also, please note that software in 
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial multiverse
+deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial multiverse
+deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial-updates multiverse
+deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+
+deb http://security.ubuntu.com/ubuntu xenial-security main restricted
+deb-src http://security.ubuntu.com/ubuntu xenial-security main restricted
+deb http://security.ubuntu.com/ubuntu xenial-security universe
+deb-src http://security.ubuntu.com/ubuntu xenial-security universe
+deb http://security.ubuntu.com/ubuntu xenial-security multiverse
+deb-src http://security.ubuntu.com/ubuntu xenial-security multiverse

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,11 @@ before_install:
   - docker run --name mysql -e MYSQL_ROOT_PASSWORD=Password12! -d mysql:5.7
   - docker pull ubuntu:16.04
   - docker run -v $(pwd):/dotnet/:rw -e 'CI=True' --name dotnet --link mysql:mysql -d ubuntu:16.04 sh -c 'while true; do sleep 0.1; done'
-  - docker exec -it dotnet sh -c 'apt-get update && apt-get install -y apt-transport-https mono-complete'
-  - docker exec -it dotnet sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list && apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 && apt-get update && apt-get install -y dotnet-dev-1.0.0-preview2-003131'
+  - docker exec -it dotnet sh -c 'cp /dotnet/.travis.sources.list /etc/apt/sources.list && apt-get update && apt-get install -y apt-transport-https mono-complete'
+  - docker exec -it dotnet sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list && apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 && apt-get update && apt-get install -y dotnet-dev-1.0.0-preview2-003131 dotnet-dev-1.0.0-preview2.1-003155'
 
 script:
   - docker exec -it dotnet sh -c 'cd /dotnet && dotnet restore'
   - docker exec -it dotnet sh -c 'cd /dotnet/src/Pomelo.EntityFrameworkCore.MySql && dotnet build -c Release'
   - docker exec -it dotnet sh -c 'cd /dotnet/test/Pomelo.EntityFrameworkCore.MySql.Tests && dotnet test -c Release'
   - docker exec -it dotnet sh -c 'cd /dotnet/test/Pomelo.EntityFrameworkCore.MySql.PerfTests && sed -i "s/127.0.0.1/mysql/g" config.json.example && dotnet test -c Release;'
-

--- a/src/Pomelo.EntityFrameworkCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -645,7 +645,7 @@ END;");
             }
         }
 
-        string ColumnList(string[] columns) => string.Join(", ", columns.Select(SqlGenerationHelper.DelimitIdentifier));
+	    protected override string ColumnList(string[] columns) => string.Join(", ", columns.Select(SqlGenerationHelper.DelimitIdentifier));
     }
 
     public static class StringExtensions

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryContext.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryContext.cs
@@ -18,9 +18,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 		public MySqlQueryContext(
 			[NotNull] Func<IQueryBuffer> queryBufferFactory,
 			[NotNull] IRelationalConnection connection,
-			[NotNull] IStateManager stateManager,
-			[NotNull] IConcurrencyDetector concurrencyDetector)
-			: base(queryBufferFactory, connection, stateManager, concurrencyDetector)
+			[NotNull] LazyRef<IStateManager> stateManager,
+			[NotNull] IConcurrencyDetector concurrencyDetector,
+			[NotNull] IExecutionStrategyFactory executionStrategyFactory)
+			: base(queryBufferFactory, connection, stateManager, concurrencyDetector, executionStrategyFactory)
 		{
 		}
 	}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryContextFactory.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Internal/MySqlQueryContextFactory.cs
@@ -11,16 +11,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 		private readonly IRelationalConnection _connection;
 
 		public MySqlQueryContextFactory(
-			[NotNull] IStateManager stateManager,
+			[NotNull] ICurrentDbContext currentContext,
 			[NotNull] IConcurrencyDetector concurrencyDetector,
 			[NotNull] IRelationalConnection connection,
-			[NotNull] IChangeDetector changeDetector)
-			: base(stateManager, concurrencyDetector, connection, changeDetector)
+			[NotNull] IExecutionStrategyFactory executionStrategyFactory)
+			: base(currentContext, concurrencyDetector, connection, executionStrategyFactory)
 		{
 			_connection = connection;
 		}
 
 		public override QueryContext Create()
-			=> new MySqlQueryContext(CreateQueryBuffer, _connection, StateManager, ConcurrencyDetector);
+			=> new MySqlQueryContext(CreateQueryBuffer, _connection, StateManager, ConcurrencyDetector, ExecutionStrategyFactory);
+
 	}
 }

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlDatabaseCreator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlDatabaseCreator.cs
@@ -23,29 +23,32 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     {
         private readonly MySqlRelationalConnection _connection;
         private readonly IMigrationsSqlGenerator _migrationsSqlGenerator;
-        private readonly IRawSqlCommandBuilder _rawSqlCommandBuilder;
+	    private readonly IRawSqlCommandBuilder _rawSqlCommandBuilder;
 
-        /// <summary>
+
+	    /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public MySqlDatabaseCreator(
-            [NotNull] MySqlRelationalConnection connection,
-            [NotNull] IMigrationsModelDiffer modelDiffer,
-            [NotNull] IMigrationsSqlGenerator migrationsSqlGenerator,
-            [NotNull] IMigrationCommandExecutor migrationCommandExecutor,
-            [NotNull] IModel model,
-            [NotNull] IRawSqlCommandBuilder rawSqlCommandBuilder)
-            : base(model, connection, modelDiffer, migrationsSqlGenerator, migrationCommandExecutor)
+	    public MySqlDatabaseCreator(
+	        [NotNull] MySqlRelationalConnection connection,
+	        [NotNull] IMigrationsModelDiffer modelDiffer,
+	        [NotNull] IMigrationsSqlGenerator migrationsSqlGenerator,
+	        [NotNull] IMigrationCommandExecutor migrationCommandExecutor,
+	        [NotNull] IModel model,
+	        [NotNull] IRawSqlCommandBuilder rawSqlCommandBuilder,
+	        [NotNull] IExecutionStrategyFactory executionStrategyFactory)
+	        : base(model, connection, modelDiffer, migrationsSqlGenerator, migrationCommandExecutor, executionStrategyFactory)
         {
-            Check.NotNull(rawSqlCommandBuilder, nameof(rawSqlCommandBuilder));
+	        Check.NotNull(rawSqlCommandBuilder, nameof(rawSqlCommandBuilder));
+	        
+	        _connection = connection;
+		    _migrationsSqlGenerator = migrationsSqlGenerator;
+	        _rawSqlCommandBuilder = rawSqlCommandBuilder;
 
-            _connection = connection;
-            _migrationsSqlGenerator = migrationsSqlGenerator;
-            _rawSqlCommandBuilder = rawSqlCommandBuilder;
         }
 
-        /// <summary>
+	    /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -242,9 +242,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 	    // Optomizations have been added to return connections to the pool faster
 	    // Prefer PoolingOpen/Close functions when Connection Pooling is enabled
 
+	    public bool Pooling => ConnectionStringBuilder.Pooling;
+
 	    public void PoolingOpen()
 	    {
-		    if (ConnectionStringBuilder.Pooling)
+		    if (Pooling)
 		    {
 			    DoOpen();
 		    }
@@ -252,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
 	    public async Task PoolingOpenAsync(CancellationToken cancellationToken = default(CancellationToken))
 	    {
-		    if (ConnectionStringBuilder.Pooling)
+		    if (Pooling)
 		    {
 			    await DoOpenAsync(cancellationToken).ConfigureAwait(false);
 		    }
@@ -260,7 +262,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
 	    public void PoolingClose()
 	    {
-		    if (ConnectionStringBuilder.Pooling)
+		    if (Pooling)
 		    {
 			    DoClose();
 		    }
@@ -271,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
 	    public void Open()
         {
-	        if (!ConnectionStringBuilder.Pooling)
+	        if (!Pooling)
 	        {
 		        DoOpen();
 	        }
@@ -296,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         public async Task OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-	        if (!ConnectionStringBuilder.Pooling)
+	        if (!Pooling)
 	        {
 		        await DoOpenAsync(cancellationToken).ConfigureAwait(false);
 	        }
@@ -321,7 +323,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         public void Close()
         {
-	        if (!ConnectionStringBuilder.Pooling)
+	        if (!Pooling)
 	        {
 		        DoClose();
 	        }

--- a/src/Pomelo.EntityFrameworkCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
           var storeCommand = CreateStoreCommand();
           try
           {
-              using (var relationalDataReader = storeCommand.RelationalCommand.ExecuteReader(connection, storeCommand.ParameterValues, false))
+              using (var relationalDataReader = storeCommand.RelationalCommand.ExecuteReader(connection, storeCommand.ParameterValues))
               {
                   Consume(relationalDataReader.DbDataReader);
               }
@@ -192,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
           var storeCommand = CreateStoreCommand();
           try
           {
-              var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(connection, storeCommand.ParameterValues, false, cancellationToken).ConfigureAwait(false);
+              var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(connection, storeCommand.ParameterValues, cancellationToken).ConfigureAwait(false);
               try
               {
                   await ConsumeAsync(dataReader.DbDataReader, cancellationToken).ConfigureAwait(false);

--- a/src/Pomelo.EntityFrameworkCore.MySql/project.json
+++ b/src/Pomelo.EntityFrameworkCore.MySql/project.json
@@ -19,7 +19,7 @@
   },
 
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational": "1.0.1",
+    "Microsoft.EntityFrameworkCore.Relational": "1.1.0-preview1-final",
     "MySqlConnector": "0.6.*",
     "Pomelo.JsonObject": "1.0.0-*"
   },

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/project.json
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/project.json
@@ -1,33 +1,35 @@
 ﻿{
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
-    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
-    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0",
-    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0",
-    "Microsoft.Extensions.Logging": "1.0.0",
-    "Microsoft.Extensions.Logging.Console": "1.0.0",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0",
-    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.1.0-preview1-final",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0-preview1-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-preview1-final",
+    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.1.0-preview1-final",
+    "Microsoft.DotNet.InternalAbstractions": "1.0.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Configuration.Json": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Logging": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Logging.Console": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Logging.Debug": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0-preview1-final",
     "Microsoft.EntityFrameworkCore.Design": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.1.0-preview1-final",
       "type": "build"
     },
+    "Microsoft.EntityFrameworkCore.Tools": "1.0.0-preview3-final",
     "MySql.Data.EntityFrameworkCore": "7.0.6-*",
     "Pomelo.EntityFrameworkCore.MySql": {
       "target": "project"
     },
-    "xunit": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta3-build3402"
   },
 
   "testRunner": "xunit",
 
   "tools": {
-    "Microsoft.EntityFrameworkCore.Tools": "1.0.0-preview2-final"
+    "Microsoft.EntityFrameworkCore.Tools.DotNet": "1.0.0-preview3-final"
   },
 
   "configurations": {
@@ -42,14 +44,10 @@
 
   "frameworks": {
     "netcoreapp1.0": {
-      "imports": [
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0"
+          "version": "1.1.0-preview1-*"
         }
       }
     }

--- a/test/Pomelo.EntityFrameworkCore.MySql.Tests/project.json
+++ b/test/Pomelo.EntityFrameworkCore.MySql.Tests/project.json
@@ -3,21 +3,22 @@
   "testRunner": "xunit",
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "Microsoft.EntityFrameworkCore": "1.0.1",
-    "Microsoft.EntityFrameworkCore.Relational": "1.0.1",
-    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.0.1",
-    "Microsoft.Extensions.Logging": "1.0.0",
+    "Microsoft.DotNet.InternalAbstractions": "1.0.0",
+    "Microsoft.EntityFrameworkCore": "1.1.0-preview1-final",
+    "Microsoft.EntityFrameworkCore.Relational": "1.1.0-preview1-final",
+    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Logging": "1.1.0-preview1-final",
     "Pomelo.EntityFrameworkCore.MySql": {
       "target": "project"
     },
-    "xunit": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta3-build3402"
   },
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0"
+          "version": "1.1.0-preview1-*"
         }
       }
     }


### PR DESCRIPTION
- Upgrade to [.NET Core 1.1 Preview 1](https://blogs.msdn.microsoft.com/dotnet/2016/10/25/announcing-net-core-1-1-preview-1/)
- Upgrade to [Entity Framework Core 1.1 Preview 1](https://blogs.msdn.microsoft.com/dotnet/2016/10/25/announcing-entity-framework-core-1-1-preview-1/)
- Visual Studio and Command Line Tooling still depends on .NET Core 1.0.0 until https://github.com/aspnet/EntityFramework/issues/6897 is fixed