### PR TITLE
Remove dependency on System.Threading.Thread

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/project.json
+++ b/src/Pomelo.EntityFrameworkCore.MySql/project.json
@@ -53,7 +53,7 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "System.Threading.Thread": "4.3.0"
+        "System.Threading.Tasks": "4.3.0"
       }
     }
   }


### PR DESCRIPTION
`System.Threading.Thread` is incompatible with UWP.

We can use `System.Threading.Tasks` instead.

The only file I had to update was `MySqlDatabaseCreator.cs` to use `Task.Delay` instead of `Thread.Sleep`.  Also, `ref` does not work in async methods so I had to remove that.