### PR TITLE
Fix for issue #142

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalTransaction.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalTransaction.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 using MySql.Data.MySqlClient;
+using System.Data;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
@@ -87,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             if (!_disposed)
             {
                 _disposed = true;
-                if (_transactionOwned)
+                if (_transactionOwned && _dbTransaction.Connection.State == ConnectionState.Closed)
                 {
                     _dbTransaction.Dispose();
                 }

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/SynchronizedMySqlDataReader.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/SynchronizedMySqlDataReader.cs
@@ -33,8 +33,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         public override bool GetBoolean(int ordinal) => GetReader().GetBoolean(ordinal);
-	    public override byte GetByte(int ordinal) => GetReader().GetByte(ordinal);
-	    public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length) => GetReader().GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+        public override byte GetByte(int ordinal)
+        {
+            if (GetReader().GetValue(ordinal) is bool)
+                return Convert.ToByte(GetReader().GetBoolean(ordinal)); // see TreatTinyAsBoolean setting
+            else
+                return GetReader().GetByte(ordinal);
+        }
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length) => GetReader().GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
 	    public override char GetChar(int ordinal) => Convert.ToChar(GetReader().GetByte(ordinal));
 	    public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length) => GetReader().GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
         public override string GetDataTypeName(int ordinal) => GetReader().GetDataTypeName(ordinal);


### PR DESCRIPTION
Resolves following exceptions:

`There is already an open DataReader associated with this Connection which must be closed first`

`Unable to Cast Object of type 'System.Boolean' to type 'System.Byte'`