### PR TITLE
Fix for Batch Operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ script:
   - docker exec -it dotnet sh -c 'cd /dotnet && dotnet restore'
   - docker exec -it dotnet sh -c 'cd /dotnet/src/Pomelo.EntityFrameworkCore.MySql && dotnet build -c Release'
   - docker exec -it dotnet sh -c 'cd /dotnet/test/Pomelo.EntityFrameworkCore.MySql.Tests && dotnet test -c Release'
-  - docker exec -it dotnet sh -c 'cd /dotnet/test/Pomelo.EntityFrameworkCore.MySql.PerfTests && sed -i "s/127.0.0.1/mysql/g" config.json.example && dotnet test -c Release;'
+  - echo "Testing with EF_BATCH_SIZE=1" && docker exec -it dotnet sh -c 'cd /dotnet/test/Pomelo.EntityFrameworkCore.MySql.PerfTests && sed -i "s/127.0.0.1/mysql/g" config.json.example && dotnet test -c Release;'
+  - echo "Testing with EF_BATCH_SIZE=10" && docker exec -it dotnet sh -c 'cd /dotnet/test/Pomelo.EntityFrameworkCore.MySql.PerfTests && export EF_BATCH_SIZE=10 && dotnet test -c Release;'

--- a/build-run.ps1
+++ b/build-run.ps1
@@ -115,6 +115,13 @@ if ($LASTEXITCODE -ne 0){
 # run functional tests if not on MyGet
 if ($env:BuildRunner -ne "MyGet"){
     cd (Join-Path $repoFolder (Join-Path "test" "Pomelo.EntityFrameworkCore.MySql.PerfTests"))
+    echo "Testing with EF_BATCH_SIZE=1"
+    & dotnet test -c Release
+    if ($LASTEXITCODE -ne 0){
+        exit $LASTEXITCODE;
+    }
+    echo "Testing with EF_BATCH_SIZE=10"
+    $env:EF_BATCH_SIZE = 10
     & dotnet test -c Release
     if ($LASTEXITCODE -ne 0){
         exit $LASTEXITCODE;

--- a/src/Pomelo.EntityFrameworkCore.MySql/Update/Internal/MySqlUpdateSqlGenerator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Update/Internal/MySqlUpdateSqlGenerator.cs
@@ -161,18 +161,16 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             if (allOperations.Count > 0 && allOperations[0] == operations[0])
             {
                 commandStringBuilder
-                    .AppendLine()
                     .Append("SELECT LAST_INSERT_ID()");
 
                 if (operations.Count > 1)
                     for (var i = 1; i < operations.Count; i++)
                         commandStringBuilder.Append($", (SELECT { SqlGenerationHelper.DelimitIdentifier(operations[i].ColumnName) } FROM { SqlGenerationHelper.DelimitIdentifier(name) } WHERE { SqlGenerationHelper.DelimitIdentifier(operations.First().ColumnName) } = LAST_INSERT_ID())");
-                commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator);
+                commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator).AppendLine();
             }
             else if (operations.Count > 0)
             {
                 commandStringBuilder
-                    .AppendLine()
                     .Append("SELECT ");
 
                 bool isFirst = true;
@@ -198,7 +196,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
                 commandStringBuilder
                     .Append(string.Join(" AND ", predicates))
-                    .Append(SqlGenerationHelper.StatementTerminator);
+                    .Append(SqlGenerationHelper.StatementTerminator).AppendLine();
+
             }
         }
 
@@ -208,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         
             Check.NotNull(commandStringBuilder, nameof(commandStringBuilder))
                 .Append("SELECT ROW_COUNT()")
-                .Append(SqlGenerationHelper.BatchTerminator).AppendLine();
+                .Append(SqlGenerationHelper.StatementTerminator).AppendLine();
 
             return ResultSetMapping.LastInResultSet;
         }

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/AppConfig.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/AppConfig.cs
@@ -9,6 +9,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.PerfTests
     {
 	    public static readonly bool AppVeyor = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("APPVEYOR"));
         public static readonly string EfProvider = Environment.GetEnvironmentVariable("EF_PROVIDER")?.ToLower();
+	    public static readonly int EfBatchSize = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EF_BATCH_SIZE"))
+		    ? Convert.ToInt32(Environment.GetEnvironmentVariable("EF_BATCH_SIZE")) : 1;
 	    private static readonly string Ci = Environment.GetEnvironmentVariable("CI")?.ToLower();
 	    private static readonly object InitLock = new object();
 

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/AppDb.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/AppDb.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using System;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MySQL.Data.EntityFrameworkCore.Extensions;
 using Pomelo.EntityFrameworkCore.MySql.PerfTests.Models;
 
@@ -54,7 +56,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.PerfTests
 				else
 				{
 					// Pomelo defines this with a case sensitive "MySql" in Microsoft.EntityFrameworkCore
-					optionsBuilder.UseMySql(AppConfig.Config["Data:ConnectionString"]);
+					optionsBuilder.UseMySql(AppConfig.Config["Data:ConnectionString"], options => options.MaxBatchSize(AppConfig.EfBatchSize));
+					optionsBuilder.UseLoggerFactory(new LoggerFactory().AddConsole(AppConfig.Config.GetSection("Logging")));
 				}
 			}
 		}


### PR DESCRIPTION
- Fixes #151 
- Removes bulk insert logic.  We can't use it because we must call `LAST_INSERT_ID()` after each insert to get generated IDs.  I don't think there's any other way to do this with MySQL.
- Adds command batching test
- Adds logging to Performance / Functional tests (change to `Information` or `Debug` in `appsettings.json`)