### PR TITLE
Translations for DATE_ADD() and EXTRACT()

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlCompositeMemberTranslator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlCompositeMemberTranslator.cs
@@ -13,7 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             var mySqlTranslators = new List<IMemberTranslator>
             {
                 new MySqlStringLengthTranslator(),
-                new MySqlDateTimeNowTranslator()
+                new MySqlDateTimeNowTranslator(),
+                new MySqlDatePartTranslator()
             };
 
             AddTranslators(mySqlTranslators);

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlCompositeMethodCallTranslator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlCompositeMethodCallTranslator.cs
@@ -24,7 +24,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             new MySqlRegexIsMatchTranslator(),
             new MySqlContainsOptimizedTranslator(),
             new MySqlStartsWithOptimizedTranslator(),
-            new MySqlEndsWithOptimizedTranslator()
+            new MySqlEndsWithOptimizedTranslator(),
+            new MySqlDateAddTranslator()
         };
 
         public MySqlCompositeMethodCallTranslator([NotNull] ILogger<MySqlCompositeMethodCallTranslator> logger)

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlDateAddTranslator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlDateAddTranslator.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class MySqlDateAddTranslator : IMethodCallTranslator
+    {
+        public virtual Expression Translate([NotNull] MethodCallExpression methodCallExpression)
+        {
+            string dateTimePart;
+            if (methodCallExpression.Method.DeclaringType == typeof(DateTime)
+                && (dateTimePart = GetDatePart(methodCallExpression.Method.Name)) != null)
+            {
+                return new DateAddExpression(dateTimePart, methodCallExpression.Type, new[] {
+                        methodCallExpression.Object,
+                        methodCallExpression.Arguments.First()
+                });
+            }
+            return null;
+        }
+
+        private static string GetDatePart(string memberName)
+        {
+            switch (memberName)
+            {
+                case nameof(DateTime.AddYears):
+                    return "YEAR";
+                case nameof(DateTime.AddMonths):
+                    return "MONTH";
+                case nameof(DateTime.AddDays):
+                    return "DAY";
+                case nameof(DateTime.AddHours):
+                    return "HOUR";
+                case nameof(DateTime.AddMinutes):
+                    return "MINUTE";
+                case nameof(DateTime.AddSeconds):
+                    return "SECOND";
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlDatePartTranslator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlDatePartTranslator.cs
@@ -11,18 +11,15 @@ using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 {
-    public class MySqlDateAddTranslator : IMethodCallTranslator
+    public class MySqlDatePartTranslator : IMemberTranslator
     {
-        public virtual Expression Translate([NotNull] MethodCallExpression methodCallExpression)
+        public virtual Expression Translate([NotNull] MemberExpression memberExpression)
         {
             string datePart;
-            if (methodCallExpression.Method.DeclaringType == typeof(DateTime)
-                && (datePart = GetDatePart(methodCallExpression.Method.Name)) != null)
+            if (memberExpression.Expression.Type == typeof(DateTime)
+                && (datePart = GetDatePart(memberExpression.Member.Name)) != null)
             {
-                return new DateAddExpression(datePart, methodCallExpression.Type, new[] {
-                        methodCallExpression.Object,
-                        methodCallExpression.Arguments.First()
-                });
+                return new DatePartExpression(datePart, memberExpression.Type, memberExpression.Expression);
             }
             return null;
         }
@@ -31,17 +28,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             switch (memberName)
             {
-                case nameof(DateTime.AddYears):
+                case nameof(DateTime.Year):
                     return "YEAR";
-                case nameof(DateTime.AddMonths):
+                case nameof(DateTime.Month):
                     return "MONTH";
-                case nameof(DateTime.AddDays):
+                case nameof(DateTime.Day):
                     return "DAY";
-                case nameof(DateTime.AddHours):
+                case nameof(DateTime.Hour):
                     return "HOUR";
-                case nameof(DateTime.AddMinutes):
+                case nameof(DateTime.Minute):
                     return "MINUTE";
-                case nameof(DateTime.AddSeconds):
+                case nameof(DateTime.Second):
                     return "SECOND";
                 default:
                     return null;

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Expressions/Internal/DateAddExpression.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Expressions/Internal/DateAddExpression.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
+{
+    public class DateAddExpression : Expression
+    {
+        public DateAddExpression([NotNull] string datePart, [NotNull] Type type, [NotNull] IEnumerable<Expression> arguments)
+        {
+            DatePart = datePart;
+            Type = type;
+            Arguments = arguments;
+        }
+
+        public override Type Type { get; }
+
+        public override ExpressionType NodeType => ExpressionType.Call;
+
+        public virtual IEnumerable<Expression> Arguments { get; }
+
+        public virtual string DatePart { get; }
+
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var specificVisitor = visitor as MySqlQuerySqlGenerator;
+
+            return specificVisitor != null
+                ? specificVisitor.VisitDateAdd(this)
+                : base.Accept(visitor);
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+    }
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Expressions/Internal/DatePartExpression.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Expressions/Internal/DatePartExpression.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
+{
+    public class DatePartExpression : Expression
+    {
+        public DatePartExpression([NotNull] string datePart, [NotNull] Type type, [NotNull] Expression argument)
+        {
+            DatePart = datePart;
+            Type = type;
+            Argument = argument;
+        }
+
+        public override Type Type { get; }
+
+        public override ExpressionType NodeType => ExpressionType.Call;
+
+        public virtual Expression Argument { get; }
+
+        public virtual string DatePart { get; }
+
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var specificVisitor = visitor as MySqlQuerySqlGenerator;
+
+            return specificVisitor != null
+                ? specificVisitor.VisitDatePart(this)
+                : base.Accept(visitor);
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+    }
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Sql/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Sql/Internal/MySqlQuerySqlGenerator.cs
@@ -214,10 +214,23 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
             Visit(dateAddExpression.Arguments.First());
 
             Sql.Append(", INTERVAL ");
+
             Visit(dateAddExpression.Arguments.Last());
             Sql.Append($" {dateAddExpression.DatePart})");
 
             return dateAddExpression;
+        }
+
+        public Expression VisitDatePart([NotNull] DatePartExpression datePartExpression)
+        {
+            Check.NotNull(datePartExpression, nameof(datePartExpression));
+
+            Sql.Append($"EXTRACT({datePartExpression.DatePart} FROM ");
+
+            Visit(datePartExpression.Argument);
+            Sql.Append(")");
+
+            return datePartExpression;
         }
     }
 }

--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/Sql/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/Sql/Internal/MySqlQuerySqlGenerator.cs
@@ -206,6 +206,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
             return atTimeZoneExpression;
         }
 
-        
+        public Expression VisitDateAdd([NotNull] DateAddExpression dateAddExpression)
+        {
+            Check.NotNull(dateAddExpression, nameof(dateAddExpression));
+
+            Sql.Append("DATE_ADD(");
+            Visit(dateAddExpression.Arguments.First());
+
+            Sql.Append(", INTERVAL ");
+            Visit(dateAddExpression.Arguments.Last());
+            Sql.Append($" {dateAddExpression.DatePart})");
+
+            return dateAddExpression;
+        }
     }
 }


### PR DESCRIPTION
Implemented DATE_ADD function:

`var test = ctx.Post.Select(p => p.CreatedOn.AddYears(-1));`
will result in
`SELECT DATE_ADD(p.CreatedOn, INTERVAL -1 YEAR) FROM Posts AS p`

Implemented EXTRACT function:

`var test = ctx.Post.Select(p => p.CreatedOn.Year);`
will result in
`SELECT EXTRACT(YEAR FROM p.CreatedOn) FROM Posts AS p`