### PR TITLE
MySql < 5.6 timestamp DEFAULT / ON UPDATE handling

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlScopedTypeMapper.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlScopedTypeMapper.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             set { _connectionString = value; }
         }
 
-        protected MySqlConnectionSettings ConnectionSettings => _connectionSettings ??
+        public MySqlConnectionSettings ConnectionSettings => _connectionSettings ??
             (_connectionSettings = MySqlConnectionSettings.GetSettings(ConnectionString));
 
         protected virtual RelationalTypeMapping MaybeConvertMapping(RelationalTypeMapping mapping)


### PR DESCRIPTION
- Fixes #172 
- For MySql < 5.6, throws verbose exception if DEFAULT or ON UPDATE used with `DATETIME` column since that is not allowed