### PR TITLE
Migration History Check Fix

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Migrations/Internal/MySqlHistoryRepository.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Migrations/Internal/MySqlHistoryRepository.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             }
         }
 
-        protected override bool InterpretExistsResult(object value) => value != DBNull.Value;
+        protected override bool InterpretExistsResult(object value) => value != null;
 
         public override string GetCreateIfNotExistsScript()
         {


### PR DESCRIPTION
- Fixes #99 

The migration history table check executes the query `SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='pomelo_test' AND TABLE_NAME='__EFMigrationsHistory';`

This returns `null` if the migration history table does not exist.  Our current check is for `DBNull.Value`, however both [MySqlConnector](https://github.com/mysql-net/MySqlConnector/blob/master/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs#L32-L45) and Oracle's [MySql.Data](https://github.com/mysql/mysql-connector-net/blob/6.9/Source/MySql.Data/command.cs#L593-L612) both return `null` if `ExecuteScalar` returns no rows.  So the correct behavior here is to check for `null` and not `DBNull.Value`

I've tested this by creating a new schema by hand, then attempting to run migrations.  After this change, everything works as expected.