### PR TITLE
Add using block on reader

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
@@ -183,15 +183,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
           var storeCommand = CreateStoreCommand();
           try
           {
-              var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(connection, storeCommand.ParameterValues, cancellationToken).ConfigureAwait(false);
-              try
+              using (var relationalDataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(connection, storeCommand.ParameterValues, cancellationToken).ConfigureAwait(false))
               {
-                  await ConsumeAsync(dataReader.DbDataReader, cancellationToken).ConfigureAwait(false);
-              }
-              finally
-              {
-	                while (await dataReader.DbDataReader.NextResultAsync(cancellationToken).ConfigureAwait(false))
-                  dataReader.Dispose();
+                  await ConsumeAsync(relationalDataReader.DbDataReader, cancellationToken).ConfigureAwait(false);
               }
           }
           catch (DbUpdateException)


### PR DESCRIPTION
- Fixes #189 
- Adds Using block on Async Modification Command Batch reader, so that reader should be used up in case of an exception and  "Already has an active reader" exceptions will not be thrown when transactions are rolled back.