### PR TITLE
Upgrade MySqlConnector and Remove Redundant reader code

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql.Design/Pomelo.EntityFrameworkCore.MySql.Design.csproj
+++ b/src/Pomelo.EntityFrameworkCore.MySql.Design/Pomelo.EntityFrameworkCore.MySql.Design.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Design" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="MySqlConnector" Version="0.13.*" />
+    <PackageReference Include="MySqlConnector" Version="0.14.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Pomelo.EntityFrameworkCore.MySql/Pomelo.EntityFrameworkCore.MySql.csproj
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Pomelo.EntityFrameworkCore.MySql.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.1" />
-    <PackageReference Include="MySqlConnector" Version="0.13.*" />
+    <PackageReference Include="MySqlConnector" Version="0.14.*" />
     <PackageReference Include="Pomelo.JsonObject" Version="1.1.1" />
   </ItemGroup>
 

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalCommand.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalCommand.cs
@@ -173,8 +173,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 	                    {
 		                    if (parameterValue is char)
 			                    parameter.AddDbParameter(command, Convert.ToByte((char)parameterValue));
-		                    else if (parameterValue is DateTimeOffset)
-			                    parameter.AddDbParameter(command, ((DateTimeOffset) parameterValue).UtcDateTime);
 		                    else if (parameterValue.GetType().FullName.StartsWith("System.JsonObject"))
 			                    parameter.AddDbParameter(command, parameterValue.ToString());
 							else if (parameterValue.GetType().GetTypeInfo().IsEnum)

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/SynchronizedMySqlDataReader.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/SynchronizedMySqlDataReader.cs
@@ -149,26 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 	            // try normal casting
 	            if (typeof(T) == typeof(char))
 		            return (T) Convert.ChangeType(Convert.ToChar(GetReader().GetFieldValue<byte>(ordinal)), typeof(T));
-	            if (typeof(T) == typeof(DateTimeOffset))
-		            return (T) Convert.ChangeType(new DateTimeOffset(DateTime.SpecifyKind(GetReader().GetFieldValue<DateTime>(ordinal), DateTimeKind.Utc)), typeof(T));
                 return GetReader().GetFieldValue<T>(ordinal);
-            }
-            catch (InvalidCastException e)
-            {
-                return ConvertWithReflection<T>(ordinal, e);
-            }
-        }
-
-        public override async Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
-        {
-            try
-            {
-	            // try normal casting
-	            if (typeof(T) == typeof(char))
-		            return (T) Convert.ChangeType(Convert.ToChar(await GetReader().GetFieldValueAsync<byte>(ordinal, cancellationToken).ConfigureAwait(false)), typeof(T));
-	            if (typeof(T) == typeof(DateTimeOffset))
-		            return (T) Convert.ChangeType(new DateTimeOffset(DateTime.SpecifyKind(await GetReader().GetFieldValueAsync<DateTime>(ordinal, cancellationToken).ConfigureAwait(false), DateTimeKind.Utc)), typeof(T));
-	            return await GetReader().GetFieldValueAsync<T>(ordinal, cancellationToken).ConfigureAwait(false);
             }
             catch (InvalidCastException e)
             {


### PR DESCRIPTION
- Upgrade MySqlConnector to 0.14.*
- MySqlConnector handles DateTimeOffset now
- DbDataReader GetFieldValueAsync function is redundant (parent class implements this)