### PR TITLE
Buffered Result Sets

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore
             var csb = new MySqlConnectionStringBuilder(connectionString)
             {
 	            AllowUserVariables = true,
+                BufferResultSets = true,
 	            UseAffectedRows = false
             };
             connectionString = csb.ConnectionString;
@@ -46,18 +47,19 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(connection, nameof(connection));
 
             var csb = new MySqlConnectionStringBuilder(connection.ConnectionString);
-	        if (csb.AllowUserVariables != true || csb.UseAffectedRows != false)
+	        if (csb.AllowUserVariables != true || csb.BufferResultSets != true || csb.UseAffectedRows != false)
 	        {
 	            try
 	            {
 		            csb.AllowUserVariables = true;
+                    csb.BufferResultSets = true;
 		            csb.UseAffectedRows = false;
 		            connection.ConnectionString = csb.ConnectionString;
 	            }
 	            catch (MySqlException e)
                 {
                     throw new InvalidOperationException("The MySql Connection string used with Pomelo.EntityFrameworkCore.MySql " +
-                    	"must contain \"UseAffectedRows=false\" and \"AllowUserVariables=true\"", e);
+                    	"must contain \"AllowUserVariables=true;BufferResultSets=true;UseAffectedRows=false\"", e);
                 }
             }
             

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/IOBehavior.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/IOBehavior.cs
@@ -1,5 +1,5 @@
 ﻿// ReSharper disable once CheckNamespace
-namespace Microsoft.EntityFrameworkCore.Storage
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
 	/// <summary>
 	/// Specifies whether to perform synchronous or asynchronous I/O.

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         private int? _commandTimeout;
 	    private readonly ILogger<MySqlRelationalConnection> _logger;
 
-	    public readonly SemaphoreSlim Lock = new SemaphoreSlim(1);
+	    internal readonly SemaphoreSlim CommandLock = new SemaphoreSlim(1);
         private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1);
 
         public MySqlRelationalConnection([NotNull] IDbContextOptions options, [NotNull] ILogger<MySqlRelationalConnection> logger)
@@ -297,9 +297,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 	    // Optomizations have been added to return connections to the pool faster
 	    // Prefer PoolingOpen/Close functions when Connection Pooling is enabled
 
-	    public bool Pooling => ConnectionStringBuilder.Pooling;
+	    internal bool Pooling => ConnectionStringBuilder.Pooling;
 
-	    public void PoolingOpen()
+	    internal void PoolingOpen()
 	    {
 		    if (Pooling)
 		    {
@@ -307,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 		    }
 	    }
 
-	    public async Task PoolingOpenAsync(CancellationToken cancellationToken = default(CancellationToken))
+	    internal async Task PoolingOpenAsync(CancellationToken cancellationToken = default(CancellationToken))
 	    {
 		    if (Pooling)
 		    {
@@ -315,7 +315,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 		    }
 	    }
 
-	    public void PoolingClose()
+	    internal void PoolingClose()
 	    {
 		    if (Pooling)
 		    {

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Pomelo.EntityFrameworkCore.MySql.PerfTests.csproj
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Pomelo.EntityFrameworkCore.MySql.PerfTests.csproj
@@ -40,4 +40,10 @@
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.0" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <ThreadPoolMinThreads>64</ThreadPoolMinThreads>
+  </PropertyGroup>
+
 </Project>

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/runtimeconfig.template.json
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/runtimeconfig.template.json
@@ -1,6 +1,0 @@
-{
-  "configProperties": {
-    "System.GC.Concurrent": true,
-    "System.Threading.ThreadPool.MinThreads": 192
-  }
-}


### PR DESCRIPTION
- Forces `BufferResultSets=true` introduced in MySqlConnector 0.15.1 (https://github.com/mysql-net/MySqlConnector/issues/202)
- No longer need locking while result set is being consumed