### PR TITLE
DbContextOptionsExtension bug: pass connection string. fixes #221

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
@@ -77,10 +77,8 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] string connectionString,
             [CanBeNull] Action<MySqlDbContextOptionsBuilder> mySqlOptionsAction = null)
             where TContext : DbContext
-        {
-            return (DbContextOptionsBuilder<TContext>)UseMySql(
-                (DbContextOptionsBuilder)optionsBuilder, new MySqlConnection(connectionString), mySqlOptionsAction);
-        }
+            => (DbContextOptionsBuilder<TContext>)UseMySql(
+                (DbContextOptionsBuilder)optionsBuilder, connectionString, mySqlOptionsAction);
 
         public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(
             [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,


### PR DESCRIPTION
- Fixes #221 