### PR TITLE
Fixed substring translator

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringSubstringTranslator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringSubstringTranslator.cs
@@ -19,7 +19,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             if (methodCallExpression.Method == _methodInfo)
             {
-                var sqlArguments = new[] { methodCallExpression.Object }.Concat(methodCallExpression.Arguments);
+                var sqlArguments = new[]
+                    {
+                        methodCallExpression.Object,
+                        // There are two hard things in computer science: cache invalidation, naming things, and off-by-one errors
+                        methodCallExpression.Arguments[0].NodeType == ExpressionType.Constant
+                            ? (Expression)Expression.Constant((int)((ConstantExpression)methodCallExpression.Arguments[0]).Value + 1)
+                            : Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)),
+                        methodCallExpression.Arguments[1]
+                    };
+
                 return new SqlFunctionExpression("SUBSTRING", methodCallExpression.Type, sqlArguments);
             }
 


### PR DESCRIPTION
Fixes issue https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/239 as MySQL [SUBSTRING function](https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substring) uses a 1-based index.

