### PR TITLE
Sequential GUIDs

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/ValueGeneration/Internal/MySqlSequentialGuidValueGenerator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/ValueGeneration/Internal/MySqlSequentialGuidValueGenerator.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
+{
+    public class MySqlSequentialGuidValueGenerator  : ValueGenerator<Guid>
+    {
+
+        private readonly MySqlScopedTypeMapper _mySqlTypeMapper;
+
+        public MySqlSequentialGuidValueGenerator(MySqlScopedTypeMapper mySqlTypeMapper)
+        {
+            _mySqlTypeMapper = mySqlTypeMapper;
+        }
+
+        private static readonly RandomNumberGenerator Rng = RandomNumberGenerator.Create();
+
+        /// <summary>
+        ///     Gets a value to be assigned to a property.
+        ///     Creates a GUID where the first 8 bytes are the current UTC date/time (in ticks)
+        ///     and the last 8 bytes are cryptographically random.  This allows for better performance
+        ///     in clustered index scenarios.
+        /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
+        /// <returns> The value to be assigned to a property. </returns>
+        public override Guid Next(EntityEntry entry)
+        {
+            var randomBytes = new byte[8];
+            Rng.GetBytes(randomBytes);
+            var ticks = (ulong) DateTime.UtcNow.Ticks;
+
+            if (_mySqlTypeMapper.ConnectionSettings.OldGuids)
+            {
+                var guidBytes = new byte[16];
+                var tickBytes = BitConverter.GetBytes(ticks);
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(tickBytes);
+
+                Buffer.BlockCopy(tickBytes, 0, guidBytes, 0, 8);
+                Buffer.BlockCopy(randomBytes, 0, guidBytes, 8, 8);
+
+                return new Guid(guidBytes);
+            }
+
+            var guid = new Guid((uint) (ticks >> 32), (ushort) (ticks << 32 >> 48), (ushort) (ticks << 48 >> 48),
+                randomBytes[0],
+                randomBytes[1],
+                randomBytes[2],
+                randomBytes[3],
+                randomBytes[4],
+                randomBytes[5],
+                randomBytes[6],
+                randomBytes[7]);
+
+            return guid;
+        }
+
+        /// <summary>
+        ///     Gets a value indicating whether the values generated are temporary or permanent. This implementation
+        ///     always returns false, meaning the generated values will be saved to the database.
+        /// </summary>
+        public override bool GeneratesTemporaryValues => false;
+
+    }
+}

--- a/src/Pomelo.EntityFrameworkCore.MySql/ValueGeneration/Internal/MySqlValueGeneratorSelector.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/ValueGeneration/Internal/MySqlValueGeneratorSelector.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
@@ -8,11 +10,15 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
     public class MySqlValueGeneratorSelector : RelationalValueGeneratorSelector
     {
+        private readonly MySqlScopedTypeMapper _mySqlTypeMapper;
+
         public MySqlValueGeneratorSelector(
             [NotNull] IValueGeneratorCache cache,
-            [NotNull] IRelationalAnnotationProvider relationalExtensions)
+            [NotNull] IRelationalAnnotationProvider relationalExtensions,
+            [NotNull] IRelationalTypeMapper typeMapper)
             : base(cache, relationalExtensions)
         {
+            _mySqlTypeMapper = typeMapper as MySqlScopedTypeMapper;
         }
 
         public override ValueGenerator Create(IProperty property, IEntityType entityType)
@@ -24,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
                 ? property.ValueGenerated == ValueGenerated.Never
                   || property.MySql().DefaultValueSql != null
                     ? (ValueGenerator)new TemporaryGuidValueGenerator()
-                    : new SequentialGuidValueGenerator()
+                    : new MySqlSequentialGuidValueGenerator(_mySqlTypeMapper)
                 : base.Create(property, entityType);
             return ret;
         }

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Models/GeneratedTypes.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Models/GeneratedTypes.cs
@@ -45,7 +45,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.PerfTests.Models
 
 	public class GeneratedContact
 	{
-		public int Id { get; set; }
+	    public Guid Id { get; set; }
 
 		public string Name { get; set; }
 


### PR DESCRIPTION
- Adapt Sequential GUID generation to work on MySQL
- Re-work of initial PR #258 
- Must take into consideration if GUIDs are stored as `binary` (`OldGuids=true`) or `char(36)` (`OldGuids`=false)

Still need to add tests before we can merge