### PR TITLE
Add rename support for MySQL versions below 5.7 (and MariaDB)

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -158,15 +158,36 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (operation.NewName != null)
             {
-                builder.Append("ALTER TABLE ")
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
-                    .Append(" RENAME INDEX ")
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
-                    .Append(" TO ")
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName))
-                    .AppendLine(";");
+                if (_options.ConnectionSettings.ServerVersion.SupportsRenameIndex)
+                {
+                    builder.Append("ALTER TABLE ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
+                        .Append(" RENAME INDEX ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                        .Append(" TO ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName))
+                        .AppendLine(";");
 
-                EndStatement(builder);
+                    EndStatement(builder);
+                }
+                else
+                {
+                    builder.Append("ALTER TABLE ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
+                        .Append(" DROP INDEX ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                        .AppendLine(";");
+
+                    EndStatement(builder);
+                    
+                    builder.Append("ALTER TABLE ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
+                        .Append(" CREATE INDEX ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName))
+                        .AppendLine(";");
+
+                    EndStatement(builder);
+                }
             }
         }
 

--- a/src/EFCore.MySql/Properties/AssemblyInfo.cs
+++ b/src/EFCore.MySql/Properties/AssemblyInfo.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Design;
 
 [assembly: AssemblyTitle("Pomelo.EntityFrameworkCore.MySql")]
 [assembly: AssemblyDescription("MySQL provider for Entity Framework Core")]
 [assembly: DesignTimeProviderServices("Microsoft.EntityFrameworkCore.Design.Internal.MySqlDesignTimeServices")]
+[assembly: InternalsVisibleTo("Pomelo.EntityFrameworkCore.MySql.Tests")]

--- a/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             });
         }
 
-        private MySqlConnectionSettings(MySqlConnectionStringBuilder settingsCsb, ServerVersion serverVersion)
+        internal MySqlConnectionSettings(MySqlConnectionStringBuilder settingsCsb, ServerVersion serverVersion)
         {
             // Settings from the connection string
             OldGuids = settingsCsb.OldGuids;

--- a/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
@@ -33,6 +33,20 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public readonly Version Version;
 
         public bool SupportsDateTime6 => Version >= new Version(5,6);
+
+        public bool SupportsRenameIndex
+        {
+            get
+            {
+                if (Type == ServerType.MySql)
+                {
+                    return Version >= new Version(5,7);
+                }
+                
+                // TODO Awaiting feedback from Mariadb on when they will support rename index!
+                return false;
+            }
+        }
     }
 
     public enum ServerType

--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorMySql56Test.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorMySql56Test.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Xunit;
+using Microsoft.EntityFrameworkCore.Internal;
+using Moq;
+using MySql.Data.MySqlClient;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
+{
+    public class MigrationSqlGeneratorMySql56Test : MigrationSqlGeneratorTestBase
+    {
+        protected override IMigrationsSqlGenerator SqlGenerator
+        {
+            get
+            {
+                // type mapper
+                var typeMapper = new MySqlTypeMapper(new RelationalTypeMapperDependencies());
+
+                // migrationsSqlGeneratorDependencies
+                var commandBuilderFactory = new RelationalCommandBuilderFactory(
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                    typeMapper);
+                var migrationsSqlGeneratorDependencies = new MigrationsSqlGeneratorDependencies(
+                    commandBuilderFactory,
+                    new MySqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
+                    typeMapper);
+
+                var mySqlOptions = new Mock<IMySqlOptions>();
+                mySqlOptions.SetupGet(opts => opts.ConnectionSettings).Returns(
+                    new MySqlConnectionSettings(new MySqlConnectionStringBuilder(), new ServerVersion("5.6.2")));
+                
+                return new MySqlMigrationsSqlGenerator(
+                    migrationsSqlGeneratorDependencies,
+                    mySqlOptions.Object);
+            }
+        }
+
+        private static FakeRelationalConnection CreateConnection(IDbContextOptions options = null)
+            => new FakeRelationalConnection(options ?? CreateOptions());
+
+        private static IDbContextOptions CreateOptions(RelationalOptionsExtension optionsExtension = null)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder)
+                .AddOrUpdateExtension(optionsExtension
+                                      ?? new FakeRelationalOptionsExtension().WithConnectionString("test"));
+
+            return optionsBuilder.Options;
+        }
+
+
+        public override void RenameIndexOperation_works()
+        {
+            base.RenameIndexOperation_works();
+            
+            Assert.Equal("ALTER TABLE `People` DROP INDEX `IX_People_Name`;" + EOL 
+                         + "ALTER TABLE `People` CREATE INDEX `IX_People_Better_Name`;" + EOL,
+                Sql);
+        }
+    }
+}

--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -255,6 +255,19 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
         }
 
         [Fact]
+        public virtual void RenameIndexOperation_works()
+        {
+            Generate(
+                new RenameIndexOperation
+                {
+                    IsDestructiveChange = false,
+                    Name = "IX_People_Name",
+                    NewName = "IX_People_Better_Name",
+                    Table = "People"
+                });
+        }
+        
+        [Fact]
         public virtual void CreateTableOperation()
         {
             Generate(

--- a/test/EFCore.MySql.Tests/Migrations/ServerVersionTest.cs
+++ b/test/EFCore.MySql.Tests/Migrations/ServerVersionTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Xunit;
 
@@ -7,17 +7,18 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
     public class ServerVersionTest
     {
         [Theory]
-        [InlineData("5.7.18", ServerType.MySql, "5.7.18")]
-        [InlineData("5.5.5-10.1.23-MariaDB-1~jessie", ServerType.MariaDb, "10.1.23")]
-        [InlineData("5.5.5-10.3.0-MariaDB-10.3.0+maria~jessie", ServerType.MariaDb, "10.3.0")]
-        [InlineData("5.5.5-1.2.3-myslq~jessie", ServerType.MySql, "5.5.5")]
-        [InlineData("version5.0", ServerType.MySql, "5.0")]
-        [InlineData("5.1", ServerType.MySql, "5.1")]
-        public void TestValidVersion(string input, ServerType serverType, string actualVersion)
+        [InlineData("5.7.18", ServerType.MySql, "5.7.18", true)]
+        [InlineData("5.5.5-10.1.23-MariaDB-1~jessie", ServerType.MariaDb, "10.1.23", false)]
+        [InlineData("5.5.5-10.3.0-MariaDB-10.3.0+maria~jessie", ServerType.MariaDb, "10.3.0", false)]
+        [InlineData("5.5.5-1.2.3-myslq~jessie", ServerType.MySql, "5.5.5", false)]
+        [InlineData("version5.0", ServerType.MySql, "5.0", false)]
+        [InlineData("5.1", ServerType.MySql, "5.1", false)]
+        public void TestValidVersion(string input, ServerType serverType, string actualVersion, bool supportsRenameIndex)
         {
             var serverVersion = new ServerVersion(input);
             Assert.Equal(serverVersion.Type, serverType);
             Assert.Equal(serverVersion.Version, new Version(actualVersion));
+            Assert.Equal(serverVersion.SupportsRenameIndex, supportsRenameIndex);
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds support for renaming indices  on MySQL versions below 5.7 and MariaDB

- `ServerVersion` updated to determine whether renaming is supported
- `MySqlMigrationsSqlGenerator` updated to support `RENAME` and `DROP+CREATE`
- Added tests for rename support on MySQL 5.6 and 5.7
- Other small changes to allow unit-testing the rename support

**one caveat** if the index being renamed is unique and it is not version 5.7 I can't se a way to determine whether the index being changed is unique or not, hence it will DROP and create a non unique index.

Relates to #320 