### PR TITLE
WIP: Backport index RENAME / DROP+CREATE support

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
@@ -185,15 +185,36 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (operation.NewName != null)
             {
-                builder.Append("ALTER TABLE ")
-                    .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
-                    .Append(" RENAME INDEX ")
-                    .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
-                    .Append(" TO ")
-                    .Append(SqlGenerationHelper.DelimitIdentifier(operation.NewName))
-                    .AppendLine(";");
+                if (_mySqlTypeMapper.ConnectionSettings.ServerVersion.SupportsRenameIndex)
+                {
+                    builder.Append("ALTER TABLE ")
+                        .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
+                        .Append(" RENAME INDEX ")
+                        .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                        .Append(" TO ")
+                        .Append(SqlGenerationHelper.DelimitIdentifier(operation.NewName))
+                        .AppendLine(";");
 
-                EndStatement(builder);
+                    EndStatement(builder);
+                }
+                else
+                {
+                    builder.Append("ALTER TABLE ")
+                        .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
+                        .Append(" DROP INDEX ")
+                        .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                        .AppendLine(";");
+
+                    EndStatement(builder);
+
+                    builder.Append("ALTER TABLE ")
+                        .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
+                        .Append(" CREATE INDEX ")
+                        .Append(SqlGenerationHelper.DelimitIdentifier(operation.NewName))
+                        .AppendLine(";");
+
+                    EndStatement(builder);
+                }
             }
         }
 

--- a/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/ServerVersion.cs
+++ b/src/Pomelo.EntityFrameworkCore.MySql/Storage/Internal/ServerVersion.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
@@ -33,6 +33,20 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public readonly Version Version;
 
         public bool SupportsDateTime6 => Version >= new Version(5,6);
+
+        public bool SupportsRenameIndex
+        {
+            get
+            {
+                if (Type == ServerType.MySql)
+                {
+                    return Version >= new Version(5, 7);
+                }
+
+                // TODO Awaiting feedback from Mariadb on when they will support rename index!
+                return false;
+            }
+        }
     }
 
     public enum ServerType

--- a/test/Pomelo.EntityFrameworkCore.MySql.Tests/Migrations/ServerVersionTest.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.Tests/Migrations/ServerVersionTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Xunit;
 
@@ -7,17 +7,18 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
     public class ServerVersionTest
     {
         [Theory]
-        [InlineData("5.7.18", ServerType.MySql, "5.7.18")]
-        [InlineData("5.5.5-10.1.23-MariaDB-1~jessie", ServerType.MariaDb, "10.1.23")]
-        [InlineData("5.5.5-10.3.0-MariaDB-10.3.0+maria~jessie", ServerType.MariaDb, "10.3.0")]
-        [InlineData("5.5.5-1.2.3-myslq~jessie", ServerType.MySql, "5.5.5")]
-        [InlineData("version5.0", ServerType.MySql, "5.0")]
-        [InlineData("5.1", ServerType.MySql, "5.1")]
-        public void TestValidVersion(string input, ServerType serverType, string actualVersion)
+        [InlineData("5.7.18", ServerType.MySql, "5.7.18", true)]
+        [InlineData("5.5.5-10.1.23-MariaDB-1~jessie", ServerType.MariaDb, "10.1.23", false)]
+        [InlineData("5.5.5-10.3.0-MariaDB-10.3.0+maria~jessie", ServerType.MariaDb, "10.3.0", false)]
+        [InlineData("5.5.5-1.2.3-myslq~jessie", ServerType.MySql, "5.5.5", false)]
+        [InlineData("version5.0", ServerType.MySql, "5.0", false)]
+        [InlineData("5.1", ServerType.MySql, "5.1", false)]
+        public void TestValidVersion(string input, ServerType serverType, string actualVersion, bool supportsRenameIndex)
         {
             var serverVersion = new ServerVersion(input);
             Assert.Equal(serverVersion.Type, serverType);
             Assert.Equal(serverVersion.Version, new Version(actualVersion));
+            Assert.Equal(serverVersion.SupportsRenameIndex, supportsRenameIndex);
         }
 
         [Fact]


### PR DESCRIPTION
This PR backports the index `RENAME` / `DROP+CREATE` made for the mainline version of the library.

The sql migration tests were not ported.

See #321 for details
Relates to #320 

