### PR TITLE
rename index from SHOW CREATE TABLE

### DIFF
--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -256,7 +256,7 @@ END;" + EOL +
         {
             base.RenameIndexOperation_works();
             
-            Assert.Equal("ALTER TABLE `People` RENAME INDEX `IX_People_Name` TO `IX_People_Better_Name`;" + EOL,
+            Assert.Equal("ALTER TABLE `People` RENAME INDEX `IX_People_Discriminator` TO `IX_People_DiscriminatorNew`;" + EOL,
                 Sql);
         }
 

--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -261,8 +261,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
                 new RenameIndexOperation
                 {
                     IsDestructiveChange = false,
-                    Name = "IX_People_Name",
-                    NewName = "IX_People_Better_Name",
+                    Name = "IX_People_Discriminator",
+                    NewName = "IX_People_DiscriminatorNew",
                     Table = "People"
                 });
         }


### PR DESCRIPTION
- Fixes problems with #321 where Columns are not included in Drop / Add index for MySQL 5.6 and MariaDB
- Will take into account `UNIQUE`, `BTREE`, and other options