### PR TITLE
#328 Unable to use uint as primary key (repro the issue with the CRM Test Model)

### DIFF
--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Migrations/20170727192207_initial.Designer.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Migrations/20170727192207_initial.Designer.cs
@@ -1,0 +1,669 @@
+using System.Collections.Generic;
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pomelo.EntityFrameworkCore.MySql.PerfTests;
+using Pomelo.EntityFrameworkCore.MySql.PerfTests.Models;
+
+namespace Pomelo.EntityFrameworkCore.MySql.PerfTests.Migrations
+{
+    [DbContext(typeof(AppDb))]
+    [Migration("20170727192207_initial")]
+    partial class initial
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.1");
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole", b =>
+                {
+                    b.Property<string>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("NormalizedName")
+                        .HasMaxLength(127);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .IsUnique()
+                        .HasName("RoleNameIndex");
+
+                    b.ToTable("AspNetRoles");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("RoleId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("AspNetRoleClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("ProviderKey")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("ProviderDisplayName");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserLogins");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("RoleId")
+                        .HasMaxLength(127);
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("AspNetUserRoles");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserToken<string>", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("LoginProvider")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("Value");
+
+                    b.HasKey("UserId", "LoginProvider", "Name");
+
+                    b.ToTable("AspNetUserTokens");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.AppIdentityUser", b =>
+                {
+                    b.Property<string>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+                        .HasMaxLength(127);
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+                        .HasMaxLength(127);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasName("EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .IsUnique()
+                        .HasName("UserNameIndex");
+
+                    b.ToTable("AspNetUsers");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Blog", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Title");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Blogs");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.BlogPost", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("BlogId");
+
+                    b.Property<string>("Content");
+
+                    b.Property<string>("Title");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("BlogId");
+
+                    b.ToTable("BlogPost");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdmin", b =>
+                {
+                    b.Property<uint>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Password")
+                        .HasMaxLength(20);
+
+                    b.Property<string>("Username")
+                        .HasMaxLength(10);
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CrmAdmins");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdminMenu", b =>
+                {
+                    b.Property<uint>("AdminId");
+
+                    b.Property<uint>("MenuId");
+
+                    b.HasKey("AdminId", "MenuId");
+
+                    b.HasIndex("MenuId");
+
+                    b.ToTable("CrmAdminMenu");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdminRole", b =>
+                {
+                    b.Property<uint>("AdminId");
+
+                    b.Property<uint>("RoleId");
+
+                    b.HasKey("AdminId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("CrmAdminRole");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmMenu", b =>
+                {
+                    b.Property<uint>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Name");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CrmMenus");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmRole", b =>
+                {
+                    b.Property<uint>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Name");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CrmRoles");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.DataTypesSimple", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<bool>("TypeBool");
+
+                    b.Property<bool?>("TypeBoolN");
+
+                    b.Property<byte>("TypeByte");
+
+                    b.Property<byte?>("TypeByteN");
+
+                    b.Property<char>("TypeChar");
+
+                    b.Property<char?>("TypeCharN");
+
+                    b.Property<DateTime>("TypeDateTime");
+
+                    b.Property<DateTime?>("TypeDateTimeN");
+
+                    b.Property<DateTimeOffset>("TypeDateTimeOffset");
+
+                    b.Property<DateTimeOffset?>("TypeDateTimeOffsetN");
+
+                    b.Property<decimal>("TypeDecimal");
+
+                    b.Property<decimal?>("TypeDecimalN");
+
+                    b.Property<double>("TypeDouble");
+
+                    b.Property<double?>("TypeDoubleN");
+
+                    b.Property<int>("TypeEnum");
+
+                    b.Property<byte>("TypeEnumByte");
+
+                    b.Property<byte?>("TypeEnumByteN");
+
+                    b.Property<int?>("TypeEnumN");
+
+                    b.Property<float>("TypeFloat");
+
+                    b.Property<float?>("TypeFloatN");
+
+                    b.Property<Guid>("TypeGuid");
+
+                    b.Property<Guid?>("TypeGuidN");
+
+                    b.Property<int>("TypeInt");
+
+                    b.Property<int?>("TypeIntN");
+
+                    b.Property<long>("TypeLong");
+
+                    b.Property<long?>("TypeLongN");
+
+                    b.Property<sbyte>("TypeSbyte");
+
+                    b.Property<sbyte?>("TypeSbyteN");
+
+                    b.Property<short>("TypeShort");
+
+                    b.Property<short?>("TypeShortN");
+
+                    b.Property<TimeSpan>("TypeTimeSpan");
+
+                    b.Property<TimeSpan?>("TypeTimeSpanN");
+
+                    b.Property<uint>("TypeUint");
+
+                    b.Property<uint?>("TypeUintN");
+
+                    b.Property<ulong>("TypeUlong");
+
+                    b.Property<ulong?>("TypeUlongN");
+
+                    b.Property<ushort>("TypeUshort");
+
+                    b.Property<ushort?>("TypeUshortN");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("DataTypesSimple");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.DataTypesVariable", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<byte[]>("TypeByteArray")
+                        .IsRequired();
+
+                    b.Property<byte[]>("TypeByteArray255")
+                        .IsRequired()
+                        .HasMaxLength(255);
+
+                    b.Property<byte[]>("TypeByteArray255N")
+                        .HasMaxLength(255);
+
+                    b.Property<byte[]>("TypeByteArrayN");
+
+                    b.Property<JsonObject<List<string>>>("TypeJsonArray")
+                        .IsRequired();
+
+                    b.Property<JsonObject<List<string>>>("TypeJsonArrayN");
+
+                    b.Property<JsonObject<Dictionary<string, string>>>("TypeJsonObject")
+                        .IsRequired();
+
+                    b.Property<JsonObject<Dictionary<string, string>>>("TypeJsonObjectN");
+
+                    b.Property<string>("TypeString")
+                        .IsRequired();
+
+                    b.Property<string>("TypeString255")
+                        .IsRequired()
+                        .HasMaxLength(255);
+
+                    b.Property<string>("TypeString255N")
+                        .HasMaxLength(255);
+
+                    b.Property<string>("TypeStringN");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("DataTypesVariable");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.GeneratedContact", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
+						CONCAT_WS(', ',
+							`ContactInfo` ->> ""$.Address"",
+                            `ContactInfo` ->> ""$.City"",
+                            `ContactInfo` ->> ""$.State"",
+                            `ContactInfo` ->> ""$.Zip""
+						)) STORED");
+
+                    b.Property<JsonObject<Dictionary<string, string>>>("ContactInfo");
+
+                    b.Property<string>("Email")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
+						`ContactInfo` ->> ""$.Email""
+					) VIRTUAL");
+
+                    b.Property<string>("Name")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
+						`Names` ->> ""$[0]""
+					) VIRTUAL");
+
+                    b.Property<JsonObject<List<string>>>("Names");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Email");
+
+                    b.HasIndex("Name");
+
+                    b.ToTable("GeneratedContacts");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.GeneratedTime", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime>("CreatedDateTime")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("DATETIME");
+
+                    b.Property<DateTime>("CreatedDateTime3")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("DATETIME(3)");
+
+                    b.Property<DateTime>("CreatedDateTime6")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime>("CreatedTimestamp")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TIMESTAMP");
+
+                    b.Property<DateTime>("CreatedTimestamp3")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TIMESTAMP(3)");
+
+                    b.Property<DateTime>("CreatedTimestamp6")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TIMESTAMP(6)");
+
+                    b.Property<string>("Name");
+
+                    b.Property<DateTime>("UpdatedDateTime")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("DATETIME");
+
+                    b.Property<DateTime>("UpdatedDateTime3")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("DATETIME(3)");
+
+                    b.Property<DateTime>("UpdatedDateTime6")
+                        .ValueGeneratedOnAddOrUpdate();
+
+                    b.Property<DateTime>("UpdatedTimetamp")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("TIMESTAMP");
+
+                    b.Property<DateTime>("UpdatedTimetamp3")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("TIMESTAMP(3)");
+
+                    b.Property<DateTime>("UpdatedTimetamp6")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("TIMESTAMP(6)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("GeneratedTime");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Discriminator")
+                        .IsRequired()
+                        .HasMaxLength(63);
+
+                    b.Property<int?>("FamilyId");
+
+                    b.Property<string>("Name");
+
+                    b.Property<int?>("TeacherId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("FamilyId");
+
+                    b.ToTable("People");
+
+                    b.HasDiscriminator<string>("Discriminator").HasValue("Person");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonFamily", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("LastName");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("PeopleFamilies");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonKid", b =>
+                {
+                    b.HasBaseType("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person");
+
+                    b.Property<int>("Grade");
+
+                    b.HasIndex("Discriminator");
+
+                    b.HasIndex("TeacherId");
+
+                    b.ToTable("PersonKid");
+
+                    b.HasDiscriminator().HasValue("PersonKid");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonParent", b =>
+                {
+                    b.HasBaseType("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person");
+
+                    b.Property<string>("Occupation");
+
+                    b.Property<bool>("OnPta");
+
+                    b.ToTable("PersonParent");
+
+                    b.HasDiscriminator().HasValue("PersonParent");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonTeacher", b =>
+                {
+                    b.HasBaseType("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person");
+
+
+                    b.ToTable("PersonTeacher");
+
+                    b.HasDiscriminator().HasValue("PersonTeacher");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole")
+                        .WithMany("Claims")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.AppIdentityUser")
+                        .WithMany("Claims")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.AppIdentityUser")
+                        .WithMany("Logins")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole")
+                        .WithMany("Users")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.AppIdentityUser")
+                        .WithMany("Roles")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.BlogPost", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Blog", "Blog")
+                        .WithMany("Posts")
+                        .HasForeignKey("BlogId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdminMenu", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdmin", "Admin")
+                        .WithMany("AdminMenus")
+                        .HasForeignKey("AdminId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmMenu", "Menu")
+                        .WithMany("AdminMenus")
+                        .HasForeignKey("MenuId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdminRole", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdmin", "Admin")
+                        .WithMany("AdminRoles")
+                        .HasForeignKey("AdminId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmRole", "Role")
+                        .WithMany("AdminRoles")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonFamily", "Family")
+                        .WithMany("Members")
+                        .HasForeignKey("FamilyId");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonKid", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonTeacher", "Teacher")
+                        .WithMany("Students")
+                        .HasForeignKey("TeacherId");
+                });
+        }
+    }
+}

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Migrations/20170727192207_initial.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Migrations/20170727192207_initial.cs
@@ -1,0 +1,600 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Pomelo.EntityFrameworkCore.MySql.PerfTests.Migrations
+{
+    public partial class initial : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<string>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    ConcurrencyStamp = table.Column<string>(nullable: true),
+                    Name = table.Column<string>(maxLength: 127, nullable: true),
+                    NormalizedName = table.Column<string>(maxLength: 127, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(maxLength: 127, nullable: false),
+                    LoginProvider = table.Column<string>(maxLength: 127, nullable: false),
+                    Name = table.Column<string>(maxLength: 127, nullable: false),
+                    Value = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<string>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    AccessFailedCount = table.Column<int>(nullable: false),
+                    ConcurrencyStamp = table.Column<string>(nullable: true),
+                    Email = table.Column<string>(maxLength: 127, nullable: true),
+                    EmailConfirmed = table.Column<bool>(nullable: false),
+                    LockoutEnabled = table.Column<bool>(nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(nullable: true),
+                    NormalizedEmail = table.Column<string>(maxLength: 127, nullable: true),
+                    NormalizedUserName = table.Column<string>(maxLength: 127, nullable: true),
+                    PasswordHash = table.Column<string>(nullable: true),
+                    PhoneNumber = table.Column<string>(nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(nullable: false),
+                    SecurityStamp = table.Column<string>(nullable: true),
+                    TwoFactorEnabled = table.Column<bool>(nullable: false),
+                    UserName = table.Column<string>(maxLength: 127, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Blogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    Title = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Blogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CrmAdmins",
+                columns: table => new
+                {
+                    Id = table.Column<uint>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    Password = table.Column<string>(maxLength: 20, nullable: true),
+                    Username = table.Column<string>(maxLength: 10, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CrmAdmins", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CrmMenus",
+                columns: table => new
+                {
+                    Id = table.Column<uint>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    Name = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CrmMenus", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CrmRoles",
+                columns: table => new
+                {
+                    Id = table.Column<uint>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    Name = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CrmRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DataTypesSimple",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    TypeBool = table.Column<bool>(nullable: false),
+                    TypeBoolN = table.Column<bool>(nullable: true),
+                    TypeByte = table.Column<byte>(nullable: false),
+                    TypeByteN = table.Column<byte>(nullable: true),
+                    TypeChar = table.Column<char>(nullable: false),
+                    TypeCharN = table.Column<char>(nullable: true),
+                    TypeDateTime = table.Column<DateTime>(nullable: false),
+                    TypeDateTimeN = table.Column<DateTime>(nullable: true),
+                    TypeDateTimeOffset = table.Column<DateTimeOffset>(nullable: false),
+                    TypeDateTimeOffsetN = table.Column<DateTimeOffset>(nullable: true),
+                    TypeDecimal = table.Column<decimal>(nullable: false),
+                    TypeDecimalN = table.Column<decimal>(nullable: true),
+                    TypeDouble = table.Column<double>(nullable: false),
+                    TypeDoubleN = table.Column<double>(nullable: true),
+                    TypeEnum = table.Column<int>(nullable: false),
+                    TypeEnumByte = table.Column<byte>(nullable: false),
+                    TypeEnumByteN = table.Column<byte>(nullable: true),
+                    TypeEnumN = table.Column<int>(nullable: true),
+                    TypeFloat = table.Column<float>(nullable: false),
+                    TypeFloatN = table.Column<float>(nullable: true),
+                    TypeGuid = table.Column<Guid>(nullable: false),
+                    TypeGuidN = table.Column<Guid>(nullable: true),
+                    TypeInt = table.Column<int>(nullable: false),
+                    TypeIntN = table.Column<int>(nullable: true),
+                    TypeLong = table.Column<long>(nullable: false),
+                    TypeLongN = table.Column<long>(nullable: true),
+                    TypeSbyte = table.Column<sbyte>(nullable: false),
+                    TypeSbyteN = table.Column<sbyte>(nullable: true),
+                    TypeShort = table.Column<short>(nullable: false),
+                    TypeShortN = table.Column<short>(nullable: true),
+                    TypeTimeSpan = table.Column<TimeSpan>(nullable: false),
+                    TypeTimeSpanN = table.Column<TimeSpan>(nullable: true),
+                    TypeUint = table.Column<uint>(nullable: false),
+                    TypeUintN = table.Column<uint>(nullable: true),
+                    TypeUlong = table.Column<ulong>(nullable: false),
+                    TypeUlongN = table.Column<ulong>(nullable: true),
+                    TypeUshort = table.Column<ushort>(nullable: false),
+                    TypeUshortN = table.Column<ushort>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataTypesSimple", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DataTypesVariable",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    TypeByteArray = table.Column<byte[]>(nullable: false),
+                    TypeByteArray255 = table.Column<byte[]>(maxLength: 255, nullable: false),
+                    TypeByteArray255N = table.Column<byte[]>(maxLength: 255, nullable: true),
+                    TypeByteArrayN = table.Column<byte[]>(nullable: true),
+                    TypeJsonArray = table.Column<JsonObject<List<string>>>(nullable: false),
+                    TypeJsonArrayN = table.Column<JsonObject<List<string>>>(nullable: true),
+                    TypeJsonObject = table.Column<JsonObject<Dictionary<string, string>>>(nullable: false),
+                    TypeJsonObjectN = table.Column<JsonObject<Dictionary<string, string>>>(nullable: true),
+                    TypeString = table.Column<string>(nullable: false),
+                    TypeString255 = table.Column<string>(maxLength: 255, nullable: false),
+                    TypeString255N = table.Column<string>(maxLength: 255, nullable: true),
+                    TypeStringN = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataTypesVariable", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GeneratedContacts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    Address = table.Column<string>(type: @"VARCHAR(63) GENERATED ALWAYS AS (
+						CONCAT_WS(', ',
+							`ContactInfo` ->> ""$.Address"",
+                            `ContactInfo` ->> ""$.City"",
+                            `ContactInfo` ->> ""$.State"",
+                            `ContactInfo` ->> ""$.Zip""
+						)) STORED", nullable: true)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true),
+                    ContactInfo = table.Column<JsonObject<Dictionary<string, string>>>(nullable: true),
+                    Email = table.Column<string>(type: @"VARCHAR(63) GENERATED ALWAYS AS (
+						`ContactInfo` ->> ""$.Email""
+					) VIRTUAL", nullable: true)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true),
+                    Name = table.Column<string>(type: @"VARCHAR(63) GENERATED ALWAYS AS (
+						`Names` ->> ""$[0]""
+					) VIRTUAL", nullable: true)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true),
+                    Names = table.Column<JsonObject<List<string>>>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GeneratedContacts", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GeneratedTime",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    CreatedDateTime = table.Column<DateTime>(type: "DATETIME", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    CreatedDateTime3 = table.Column<DateTime>(type: "DATETIME(3)", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    CreatedDateTime6 = table.Column<DateTime>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    CreatedTimestamp = table.Column<DateTime>(type: "TIMESTAMP", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    CreatedTimestamp3 = table.Column<DateTime>(type: "TIMESTAMP(3)", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    CreatedTimestamp6 = table.Column<DateTime>(type: "TIMESTAMP(6)", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    Name = table.Column<string>(nullable: true),
+                    UpdatedDateTime = table.Column<DateTime>(type: "DATETIME", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true),
+                    UpdatedDateTime3 = table.Column<DateTime>(type: "DATETIME(3)", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true),
+                    UpdatedDateTime6 = table.Column<DateTime>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true),
+                    UpdatedTimetamp = table.Column<DateTime>(type: "TIMESTAMP", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true),
+                    UpdatedTimetamp3 = table.Column<DateTime>(type: "TIMESTAMP(3)", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true),
+                    UpdatedTimetamp6 = table.Column<DateTime>(type: "TIMESTAMP(6)", nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAddOrUpdate", true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GeneratedTime", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PeopleFamilies",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    LastName = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PeopleFamilies", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    ClaimType = table.Column<string>(nullable: true),
+                    ClaimValue = table.Column<string>(nullable: true),
+                    RoleId = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    ClaimType = table.Column<string>(nullable: true),
+                    ClaimValue = table.Column<string>(nullable: true),
+                    UserId = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(maxLength: 127, nullable: false),
+                    ProviderKey = table.Column<string>(maxLength: 127, nullable: false),
+                    ProviderDisplayName = table.Column<string>(nullable: true),
+                    UserId = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(maxLength: 127, nullable: false),
+                    RoleId = table.Column<string>(maxLength: 127, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BlogPost",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    BlogId = table.Column<int>(nullable: false),
+                    Content = table.Column<string>(nullable: true),
+                    Title = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BlogPost", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BlogPost_Blogs_BlogId",
+                        column: x => x.BlogId,
+                        principalTable: "Blogs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CrmAdminMenu",
+                columns: table => new
+                {
+                    AdminId = table.Column<uint>(nullable: false),
+                    MenuId = table.Column<uint>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CrmAdminMenu", x => new { x.AdminId, x.MenuId });
+                    table.ForeignKey(
+                        name: "FK_CrmAdminMenu_CrmAdmins_AdminId",
+                        column: x => x.AdminId,
+                        principalTable: "CrmAdmins",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CrmAdminMenu_CrmMenus_MenuId",
+                        column: x => x.MenuId,
+                        principalTable: "CrmMenus",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CrmAdminRole",
+                columns: table => new
+                {
+                    AdminId = table.Column<uint>(nullable: false),
+                    RoleId = table.Column<uint>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CrmAdminRole", x => new { x.AdminId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_CrmAdminRole_CrmAdmins_AdminId",
+                        column: x => x.AdminId,
+                        principalTable: "CrmAdmins",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CrmAdminRole_CrmRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "CrmRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "People",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGeneratedOnAdd", true),
+                    Discriminator = table.Column<string>(maxLength: 63, nullable: false),
+                    FamilyId = table.Column<int>(nullable: true),
+                    Name = table.Column<string>(nullable: true),
+                    TeacherId = table.Column<int>(nullable: true),
+                    Grade = table.Column<int>(nullable: true),
+                    Occupation = table.Column<string>(nullable: true),
+                    OnPta = table.Column<bool>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_People", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_People_PeopleFamilies_FamilyId",
+                        column: x => x.FamilyId,
+                        principalTable: "PeopleFamilies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_People_People_TeacherId",
+                        column: x => x.TeacherId,
+                        principalTable: "People",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BlogPost_BlogId",
+                table: "BlogPost",
+                column: "BlogId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CrmAdminMenu_MenuId",
+                table: "CrmAdminMenu",
+                column: "MenuId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CrmAdminRole_RoleId",
+                table: "CrmAdminRole",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GeneratedContacts_Email",
+                table: "GeneratedContacts",
+                column: "Email");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GeneratedContacts_Name",
+                table: "GeneratedContacts",
+                column: "Name");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_People_FamilyId",
+                table: "People",
+                column: "FamilyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_People_Discriminator",
+                table: "People",
+                column: "Discriminator");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_People_TeacherId",
+                table: "People",
+                column: "TeacherId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "BlogPost");
+
+            migrationBuilder.DropTable(
+                name: "CrmAdminMenu");
+
+            migrationBuilder.DropTable(
+                name: "CrmAdminRole");
+
+            migrationBuilder.DropTable(
+                name: "DataTypesSimple");
+
+            migrationBuilder.DropTable(
+                name: "DataTypesVariable");
+
+            migrationBuilder.DropTable(
+                name: "GeneratedContacts");
+
+            migrationBuilder.DropTable(
+                name: "GeneratedTime");
+
+            migrationBuilder.DropTable(
+                name: "People");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+
+            migrationBuilder.DropTable(
+                name: "Blogs");
+
+            migrationBuilder.DropTable(
+                name: "CrmMenus");
+
+            migrationBuilder.DropTable(
+                name: "CrmAdmins");
+
+            migrationBuilder.DropTable(
+                name: "CrmRoles");
+
+            migrationBuilder.DropTable(
+                name: "PeopleFamilies");
+        }
+    }
+}

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Migrations/AppDbModelSnapshot.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Migrations/AppDbModelSnapshot.cs
@@ -1,0 +1,668 @@
+using System.Collections.Generic;
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pomelo.EntityFrameworkCore.MySql.PerfTests;
+using Pomelo.EntityFrameworkCore.MySql.PerfTests.Models;
+
+namespace Pomelo.EntityFrameworkCore.MySql.PerfTests.Migrations
+{
+    [DbContext(typeof(AppDb))]
+    partial class AppDbModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.1");
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole", b =>
+                {
+                    b.Property<string>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("NormalizedName")
+                        .HasMaxLength(127);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .IsUnique()
+                        .HasName("RoleNameIndex");
+
+                    b.ToTable("AspNetRoles");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("RoleId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("AspNetRoleClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("ProviderKey")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("ProviderDisplayName");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserLogins");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("RoleId")
+                        .HasMaxLength(127);
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("AspNetUserRoles");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserToken<string>", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("LoginProvider")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("Value");
+
+                    b.HasKey("UserId", "LoginProvider", "Name");
+
+                    b.ToTable("AspNetUserTokens");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.AppIdentityUser", b =>
+                {
+                    b.Property<string>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+                        .HasMaxLength(127);
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasMaxLength(127);
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+                        .HasMaxLength(127);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasName("EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .IsUnique()
+                        .HasName("UserNameIndex");
+
+                    b.ToTable("AspNetUsers");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Blog", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Title");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Blogs");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.BlogPost", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("BlogId");
+
+                    b.Property<string>("Content");
+
+                    b.Property<string>("Title");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("BlogId");
+
+                    b.ToTable("BlogPost");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdmin", b =>
+                {
+                    b.Property<uint>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Password")
+                        .HasMaxLength(20);
+
+                    b.Property<string>("Username")
+                        .HasMaxLength(10);
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CrmAdmins");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdminMenu", b =>
+                {
+                    b.Property<uint>("AdminId");
+
+                    b.Property<uint>("MenuId");
+
+                    b.HasKey("AdminId", "MenuId");
+
+                    b.HasIndex("MenuId");
+
+                    b.ToTable("CrmAdminMenu");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdminRole", b =>
+                {
+                    b.Property<uint>("AdminId");
+
+                    b.Property<uint>("RoleId");
+
+                    b.HasKey("AdminId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("CrmAdminRole");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmMenu", b =>
+                {
+                    b.Property<uint>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Name");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CrmMenus");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmRole", b =>
+                {
+                    b.Property<uint>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Name");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CrmRoles");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.DataTypesSimple", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<bool>("TypeBool");
+
+                    b.Property<bool?>("TypeBoolN");
+
+                    b.Property<byte>("TypeByte");
+
+                    b.Property<byte?>("TypeByteN");
+
+                    b.Property<char>("TypeChar");
+
+                    b.Property<char?>("TypeCharN");
+
+                    b.Property<DateTime>("TypeDateTime");
+
+                    b.Property<DateTime?>("TypeDateTimeN");
+
+                    b.Property<DateTimeOffset>("TypeDateTimeOffset");
+
+                    b.Property<DateTimeOffset?>("TypeDateTimeOffsetN");
+
+                    b.Property<decimal>("TypeDecimal");
+
+                    b.Property<decimal?>("TypeDecimalN");
+
+                    b.Property<double>("TypeDouble");
+
+                    b.Property<double?>("TypeDoubleN");
+
+                    b.Property<int>("TypeEnum");
+
+                    b.Property<byte>("TypeEnumByte");
+
+                    b.Property<byte?>("TypeEnumByteN");
+
+                    b.Property<int?>("TypeEnumN");
+
+                    b.Property<float>("TypeFloat");
+
+                    b.Property<float?>("TypeFloatN");
+
+                    b.Property<Guid>("TypeGuid");
+
+                    b.Property<Guid?>("TypeGuidN");
+
+                    b.Property<int>("TypeInt");
+
+                    b.Property<int?>("TypeIntN");
+
+                    b.Property<long>("TypeLong");
+
+                    b.Property<long?>("TypeLongN");
+
+                    b.Property<sbyte>("TypeSbyte");
+
+                    b.Property<sbyte?>("TypeSbyteN");
+
+                    b.Property<short>("TypeShort");
+
+                    b.Property<short?>("TypeShortN");
+
+                    b.Property<TimeSpan>("TypeTimeSpan");
+
+                    b.Property<TimeSpan?>("TypeTimeSpanN");
+
+                    b.Property<uint>("TypeUint");
+
+                    b.Property<uint?>("TypeUintN");
+
+                    b.Property<ulong>("TypeUlong");
+
+                    b.Property<ulong?>("TypeUlongN");
+
+                    b.Property<ushort>("TypeUshort");
+
+                    b.Property<ushort?>("TypeUshortN");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("DataTypesSimple");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.DataTypesVariable", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<byte[]>("TypeByteArray")
+                        .IsRequired();
+
+                    b.Property<byte[]>("TypeByteArray255")
+                        .IsRequired()
+                        .HasMaxLength(255);
+
+                    b.Property<byte[]>("TypeByteArray255N")
+                        .HasMaxLength(255);
+
+                    b.Property<byte[]>("TypeByteArrayN");
+
+                    b.Property<JsonObject<List<string>>>("TypeJsonArray")
+                        .IsRequired();
+
+                    b.Property<JsonObject<List<string>>>("TypeJsonArrayN");
+
+                    b.Property<JsonObject<Dictionary<string, string>>>("TypeJsonObject")
+                        .IsRequired();
+
+                    b.Property<JsonObject<Dictionary<string, string>>>("TypeJsonObjectN");
+
+                    b.Property<string>("TypeString")
+                        .IsRequired();
+
+                    b.Property<string>("TypeString255")
+                        .IsRequired()
+                        .HasMaxLength(255);
+
+                    b.Property<string>("TypeString255N")
+                        .HasMaxLength(255);
+
+                    b.Property<string>("TypeStringN");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("DataTypesVariable");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.GeneratedContact", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
+						CONCAT_WS(', ',
+							`ContactInfo` ->> ""$.Address"",
+                            `ContactInfo` ->> ""$.City"",
+                            `ContactInfo` ->> ""$.State"",
+                            `ContactInfo` ->> ""$.Zip""
+						)) STORED");
+
+                    b.Property<JsonObject<Dictionary<string, string>>>("ContactInfo");
+
+                    b.Property<string>("Email")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
+						`ContactInfo` ->> ""$.Email""
+					) VIRTUAL");
+
+                    b.Property<string>("Name")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
+						`Names` ->> ""$[0]""
+					) VIRTUAL");
+
+                    b.Property<JsonObject<List<string>>>("Names");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Email");
+
+                    b.HasIndex("Name");
+
+                    b.ToTable("GeneratedContacts");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.GeneratedTime", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime>("CreatedDateTime")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("DATETIME");
+
+                    b.Property<DateTime>("CreatedDateTime3")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("DATETIME(3)");
+
+                    b.Property<DateTime>("CreatedDateTime6")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime>("CreatedTimestamp")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TIMESTAMP");
+
+                    b.Property<DateTime>("CreatedTimestamp3")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TIMESTAMP(3)");
+
+                    b.Property<DateTime>("CreatedTimestamp6")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TIMESTAMP(6)");
+
+                    b.Property<string>("Name");
+
+                    b.Property<DateTime>("UpdatedDateTime")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("DATETIME");
+
+                    b.Property<DateTime>("UpdatedDateTime3")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("DATETIME(3)");
+
+                    b.Property<DateTime>("UpdatedDateTime6")
+                        .ValueGeneratedOnAddOrUpdate();
+
+                    b.Property<DateTime>("UpdatedTimetamp")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("TIMESTAMP");
+
+                    b.Property<DateTime>("UpdatedTimetamp3")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("TIMESTAMP(3)");
+
+                    b.Property<DateTime>("UpdatedTimetamp6")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("TIMESTAMP(6)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("GeneratedTime");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Discriminator")
+                        .IsRequired()
+                        .HasMaxLength(63);
+
+                    b.Property<int?>("FamilyId");
+
+                    b.Property<string>("Name");
+
+                    b.Property<int?>("TeacherId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("FamilyId");
+
+                    b.ToTable("People");
+
+                    b.HasDiscriminator<string>("Discriminator").HasValue("Person");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonFamily", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("LastName");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("PeopleFamilies");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonKid", b =>
+                {
+                    b.HasBaseType("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person");
+
+                    b.Property<int>("Grade");
+
+                    b.HasIndex("Discriminator");
+
+                    b.HasIndex("TeacherId");
+
+                    b.ToTable("PersonKid");
+
+                    b.HasDiscriminator().HasValue("PersonKid");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonParent", b =>
+                {
+                    b.HasBaseType("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person");
+
+                    b.Property<string>("Occupation");
+
+                    b.Property<bool>("OnPta");
+
+                    b.ToTable("PersonParent");
+
+                    b.HasDiscriminator().HasValue("PersonParent");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonTeacher", b =>
+                {
+                    b.HasBaseType("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person");
+
+
+                    b.ToTable("PersonTeacher");
+
+                    b.HasDiscriminator().HasValue("PersonTeacher");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole")
+                        .WithMany("Claims")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.AppIdentityUser")
+                        .WithMany("Claims")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.AppIdentityUser")
+                        .WithMany("Logins")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole")
+                        .WithMany("Users")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.AppIdentityUser")
+                        .WithMany("Roles")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.BlogPost", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Blog", "Blog")
+                        .WithMany("Posts")
+                        .HasForeignKey("BlogId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdminMenu", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdmin", "Admin")
+                        .WithMany("AdminMenus")
+                        .HasForeignKey("AdminId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmMenu", "Menu")
+                        .WithMany("AdminMenus")
+                        .HasForeignKey("MenuId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdminRole", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmAdmin", "Admin")
+                        .WithMany("AdminRoles")
+                        .HasForeignKey("AdminId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.CrmRole", "Role")
+                        .WithMany("AdminRoles")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.Person", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonFamily", "Family")
+                        .WithMany("Members")
+                        .HasForeignKey("FamilyId");
+                });
+
+            modelBuilder.Entity("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonKid", b =>
+                {
+                    b.HasOne("Pomelo.EntityFrameworkCore.MySql.PerfTests.Models.PersonTeacher", "Teacher")
+                        .WithMany("Students")
+                        .HasForeignKey("TeacherId");
+                });
+        }
+    }
+}

--- a/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Models/Crm.cs
+++ b/test/Pomelo.EntityFrameworkCore.MySql.PerfTests/Models/Crm.cs
@@ -48,7 +48,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.PerfTests.Models
 
 	public class CrmAdmin
 	{
-		public int Id { get; set; }
+		public uint Id { get; set; }
 		public string Username { get; set; }
 		public string Password { get; set; }
 		public List<CrmAdminRole> AdminRoles { get; set; }
@@ -57,30 +57,30 @@ namespace Pomelo.EntityFrameworkCore.MySql.PerfTests.Models
 
 	public class CrmRole
 	{
-		public int Id { get; set; }
+		public uint Id { get; set; }
 		public string Name { get; set; }
 		public List<CrmAdminRole> AdminRoles { get; set; }
 	}
 
 	public class CrmMenu
 	{
-		public int Id { get; set; }
+		public uint Id { get; set; }
 		public string Name { get; set; }
 		public List<CrmAdminMenu> AdminMenus { get; set; }
 	}
 
 	public class CrmAdminRole
 	{
-		public int AdminId { get; set; }
-		public int RoleId { get; set; }
+		public uint AdminId { get; set; }
+		public uint RoleId { get; set; }
 		public CrmAdmin Admin { get; set; }
 		public CrmRole Role { get; set; }
 	}
 
 	public class CrmAdminMenu
 	{
-		public int AdminId { get; set; }
-		public int MenuId { get; set; }
+		public uint AdminId { get; set; }
+		public uint MenuId { get; set; }
 		public CrmAdmin Admin { get; set; }
 		public CrmMenu Menu { get; set; }
 	}


### PR DESCRIPTION
#328 Unable to use uint as primary key

### Steps to reproduce
change PK in CRM Test Model to uint from branch 1.1.3

use docker for mysql db (settings from config.json)
```
docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=Password12! -e MYSQL_DATABASE=pomelo_test -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
```

run `test\Pomelo.EntityFrameworkCore.MySql.PerfTests\scripts\rebuild.ps1` (migration file inside)

run `dotnet test`

### The issue

```
Build started, please wait...
Build completed.

Test run for D:\Projects\Pomelo.EntityFrameworkCore.MySql\test\Pomelo.EntityFrameworkCore.MySql.PerfTests\bin\Debug\netcoreapp1.1.1\Pomelo.EntityFrameworkCore.MySql.PerfTests.dll(.NETCoreApp,Version=v1.1.1)
Microsoft (R) Testausführungs-Befehlszeilentool Version 15.3.0-dev
Copyright (c) Microsoft Corporation. Alle Rechte vorbehalten.

Die Testausführung wird gestartet, bitte warten...
[xUnit.net 00:00:00.9974984]   Discovering: Pomelo.EntityFrameworkCore.MySql.PerfTests
[xUnit.net 00:00:01.2434792]   Discovered:  Pomelo.EntityFrameworkCore.MySql.PerfTests
[xUnit.net 00:00:01.3323335]   Starting:    Pomelo.EntityFrameworkCore.MySql.PerfTests
[xUnit.net 00:00:03.4285425]     Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.CrmTest.TestCrmSuperUserExplicitLoading [FAIL]
[xUnit.net 00:00:03.4298727]       Microsoft.EntityFrameworkCore.DbUpdateException : An error occurred while updating the entries. See the inner exception for details.
[xUnit.net 00:00:03.4300544]       ---- System.InvalidCastException : Unable to cast object of type 'System.UInt64' to type 'System.UInt32'.
[xUnit.net 00:00:03.4339281]       Stack Trace:
[xUnit.net 00:00:03.4356170]            at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.Consume(DbDataReader reader)
[xUnit.net 00:00:03.4358414]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Update\Internal\MySqlModificationCommandBatch.cs(173,0): at Microsoft.EntityFrameworkCore.Update.Internal.MySqlModificationCommandBatch.Execute(IRelationalConnection connection)
[xUnit.net 00:00:03.4361670]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Update\Internal\MySqlBatchExecutor.cs(49,0): at Microsoft.EntityFrameworkCore.Update.Internal.MySqlBatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection)
[xUnit.net 00:00:03.4364531]            at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IReadOnlyList`1 entriesToSave)
[xUnit.net 00:00:03.4365721]            at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
[xUnit.net 00:00:03.4366748]            at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
[xUnit.net 00:00:03.4367859]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\test\Pomelo.EntityFrameworkCore.MySql.PerfTests\Tests\Models\CrmTest.cs(52,0): at Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.CrmFixture..ctor()
[xUnit.net 00:00:03.4370217]         ----- Inner Stack Trace -----
[xUnit.net 00:00:03.4371334]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Storage\Internal\WrappedMySqlDataReader.cs(108,0): at Microsoft.EntityFrameworkCore.Storage.Internal.WrappedMySqlDataReader.ConvertWithReflection[T](Int32 ordinal, InvalidCastException e)
[xUnit.net 00:00:03.4375211]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Storage\Internal\WrappedMySqlDataReader.cs(91,0): at Microsoft.EntityFrameworkCore.Storage.Internal.WrappedMySqlDataReader.GetFieldValue[T](Int32 ordinal)
[xUnit.net 00:00:03.4378364]            at lambda_method(Closure , DbDataReader )
[xUnit.net 00:00:03.4379608]            at Microsoft.EntityFrameworkCore.Storage.Internal.TypedRelationalValueBufferFactory.Create(DbDataReader dataReader)
[xUnit.net 00:00:03.4380701]            at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.ConsumeResultSetWithPropagation(Int32 commandIndex, DbDataReader reader)
[xUnit.net 00:00:03.4382791]            at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.Consume(DbDataReader reader)
[xUnit.net 00:00:03.4589375]     Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.CrmTest.TestCrmSuperUserEagerLoading [FAIL]
[xUnit.net 00:00:03.4590571]       Microsoft.EntityFrameworkCore.DbUpdateException : An error occurred while updating the entries. See the inner exception for details.
[xUnit.net 00:00:03.4591013]       ---- System.InvalidCastException : Unable to cast object of type 'System.UInt64' to type 'System.UInt32'.
[xUnit.net 00:00:03.4593320]       Stack Trace:
[xUnit.net 00:00:03.4596398]            at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.Consume(DbDataReader reader)
[xUnit.net 00:00:03.4597766]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Update\Internal\MySqlModificationCommandBatch.cs(173,0): at Microsoft.EntityFrameworkCore.Update.Internal.MySqlModificationCommandBatch.Execute(IRelationalConnection connection)
[xUnit.net 00:00:03.4601913]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Update\Internal\MySqlBatchExecutor.cs(49,0): at Microsoft.EntityFrameworkCore.Update.Internal.MySqlBatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection)
[xUnit.net 00:00:03.4605039]            at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IReadOnlyList`1 entriesToSave)
[xUnit.net 00:00:03.4606150]            at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
[xUnit.net 00:00:03.4607135]            at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
[xUnit.net 00:00:03.4608286]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\test\Pomelo.EntityFrameworkCore.MySql.PerfTests\Tests\Models\CrmTest.cs(52,0): at Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.CrmFixture..ctor()
[xUnit.net 00:00:03.4610831]         ----- Inner Stack Trace -----
[xUnit.net 00:00:03.4612074]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Storage\Internal\WrappedMySqlDataReader.cs(108,0): at Microsoft.EntityFrameworkCore.Storage.Internal.WrappedMySqlDataReader.ConvertWithReflection[T](Int32 ordinal, InvalidCastException e)
[xUnit.net 00:00:03.4615667]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Storage\Internal\WrappedMySqlDataReader.cs(91,0): at Microsoft.EntityFrameworkCore.Storage.Internal.WrappedMySqlDataReader.GetFieldValue[T](Int32 ordinal)
[xUnit.net 00:00:03.4618252]            at lambda_method(Closure , DbDataReader )
[xUnit.net 00:00:03.4620926]            at Microsoft.EntityFrameworkCore.Storage.Internal.TypedRelationalValueBufferFactory.Create(DbDataReader dataReader)
[xUnit.net 00:00:03.4622079]            at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.ConsumeResultSetWithPropagation(Int32 commandIndex, DbDataReader reader)
[xUnit.net 00:00:03.4624392]            at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.Consume(DbDataReader reader)
Fehler Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.CrmTest.TestCrmSuperUserExplicitLoading
Fehlermeldung:
 Microsoft.EntityFrameworkCore.DbUpdateException : An error occurred while updating the entries. See the inner exception for details.
---- System.InvalidCastException : Unable to cast object of type 'System.UInt64' to type 'System.UInt32'.
Stapelverfolgung:
   at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.Consume(DbDataReader reader)
   at Microsoft.EntityFrameworkCore.Update.Internal.MySqlModificationCommandBatch.Execute(IRelationalConnection connection) in D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Update\Internal\MySqlModificationCommandBatch.cs:line 173
   at Microsoft.EntityFrameworkCore.Update.Internal.MySqlBatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection) in D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Update\Internal\MySqlBatchExecutor.cs:line 49
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IReadOnlyList`1 entriesToSave)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.CrmFixture..ctor() in D:\Projects\Pomelo.EntityFrameworkCore.MySql\test\Pomelo.EntityFrameworkCore.MySql.PerfTests\Tests\Models\CrmTest.cs:line 52
----- Inner Stack Trace -----
   at Microsoft.EntityFrameworkCore.Storage.Internal.WrappedMySqlDataReader.ConvertWithReflection[T](Int32 ordinal, InvalidCastException e) in D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Storage\Internal\WrappedMySqlDataReader.cs:line 108
   at Microsoft.EntityFrameworkCore.Storage.Internal.WrappedMySqlDataReader.GetFieldValue[T](Int32 ordinal) in D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Storage\Internal\WrappedMySqlDataReader.cs:line 91
   at lambda_method(Closure , DbDataReader )
   at Microsoft.EntityFrameworkCore.Storage.Internal.TypedRelationalValueBufferFactory.Create(DbDataReader dataReader)
   at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.ConsumeResultSetWithPropagation(Int32 commandIndex, DbDataReader reader)
   at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.Consume(DbDataReader reader)
Fehler Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.CrmTest.TestCrmSuperUserEagerLoading
Fehlermeldung:
 Microsoft.EntityFrameworkCore.DbUpdateException : An error occurred while updating the entries. See the inner exception for details.
---- System.InvalidCastException : Unable to cast object of type 'System.UInt64' to type 'System.UInt32'.
Stapelverfolgung:
   at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.Consume(DbDataReader reader)
   at Microsoft.EntityFrameworkCore.Update.Internal.MySqlModificationCommandBatch.Execute(IRelationalConnection connection) in D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Update\Internal\MySqlModificationCommandBatch.cs:line 173
   at Microsoft.EntityFrameworkCore.Update.Internal.MySqlBatchExecutor.Execute(IEnumerable`1 commandBatches, IRelationalConnection connection) in D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Update\Internal\MySqlBatchExecutor.cs:line 49
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(IReadOnlyList`1 entriesToSave)
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Microsoft.EntityFrameworkCore.DbContext.SaveChanges(Boolean acceptAllChangesOnSuccess)
   at Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.CrmFixture..ctor() in D:\Projects\Pomelo.EntityFrameworkCore.MySql\test\Pomelo.EntityFrameworkCore.MySql.PerfTests\Tests\Models\CrmTest.cs:line 52
----- Inner Stack Trace -----
   at Microsoft.EntityFrameworkCore.Storage.Internal.WrappedMySqlDataReader.ConvertWithReflection[T](Int32 ordinal, InvalidCastException e) in D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Storage\Internal\WrappedMySqlDataReader.cs:line 108
   at Microsoft.EntityFrameworkCore.Storage.Internal.WrappedMySqlDataReader.GetFieldValue[T](Int32 ordinal) in D:\Projects\Pomelo.EntityFrameworkCore.MySql\src\Pomelo.EntityFrameworkCore.MySql\Storage\Internal\WrappedMySqlDataReader.cs:line 91
   at lambda_method(Closure , DbDataReader )
   at Microsoft.EntityFrameworkCore.Storage.Internal.TypedRelationalValueBufferFactory.Create(DbDataReader dataReader)
   at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.ConsumeResultSetWithPropagation(Int32 commandIndex, DbDataReader reader)
   at Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch.Consume(DbDataReader reader)
[xUnit.net 00:00:05.5777164]     Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.ExpressionTest.MySqlMathCosTranslator [FAIL]
[xUnit.net 00:00:05.5780531]       Assert.Equal() Failure
[xUnit.net 00:00:05.5781736]       Expected: 0,54030230586814
[xUnit.net 00:00:05.5783004]       Actual:   0,54030230586814
[xUnit.net 00:00:05.5788356]       Stack Trace:
[xUnit.net 00:00:05.5789530]         D:\Projects\Pomelo.EntityFrameworkCore.MySql\test\Pomelo.EntityFrameworkCore.MySql.PerfTests\Tests\Models\ExpressionTest.cs(361,0): at Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.ExpressionTest.<MySqlMathCosTranslator>d__25.MoveNext()
[xUnit.net 00:00:05.5793602]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:00:05.5796045]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[xUnit.net 00:00:05.5797162]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[xUnit.net 00:00:05.5798346]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:00:05.5801204]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[xUnit.net 00:00:05.5803393]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[xUnit.net 00:00:05.5804722]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:00:05.5805773]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[xUnit.net 00:00:05.5806794]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[xUnit.net 00:00:05.7912331]   Finished:    Pomelo.EntityFrameworkCore.MySql.PerfTests
Fehler Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.ExpressionTest.MySqlMathCosTranslator
Fehlermeldung:
 Assert.Equal() Failure
Expected: 0,54030230586814
Actual:   0,54030230586814
Stapelverfolgung:
   at Pomelo.EntityFrameworkCore.MySql.PerfTests.Tests.Models.ExpressionTest.<MySqlMathCosTranslator>d__25.MoveNext() in D:\Projects\Pomelo.EntityFrameworkCore.MySql\test\Pomelo.EntityFrameworkCore.MySql.PerfTests\Tests\Models\ExpressionTest.cs:line 361
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)

Tests gesamt: 30. Bestanden: 27. Fehler: 3. Übersprungen: 0.
Fehler beim Testlauf.
Testausführungszeit: 6,7233 Sekunden
```

### Further technical details

MySQL version: 5.7
Operating system: Windows 10
