### PR TITLE
Functional Tests: scoped commands

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/AppDb.cs
+++ b/test/EFCore.MySql.FunctionalTests/AppDb.cs
@@ -10,7 +10,7 @@ using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Models;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 {
-	public class AppDb : IdentityDbContext<AppIdentityUser>//, IDesignTimeDbContextFactory<AppDb>
+	public class AppDb : IdentityDbContext<AppIdentityUser>, IDesignTimeDbContextFactory<AppDb>
 	{
 		// blog
 		public DbSet<Blog> Blogs { get; set; }
@@ -54,13 +54,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 	        _connection = connection;
 	    }
 
-		// AppDb IDesignTimeDbContextFactory<AppDb>.CreateDbContext(string[] args)
-		// {
-		// 	var optionsBuilder = new DbContextOptionsBuilder<AppDb>()
-		// 		.UseMySql(AppConfig.Config["Data:ConnectionString"]);
-		// 	new MySqlDbContextOptionsBuilder(optionsBuilder).MaxBatchSize(AppConfig.EfBatchSize);
-		// 	return new AppDb(optionsBuilder.Options);
-		// }
+		AppDb IDesignTimeDbContextFactory<AppDb>.CreateDbContext(string[] args)
+		{
+			var optionsBuilder = new DbContextOptionsBuilder<AppDb>()
+				.UseMySql(AppConfig.Config["Data:ConnectionString"]);
+			new MySqlDbContextOptionsBuilder(optionsBuilder).MaxBatchSize(AppConfig.EfBatchSize);
+			return new AppDb(optionsBuilder.Options);
+		}
 
 		protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
 		{

--- a/test/EFCore.MySql.FunctionalTests/AppDb.cs
+++ b/test/EFCore.MySql.FunctionalTests/AppDb.cs
@@ -10,7 +10,7 @@ using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Models;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 {
-	public class AppDb : IdentityDbContext<AppIdentityUser>, IDesignTimeDbContextFactory<AppDb>
+	public class AppDb : IdentityDbContext<AppIdentityUser>
 	{
 		// blog
 		public DbSet<Blog> Blogs { get; set; }
@@ -34,17 +34,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 		public DbSet<PersonKid> PeopleKids { get; set; }
 		public DbSet<PersonParent> PeopleParents { get; set; }
 		public DbSet<PersonFamily> PeopleFamilies { get; set; }
-
+		
 		public AppDb(DbContextOptions options) : base(options)
 		{
-		}
-
-		AppDb IDesignTimeDbContextFactory<AppDb>.CreateDbContext(string[] args)
-		{
-			var optionsBuilder = new DbContextOptionsBuilder<AppDb>()
-				.UseMySql(AppConfig.Config["Data:ConnectionString"]);
-			new MySqlDbContextOptionsBuilder(optionsBuilder).MaxBatchSize(AppConfig.EfBatchSize);
-			return new AppDb(optionsBuilder.Options);
 		}
 
 		protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EFCore.MySql.FunctionalTests/AppDb.cs
+++ b/test/EFCore.MySql.FunctionalTests/AppDb.cs
@@ -35,24 +35,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 		public DbSet<PersonParent> PeopleParents { get; set; }
 		public DbSet<PersonFamily> PeopleFamilies { get; set; }
 
-		private readonly bool _configured;
-	    private readonly DbConnection _connection;
-
-		public AppDb()
-		{
-			_configured = false;
-		}
-
 		public AppDb(DbContextOptions options) : base(options)
 		{
-			_configured = true;
 		}
-
-	    public AppDb(DbConnection connection)
-	    {
-	        _configured = false;
-	        _connection = connection;
-	    }
 
 		AppDb IDesignTimeDbContextFactory<AppDb>.CreateDbContext(string[] args)
 		{
@@ -60,19 +45,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 				.UseMySql(AppConfig.Config["Data:ConnectionString"]);
 			new MySqlDbContextOptionsBuilder(optionsBuilder).MaxBatchSize(AppConfig.EfBatchSize);
 			return new AppDb(optionsBuilder.Options);
-		}
-
-		protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-		{
-		    if (_configured)
-		        return;
-
-		    if (_connection != null)
-                optionsBuilder.UseMySql(_connection, options => options.MaxBatchSize(AppConfig.EfBatchSize));
-		    else
-				optionsBuilder.UseMySql(AppConfig.Config["Data:ConnectionString"], options => options.MaxBatchSize(AppConfig.EfBatchSize));
-
-		    optionsBuilder.UseLoggerFactory(new LoggerFactory().AddConsole(AppConfig.Config.GetSection("Logging")));
 		}
 
 		protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EFCore.MySql.FunctionalTests/AppDbScope.cs
+++ b/test/EFCore.MySql.FunctionalTests/AppDbScope.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using System.Data.Common;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
+{
+    public class AppDbScope : IDisposable
+    {
+        private static ServiceProvider CreateServiceProvider(DbConnection connection = null)
+        {
+            var serviceCollection = new ServiceCollection();
+                serviceCollection
+                    .AddLogging();
+                Startup.ConfigureEntityFramework(serviceCollection);
+
+                var serviceProvider = serviceCollection.BuildServiceProvider();
+                serviceProvider
+                    .GetService<ILoggerFactory>()
+                    .AddConsole(AppConfig.Config.GetSection("Logging"));
+                return serviceProvider;
+        }
+
+        private static Lazy<ServiceProvider> DefaultLazyServiceProvider = new Lazy<ServiceProvider>(() => {
+            return CreateServiceProvider();
+        });
+
+        private IServiceScope _scope;
+
+        public AppDbScope()
+        {
+            var serviceProvider = DefaultLazyServiceProvider.Value;
+            _scope = serviceProvider.CreateScope();
+        }
+
+        public AppDbScope(DbConnection connection = null)
+        {
+            var serviceProvider = CreateServiceProvider(connection);
+            _scope = serviceProvider.CreateScope();
+        }
+
+        public AppDb AppDb => _scope.ServiceProvider.GetService<AppDb>();
+
+        public void Dispose()
+        {
+            if (_scope != null)
+            {
+                _scope.Dispose();
+                _scope = null;
+            }
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Commands/CommandRunner.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/CommandRunner.cs
@@ -2,19 +2,35 @@ using System;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
 
-    public static class CommandRunner
+    public class CommandRunner : ICommandRunner
     {
-        public static void Help()
+
+        private IConnectionStringCommand _connectionStringCommand;
+        private ITestMigrateCommand _testMigrateCommand;
+        private ITestPerformanceCommand _testPerformanceCommand;
+
+        public CommandRunner(
+            IConnectionStringCommand connectionStringCommand,
+            ITestMigrateCommand testMigrateCommand,
+            ITestPerformanceCommand testPerformanceCommand
+        )
+        {
+            _connectionStringCommand = connectionStringCommand;
+            _testMigrateCommand = testMigrateCommand;
+            _testPerformanceCommand = testPerformanceCommand;
+        }
+
+        public void Help()
         {
             Console.Error.WriteLine(@"dotnet run
     connectionString   print connection string
     testMigrate        test dbContext.Database functions: ensureCreate, ensureDelete, migrate
-    testPerformance [iteratoins] [concurrency] [operations]
+    testPerformance [iterations] [concurrency] [operations]
     -h, --help         show this message
             ");
         }
 
-        public static int Run(string[] args)
+        public int Run(string[] args)
         {
             var cmd = args[0];
 
@@ -23,15 +39,15 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
 	            switch (cmd)
 	            {
 		            case "connectionString":
-						ConnectionStringCommand.Run();
+						_connectionStringCommand.Run();
 			            break;
 		            case "testMigrate":
-						TestMigrateCommand.Run();
+						_testMigrateCommand.Run();
 			            break;
 	                case "testPerformance":
 	                    if (args.Length != 4)
 	                        goto default;
-	                    TestPerformanceCommand.Run(int.Parse(args[1]), int.Parse(args[2]), int.Parse(args[3]));
+	                    _testPerformanceCommand.Run(int.Parse(args[1]), int.Parse(args[2]), int.Parse(args[3]));
 	                    break;
 		            case "-h":
 		            case "--help":

--- a/test/EFCore.MySql.FunctionalTests/Commands/ConnectionStringCommand.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/ConnectionStringCommand.cs
@@ -2,9 +2,11 @@ using System;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
 
-    public static class ConnectionStringCommand{
+    public class ConnectionStringCommand : IConnectionStringCommand
+    {
 
-        public static void Run(){
+        public void Run()
+        {
             Console.Write(AppConfig.Config["Data:ConnectionString"]);
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Commands/ICommandRunner.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/ICommandRunner.cs
@@ -1,0 +1,9 @@
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands
+{
+
+    public interface ICommandRunner
+    {
+        int Run(string[] args);
+    }
+
+}

--- a/test/EFCore.MySql.FunctionalTests/Commands/IConnectionStringCommand.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/IConnectionStringCommand.cs
@@ -1,0 +1,9 @@
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands
+{
+
+    public interface IConnectionStringCommand
+    {
+        void Run();
+    }
+
+}

--- a/test/EFCore.MySql.FunctionalTests/Commands/ITestMigrateCommand.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/ITestMigrateCommand.cs
@@ -1,0 +1,9 @@
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands
+{
+
+    public interface ITestMigrateCommand
+    {
+        void Run();
+    }
+
+}

--- a/test/EFCore.MySql.FunctionalTests/Commands/ITestPerformanceCommand.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/ITestPerformanceCommand.cs
@@ -1,0 +1,9 @@
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands
+{
+
+    public interface ITestPerformanceCommand
+    {
+        void Run(int iterations, int concurrency, int ops);
+    }
+
+}

--- a/test/EFCore.MySql.FunctionalTests/Commands/ITestPerformanceRunner.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/ITestPerformanceRunner.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands
+{
+
+    public interface ITestPerformanceRunner
+    {
+        Task ConnectionTask(Func<AppDb, Task> cb, int ops);
+    }
+
+}

--- a/test/EFCore.MySql.FunctionalTests/Commands/TestMigrateCommand.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/TestMigrateCommand.cs
@@ -5,50 +5,55 @@ using MySql.Data.MySqlClient;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
 
-    public static class TestMigrateCommand{
+    public class TestMigrateCommand : ITestMigrateCommand {
 
-        public static void Run(){
-            using (var db = new AppDb()){
-                db.Database.EnsureDeleted();
+        private AppDb _db;
 
-                Console.Write("EnsureCreate creates database...");
-                Assert.True(db.Database.EnsureCreated());
-                Console.WriteLine(" OK");
+        public TestMigrateCommand(AppDb db)
+        {
+            _db = db;
+        }
 
-                Console.Write("EnsureCreate existing database...");
-                Assert.False(db.Database.EnsureCreated());
-                Console.WriteLine(" OK");
+        public void Run(){
+            _db.Database.EnsureDeleted();
 
-                Console.Write("EnsureDelete deletes database...");
-                Assert.True(db.Database.EnsureDeleted());
-                Console.WriteLine(" OK");
+            Console.Write("EnsureCreate creates database...");
+            Assert.True(_db.Database.EnsureCreated());
+            Console.WriteLine(" OK");
 
-                Console.Write("EnsureCreate non-existant database...");
-                Assert.False(db.Database.EnsureDeleted());
-                Console.WriteLine(" OK");
+            Console.Write("EnsureCreate existing database...");
+            Assert.False(_db.Database.EnsureCreated());
+            Console.WriteLine(" OK");
 
-                Console.Write("Migrate non-existant database...");
-                db.Database.Migrate();
-                Console.WriteLine(" OK");
+            Console.Write("EnsureDelete deletes database...");
+            Assert.True(_db.Database.EnsureDeleted());
+            Console.WriteLine(" OK");
 
-                db.Database.EnsureDeleted();
-                Console.Write("Create blank database...");
-                var csb = new MySqlConnectionStringBuilder(AppConfig.Config["Data:ConnectionString"]);
-                var dbName = "`" + csb.Database.Replace('`', ' ') + "`";
-                csb.Database = "";
-                using (var connection = new MySqlConnection(csb.ConnectionString)){
-                    connection.Open();
-                    using (var cmd = connection.CreateCommand()){
-                        cmd.CommandText = $"CREATE DATABASE {dbName} CHARACTER SET utf8 COLLATE utf8_unicode_ci";
-                        cmd.ExecuteNonQuery();
-                    }
+            Console.Write("EnsureCreate non-existant database...");
+            Assert.False(_db.Database.EnsureDeleted());
+            Console.WriteLine(" OK");
+
+            Console.Write("Migrate non-existant database...");
+            _db.Database.Migrate();
+            Console.WriteLine(" OK");
+
+            _db.Database.EnsureDeleted();
+            Console.Write("Create blank database...");
+            var csb = new MySqlConnectionStringBuilder(AppConfig.Config["Data:ConnectionString"]);
+            var dbName = "`" + csb.Database.Replace('`', ' ') + "`";
+            csb.Database = "";
+            using (var connection = new MySqlConnection(csb.ConnectionString)){
+                connection.Open();
+                using (var cmd = connection.CreateCommand()){
+                    cmd.CommandText = $"CREATE DATABASE {dbName} CHARACTER SET utf8 COLLATE utf8_unicode_ci";
+                    cmd.ExecuteNonQuery();
                 }
-                Console.WriteLine("OK");
-
-                Console.Write("Migrate blank database...");
-                db.Database.Migrate();
-                Console.WriteLine(" OK");
             }
+            Console.WriteLine("OK");
+
+            Console.Write("Migrate blank database...");
+            _db.Database.Migrate();
+            Console.WriteLine(" OK");
 
             Console.WriteLine("All Tests Passed");
         }

--- a/test/EFCore.MySql.FunctionalTests/Commands/TestPerformanceCommand.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/TestPerformanceCommand.cs
@@ -61,6 +61,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
             async Task SleepMillisecond(AppDb db)
             {
                 await db.Database.ExecuteSqlCommandAsync("SELECT SLEEP(0.001)");
+                db.Database.CloseConnection();
                 Interlocked.Increment(ref sleepNum);
             }
 

--- a/test/EFCore.MySql.FunctionalTests/Commands/TestPerformanceCommand.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/TestPerformanceCommand.cs
@@ -7,12 +7,36 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Threading;
 using System.Threading.Tasks;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
 
-    public static class TestPerformanceCommand{
+    public class TestPerformanceCommand : ITestPerformanceCommand
+    {
 
-        public static void Run(int iterations, int concurrency, int ops)
+        private AppDb _db;
+
+        public TestPerformanceCommand(AppDb db)
+        {
+            _db = db;
+        }
+
+        private Lazy<ServiceProvider> _serviceProvider = new Lazy<ServiceProvider>(() => {
+            var serviceCollection = new ServiceCollection();
+                serviceCollection
+                    .AddLogging()
+                    .AddScoped<ITestPerformanceRunner, TestPerformanceRunner>();
+                Startup.ConfigureEntityFramework(serviceCollection);
+
+                var serviceProvider = serviceCollection.BuildServiceProvider();
+                serviceProvider
+                    .GetService<ILoggerFactory>()
+                    .AddConsole(AppConfig.Config.GetSection("Logging"));
+                return serviceProvider;
+        });
+
+        public void Run(int iterations, int concurrency, int ops)
         {
 
             var recordNum = 0;
@@ -40,17 +64,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
                 Interlocked.Increment(ref sleepNum);
             }
 
-            using (var db = new AppDb())
-            {
-                db.Database.ExecuteSqlCommand($"DELETE FROM `{db.Model.FindEntityType(typeof(Blog)).Relational().TableName}`");
-            }
+            _db.Database.ExecuteSqlCommand("DELETE FROM `" + _db.Model.FindEntityType(typeof(Blog)).Relational().TableName + "`");
 
             PerfTest(InsertOne, "Insert One", iterations, concurrency, ops).GetAwaiter().GetResult();
-            using (var db = new AppDb())
-            {
-                Console.WriteLine("Records Inserted: " + db.Blogs.Count());
-                Console.WriteLine();
-            }
+            Console.WriteLine("Records Inserted: " + _db.Blogs.Count());
+            Console.WriteLine();
 
             PerfTest(SelectOne, "Select One", iterations, concurrency, ops).GetAwaiter().GetResult();
             Console.WriteLine("Records Selected: " +selected.Count);
@@ -64,20 +82,28 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
             Console.WriteLine();
         }
 
-        public static async Task PerfTest(Func<AppDb, Task> test, string testName, int iterations, int concurrency, int ops)
+        public async Task PerfTest(Func<AppDb, Task> test, string testName, int iterations, int concurrency, int ops)
         {
             var timers = new List<TimeSpan>();
             for (var iteration = 0; iteration < iterations; iteration++)
             {
+                // run the timed tests
                 var tasks = new List<Task>();
                 var start = DateTime.UtcNow;
                 for (var connection = 0; connection < concurrency; connection++)
                 {
-                    tasks.Add(ConnectionTask(test, ops));
+                    var scope = _serviceProvider.Value.CreateScope();
+                    var testPerformanceRunner = scope.ServiceProvider.GetService<ITestPerformanceRunner>();
+                    async Task callable() {
+                        await testPerformanceRunner.ConnectionTask(test, ops);
+                        scope.Dispose();
+                    };
+                    tasks.Add(callable());
                 }
                 await Task.WhenAll(tasks);
                 timers.Add(DateTime.UtcNow - start);
             }
+            
             Console.WriteLine("Test:                     " + testName);
             Console.WriteLine("Iterations:               " + iterations);
             Console.WriteLine("Concurrency:              " + concurrency);
@@ -87,17 +113,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
                               + TimeSpan.FromTicks(timers.Sum(timer => timer.Ticks) / timers.Count) + ", "
                               + timers.Max());
             Console.WriteLine();
-        }
-
-        private static async Task ConnectionTask(Func<AppDb, Task> cb, int ops)
-        {
-            using (var db = new AppDb())
-            {
-                for (var op = 0; op < ops; op++)
-                {
-                    await cb(db);
-                }
-            }
         }
 
     }

--- a/test/EFCore.MySql.FunctionalTests/Commands/TestPerformanceRunner.cs
+++ b/test/EFCore.MySql.FunctionalTests/Commands/TestPerformanceRunner.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands{
+
+    public class TestPerformanceRunner : ITestPerformanceRunner
+    {
+
+        private AppDb _db;
+
+        public TestPerformanceRunner(AppDb db)
+        {
+            _db = db;
+        }
+
+        public async Task ConnectionTask(Func<AppDb, Task> cb, int ops)
+        {
+            for (var op = 0; op < ops; op++)
+            {
+                await cb(_db);
+            }
+        }
+
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/EFCore.MySql.FunctionalTests.csproj
+++ b/test/EFCore.MySql.FunctionalTests/EFCore.MySql.FunctionalTests.csproj
@@ -18,17 +18,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <!--app packages-->
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" />
   </ItemGroup>
 

--- a/test/EFCore.MySql.FunctionalTests/Program.cs
+++ b/test/EFCore.MySql.FunctionalTests/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Commands;
+using Microsoft.AspNetCore;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 {
@@ -12,12 +13,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         {
             if (args.Length == 0)
             {
-	            var host = new WebHostBuilder()
-                    .UseUrls("http://*:5000")
-                    .UseKestrel()
-                    .UseStartup<Startup>()
-                    .Build();
-                host.Run();
+	            BuildWebHost(args).Run();
             }
             else
             {
@@ -40,5 +36,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 Environment.Exit(commandRunner.Run(args));
             }
         }
+
+        public static IWebHost BuildWebHost(string[] args)
+        {
+            return WebHost.CreateDefaultBuilder(args)
+                .UseUrls("http://*:5000")
+                .UseStartup<Startup>()
+                .Build();
+        }
+
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Startup.cs
+++ b/test/EFCore.MySql.FunctionalTests/Startup.cs
@@ -42,7 +42,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 		        .AddDefaultTokenProviders();
         }
 
-        public void ConfigureEntityFramework(IServiceCollection services)
+        public static void ConfigureEntityFramework(IServiceCollection services)
         {
             Console.WriteLine($"Using Batch Size: {AppConfig.EfBatchSize}");
             if (AppConfig.EfSchema != null)

--- a/test/EFCore.MySql.FunctionalTests/Startup.cs
+++ b/test/EFCore.MySql.FunctionalTests/Startup.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
+using System.Data.Common;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 {
@@ -42,16 +43,20 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 		        .AddDefaultTokenProviders();
         }
 
-        public static void ConfigureEntityFramework(IServiceCollection services)
+        public static void ConfigureEntityFramework(IServiceCollection services, DbConnection connection = null)
         {
-            Console.WriteLine($"Using Batch Size: {AppConfig.EfBatchSize}");
-            if (AppConfig.EfSchema != null)
-                Console.WriteLine($"Using Schema: {AppConfig.EfSchema}");
-
-            services.AddDbContext<AppDb>(
-                options => options.UseMySql(AppConfig.Config["Data:ConnectionString"],
-                    mysqlOptions => mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize)),
-                ServiceLifetime.Scoped);
+            if (connection == null)
+            {
+                services.AddDbContextPool<AppDb>(
+                    options => options.UseMySql(AppConfig.Config["Data:ConnectionString"],
+                        mysqlOptions => mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize)));
+            }
+            else
+            {
+                services.AddDbContext<AppDb>(
+                    options => options.UseMySql(connection,
+                        mysqlOptions => mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize)));
+            }
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/EFCore.MySql.FunctionalTests/Tests/Connection/ConnectionTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Tests/Connection/ConnectionTest.cs
@@ -9,9 +9,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Connection
     {
         private static readonly MySqlConnection Connection = new MySqlConnection(AppConfig.Config["Data:ConnectionString"]);
 
-        private static AppDb NewDbContext(bool reuseConnection)
+        private static AppDbScope NewDbScope(bool reuseConnection)
         {
-            return reuseConnection ? new AppDb(Connection) : new AppDb();
+            return reuseConnection ? new AppDbScope(Connection) : new AppDbScope();
         }
 
         [Theory]
@@ -21,8 +21,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Connection
         {
             var title = "test";
             var blog = new Blog {Title = title};
-            using (var db = NewDbContext(reuseConnection))
+            using (var scope = NewDbScope(reuseConnection))
             {
+                var db = scope.AppDb;
                 db.Blogs.Add(blog);
                 await db.SaveChangesAsync();
             }
@@ -30,8 +31,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Connection
 
             // this will throw a DbUpdateConcurrencyException if UseAffectedRows=true
             var sameBlog = new Blog {Id = blog.Id, Title = title};
-            using (var db = NewDbContext(reuseConnection))
+            using (var scope = NewDbScope(reuseConnection))
             {
+                var db = scope.AppDb;
                 db.Blogs.Update(sameBlog);
                 await db.SaveChangesAsync();
             }

--- a/test/EFCore.MySql.FunctionalTests/Tests/Models/CrmTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Tests/Models/CrmTest.cs
@@ -11,8 +11,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 	{
 		public CrmFixture()
 		{
-			using (var db = new AppDb())
+			using (var scope = new AppDbScope())
 			{
+				var db = scope.AppDb;
 				var superAdmin = new CrmAdmin
 				{
 					Username = "test",
@@ -59,8 +60,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 		[Fact]
 		public async Task TestCrmSuperUserEagerLoading()
 		{
-			using (var db = new AppDb())
+			using (var scope = new AppDbScope())
 			{
+				var db = scope.AppDb;
 				var superUser = await db.CrmAdmins
 					.OrderByDescending(m => m.Id)
 					.Include(m => m.AdminMenus)
@@ -82,8 +84,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 		[Fact]
 		public async Task TestCrmSuperUserExplicitLoading()
 		{
-			using (var db = new AppDb())
+			using (var scope = new AppDbScope())
 			{
+				var db = scope.AppDb;
 				// load just the superUser
 				var superUser = await db.CrmAdmins.OrderByDescending(m => m.Id).FirstOrDefaultAsync();
 

--- a/test/EFCore.MySql.FunctionalTests/Tests/Models/DataTypesTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Tests/Models/DataTypesTest.cs
@@ -222,7 +222,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 	        var valueMemSync = NewValueMem();
 
 	        // save them to the database
-	        using (var db = new AppDb()){
+	        using (var scope = new AppDbScope())
+			{
+				var db = scope.AppDb;
 		        db.DataTypesSimple.Add(emptyMemAsync);
 		        db.DataTypesSimple.Add(valueMemAsync);
 		        await db.SaveChangesAsync();
@@ -233,8 +235,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 	        }
 
 	        // load them from the database and run tests
-	        using (var db = new AppDb())
-	        {
+	        using (var scope = new AppDbScope())
+			{
+				var db = scope.AppDb;
 		        // ReSharper disable once AccessToDisposedClosure
 	            async Task<DataTypesSimple> FromDbAsync(DataTypesSimple dt) => await db.DataTypesSimple.FirstOrDefaultAsync(m => m.Id == dt.Id);
 
@@ -346,7 +349,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 		    var valueMemSync = NewValueMem();
 
 		    // save them to the database
-		    using (var db = new AppDb()){
+		    using (var scope = new AppDbScope())
+			{
+				var db = scope.AppDb;
 			    db.DataTypesVariable.Add(emptyMemAsync);
 			    db.DataTypesVariable.Add(valueMemAsync);
 			    await db.SaveChangesAsync();
@@ -357,8 +362,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 		    }
 
 		    // load them from the database and run tests
-		    using (var db = new AppDb())
-		    {
+		    using (var scope = new AppDbScope())
+			{
+				var db = scope.AppDb;
 			    // ReSharper disable once AccessToDisposedClosure
 		        async Task<DataTypesVariable> FromDbAsync(DataTypesVariable dt) => await db.DataTypesVariable.FirstOrDefaultAsync(m => m.Id == dt.Id);
 

--- a/test/EFCore.MySql.FunctionalTests/Tests/Models/DiscriminatorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Tests/Models/DiscriminatorTest.cs
@@ -67,8 +67,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 				new PersonParent {Name = "Sharon", Occupation = "Receptionist at Tom's Rhinoplasty", OnPta = true, Family = famalies[4]},
 			};
 
-			using (var db = new AppDb())
+			using (var scope = new AppDbScope())
 			{
+				var db = scope.AppDb;
 				db.People.AddRange(teachers);
 				db.People.AddRange(students);
 				db.People.AddRange(parents);
@@ -91,8 +92,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 		[Fact(Skip="https://github.com/aspnet/EntityFramework/issues/9038")]
 		public async Task TestDiscriminator()
 		{
-			using (var db = new AppDb())
+			using (var scope = new AppDbScope())
 			{
+				var db = scope.AppDb;
 				var teachers = await db.People.OfType<PersonTeacher>()
 					.Where(m => m.Id >= _fixture.LowestTeacherId && m.Id <= _fixture.HighestTeacherId)
 					.OrderBy(m => m.Id)

--- a/test/EFCore.MySql.FunctionalTests/Tests/Models/ExpressionTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Tests/Models/ExpressionTest.cs
@@ -14,14 +14,15 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
     public class ExpressionTest : IDisposable
     {
 
-        private readonly AppDb _db;
+        private readonly AppDbScope _scope;
+        private AppDb _db => _scope.AppDb;
         private readonly DataTypesSimple _simple;
         private readonly DataTypesSimple _simple2;
         private readonly DataTypesVariable _variable;
 
         public ExpressionTest()
         {
-            _db = new AppDb();
+            _scope = new AppDbScope();
 
             // initialize simple data types
             _simple = new DataTypesSimple
@@ -58,7 +59,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
             }
             finally
             {
-                _db.Dispose();
+                _scope.Dispose();
             }
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Tests/Models/GeneratedTypesTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Tests/Models/GeneratedTypesTest.cs
@@ -21,8 +21,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 			const string zip = "99999";
 			var addressFormatted = string.Join(", ", address, city, state, zip);
 
-		    using (var db = new AppDb())
+		    using (var scope = new AppDbScope())
 			{
+				var db = scope.AppDb;
 			    void TestContact(GeneratedContact contact)
 			    {
 			        var csb = new MySqlConnectionStringBuilder(db.Database.GetDbConnection().ConnectionString);
@@ -66,8 +67,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Tests.Models
 		{
 			var gt = new GeneratedTime {Name = "test"};
 
-			using (var db = new AppDb())
+			using (var scope = new AppDbScope())
 			{
+				var db = scope.AppDb;
 				db.GeneratedTime.Add(gt);
 				await db.SaveChangesAsync();
 


### PR DESCRIPTION
- EF Core 2.0 uses DB Context Pooling
- Need to use Service Providers to take advantage of that
- Switch commands to use service providers