### PR TITLE
Resolved Insert/Update Parameter Jumping by 2 and Item with Same Key Error

### DIFF
--- a/src/EFCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
+++ b/src/EFCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
@@ -71,12 +71,12 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
       var parameterCount = 0;
       foreach (var columnModification in modificationCommand.ColumnModifications)
       {
-        if (columnModification.ParameterName != null)
+        if (columnModification.UseOriginalValueParameter)
         {
           parameterCount++;
         }
 
-        if (columnModification.OriginalParameterName != null)
+        if (columnModification.UseOriginalValueParameter)
         {
           parameterCount++;
         }

--- a/src/EFCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
+++ b/src/EFCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
@@ -68,21 +68,21 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
     private static int CountParameters(ModificationCommand modificationCommand)
     {
-      var parameterCount = 0;
-      foreach (var columnModification in modificationCommand.ColumnModifications)
-      {
-        if (columnModification.UseOriginalValueParameter)
+        var parameterCount = 0;
+        foreach (var columnModification in modificationCommand.ColumnModifications)
         {
-          parameterCount++;
+            if (columnModification.UseCurrentValueParameter)
+            {
+                parameterCount++;
+            }
+
+            if (columnModification.UseOriginalValueParameter)
+            {
+                parameterCount++;
+            }
         }
 
-        if (columnModification.UseOriginalValueParameter)
-        {
-          parameterCount++;
-        }
-      }
-
-      return parameterCount;
+        return parameterCount;
     }
 
     protected override void ResetCommandText()


### PR DESCRIPTION
Was getting this error on SaveChangesAsync in my program.

Exception thrown: 'System.ArgumentException' in System.Private.CoreLib.dll: 'An item with the same key has already been added. Key: p2058'

...I then downloaded your repository, built and debugged in my project and stopped on the exact line where the error was which was ExecuteAsync  in Src\EFCore.MySql\Update\Internal\MySqlBatchExecutor.cs, the line of code was:

await commandbatch.ExecuteAsync(connection, cancellationToken).ConfigureAwait(false);

I looked at the commandbatch.CachedCommantText and saw this, notice the first line starts with parameter values @p2058 which at the end of the CachedCommandText you'll see it again which is what caused the error. Also, notice the jumping by 2.

```
{Microsoft.EntityFrameworkCore.Update.Internal.MySqlModificationCommandBatch}
CachedCommandText [StringBuilder]: {INSERT INTO 'RepositoryItemMetaData' ('MetaDataId', 'RepositoryItemId', 'Value')
VALUES (@p2058, @p2060, @p2062);
SELECT 'Id' FROM 'RepositoryItemMetaData' WHERE 'Id' = LAST_INSERT_ID();
INSERT INTO 'RepositoryItemMetaData' ('MetaDataId', 'RepositoryItemId', 'Value')
VALUES (@p2, @p4, @p6);
SELECT 'Id' FROM 'RepositoryItemMetaData' WHERE 'Id' = LAST_INSERT_ID();
INSERT INTO 'RepositoryItemMetaData' ('MetaDataId', 'RepositoryItemId', 'Value')
VALUES (@p10, @p12, @p14);
```

....more records and then tail is this...

```
VALUES (@p2050, @p2052, @p2054);
SELECT 'Id' FROM 'RepositoryItemMetaData' WHERE 'Id' = LAST_INSERT_ID();
INSERT INTO 'RepositoryItemMetaData' ('MetaDataId', 'RepositoryItemId', 'Value')
VALUES (@p2058, @p2060, @p2062);
SELECT 'Id' FROM 'RepositoryItemMetaData' WHERE 'Id' = LAST_INSERT_ID();
INSERT INTO 'RepositoryItemMetaData' ('MetaDataId', 'RepositoryItemId', 'Value')
VALUES (@p2066, @p2068, @p2070);
SELECT 'Id' FROM 'RepositoryItemMetaData' WHERE 'Id' = LAST_INSERT_ID();
INSERT INTO 'RepositoryItemMetaData' ('MetaDataId', 'RepositoryItemId', 'Value')
VALUES (@p2074, @p2076, @p2078);
SELECT 'Id' FROM 'RepositoryItemMetaData' WHERE 'Id' = LAST_INSERT_ID();

```
I compared your Src\EFCore.MySql\Update\Internal\MySqlModificationCommandBatch.cs to the Entity Framework Core SQL Server Driver EntityFrameworkCore\src\EFCore.SqlServer\Update\Internal\SqlServerModificationCommandBatch.cs and found this difference in the CountParameters method in which they use UseCurrentValueParameter and UseOriginalValueParameter versus checking to see if the parameter is null.

With this change applied my results never have a first insert with a parameter higher than the rest and all the parameters skip by one.

Microsoft.EntityFrameworkCore.Update.Internal.MySqlModificationCommandBatch}

Example with fix:

```
 commandbatch
{Microsoft.EntityFrameworkCore.Update.Internal.MySqlModificationCommandBatch}
CachedCommandText [StringBuilder]: {INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p0, @p1, @p2);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p3, @p4, @p5);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p6, @p7, @p8);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p9, @p10, @p11);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p12, @p13, @p14);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p15, @p16, @p17);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p18, @p19, @p20);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p21, @p22, @p23);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p24, @p25, @p26);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p27, @p28, @p29);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p30, @p31, @p32);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p33, @p34, @p35);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p36, @p37, @p38);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p39, @p40, @p41);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p42, @p43, @p44);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p45, @p46, @p47);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p48, @p49, @p50);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p51, @p52, @p53);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p54, @p55, @p56);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p57, @p58, @p59);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p60, @p61, @p62);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p63, @p64, @p65);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p66, @p67, @p68);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p69, @p70, @p71);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p72, @p73, @p74);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p75, @p76, @p77);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p78, @p79, @p80);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p81, @p82, @p83);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p84, @p85, @p86);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p87, @p88, @p89);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p90, @p91, @p92);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p93, @p94, @p95);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p96, @p97, @p98);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p99, @p100, @p101);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p102, @p103, @p104);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p105, @p106, @p107);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p108, @p109, @p110);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p111, @p112, @p113);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p114, @p115, @p116);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p117, @p118, @p119);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p120, @p121, @p122);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p123, @p124, @p125);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p126, @p127, @p128);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p129, @p130, @p131);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p132, @p133, @p134);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p135, @p136, @p137);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p138, @p139, @p140);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p141, @p142, @p143);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p144, @p145, @p146);
SELECT `Id` FROM `RepositoryItemMetaData` WHERE `Id` = LAST_INSERT_ID();
INSERT INTO `RepositoryItemMetaData` (`MetaDataId`, `RepositoryItemId`, `Value`)
VALUES (@p147, @p148, @p149);
```

Let me know if this helps, this bug needs to be resolved. 

Thanks
-Chris


