### PR TITLE
Check the connection type

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -53,7 +53,15 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private async Task<IDbContextTransaction> BeginTransactionWithNoPreconditionsAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken=default(CancellationToken))
         {
-            var dbTransaction = await (DbConnection as MySqlConnection).BeginTransactionAsync(isolationLevel).ConfigureAwait(false);
+            MySqlTransaction dbTransaction = null;
+            if (DbConnection is MySqlConnection mySqlConnection)
+            {
+                dbTransaction = await mySqlConnection.BeginTransactionAsync(isolationLevel).ConfigureAwait(false);
+            }
+            else
+            {
+                dbTransaction = (MySqlTransaction)DbConnection.BeginTransaction(isolationLevel);
+            }            
 
             CurrentTransaction
                 = new MySqlRelationalTransaction(

--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalTransaction.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalTransaction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Threading;
@@ -46,7 +46,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
             try
             {
-                await (_dbTransaction as MySqlTransaction).CommitAsync(cancellationToken).ConfigureAwait(false);
+                if (_dbTransaction is MySqlTransaction)
+                {
+                    await (_dbTransaction as MySqlTransaction).CommitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    _dbTransaction.Commit();
+                }
 
                 _logger.TransactionCommitted(
                     _relationalConnection,
@@ -81,7 +88,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
             try
             {
-                await (_dbTransaction as MySqlTransaction).RollbackAsync(cancellationToken).ConfigureAwait(false);
+                if (_dbTransaction is MySqlTransaction)
+                {
+                    await (_dbTransaction as MySqlTransaction).RollbackAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    _dbTransaction.Rollback();
+                }
 
                 _logger.TransactionRolledBack(
                     _relationalConnection,


### PR DESCRIPTION
When use a WrapperConnection, a NullReferenceException will be thrown. So I think it is better to check if the Connection/Transaction is actually the MySqlConnection/MySqlTransaction.