### PR TITLE
Remove the type casting when connection is not MySqlConnection

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -53,14 +53,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private async Task<IDbContextTransaction> BeginTransactionWithNoPreconditionsAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken=default(CancellationToken))
         {
-            MySqlTransaction dbTransaction = null;
+            DbTransaction dbTransaction = null;
             if (DbConnection is MySqlConnection mySqlConnection)
             {
                 dbTransaction = await mySqlConnection.BeginTransactionAsync(isolationLevel).ConfigureAwait(false);
             }
             else
             {
-                dbTransaction = (MySqlTransaction)DbConnection.BeginTransaction(isolationLevel);
+                dbTransaction = DbConnection.BeginTransaction(isolationLevel);
             }            
 
             CurrentTransaction


### PR DESCRIPTION
In this PR [#395](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/395), I forgot to remove the type casting.