### PR TITLE
Port Update code to reflect SQL Server 2.0.1 Code

### DIFF
--- a/src/EFCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
+++ b/src/EFCore.MySql/Update/Internal/MySqlModificationCommandBatch.cs
@@ -5,158 +5,203 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
-// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Update.Internal
 {
-  using RelationalStrings = EntityFrameworkCore.Internal.RelationalStrings;
-
-  public class MySqlModificationCommandBatch : AffectedCountModificationCommandBatch
-  {
-
-    private const int DefaultNetworkPacketSizeBytes = 4096;
-    private const int MaxScriptLength = 65536 * DefaultNetworkPacketSizeBytes / 2;
-    private const int MaxParameterCount = 2100;
-    private const int MaxRowCount = 1000;
-    private int _parameterCount = 1; // Implicit parameter for the command text
-    private readonly int _maxBatchSize;
-    private readonly List<ModificationCommand> _bulkInsertCommands = new List<ModificationCommand>();
-    private int _commandsLeftToLengthCheck = 50;
-
-    public MySqlModificationCommandBatch(
-      [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
-      [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-      [NotNull] IUpdateSqlGenerator updateSqlGenerator,
-      [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
-      [CanBeNull] int? maxBatchSize)
-      : base(commandBuilderFactory, sqlGenerationHelper, updateSqlGenerator, valueBufferFactoryFactory)
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class MySqlModificationCommandBatch : AffectedCountModificationCommandBatch
     {
-      if (maxBatchSize.HasValue
-          && (maxBatchSize.Value <= 0))
-      {
-        throw new ArgumentOutOfRangeException(nameof(maxBatchSize), RelationalStrings.InvalidMaxBatchSize);
-      }
+        private const int DefaultNetworkPacketSizeBytes = 4096;
+        private const int MaxScriptLength = 65536 * DefaultNetworkPacketSizeBytes / 2;
+        private const int MaxParameterCount = 2100;
+        private const int MaxRowCount = 1000;
+        private int _parameterCount = 1; // Implicit parameter for the command text
+        private readonly int _maxBatchSize;
+        private readonly List<ModificationCommand> _bulkInsertCommands = new List<ModificationCommand>();
+        private int _commandsLeftToLengthCheck = 50;
 
-      _maxBatchSize = Math.Min(maxBatchSize ?? int.MaxValue, MaxRowCount);
-    }
-
-    protected new virtual IMySqlUpdateSqlGenerator UpdateSqlGenerator
-      => (IMySqlUpdateSqlGenerator) base.UpdateSqlGenerator;
-
-
-    protected override bool CanAddCommand(ModificationCommand modificationCommand)
-    {
-      if (_maxBatchSize <= ModificationCommands.Count)
-      {
-        return false;
-      }
-
-      var additionalParameterCount = CountParameters(modificationCommand);
-
-      if (_parameterCount + additionalParameterCount >= MaxParameterCount)
-      {
-        return false;
-      }
-
-      _parameterCount += additionalParameterCount;
-      return true;
-    }
-
-    private static int CountParameters(ModificationCommand modificationCommand)
-    {
-        var parameterCount = 0;
-        foreach (var columnModification in modificationCommand.ColumnModifications)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public MySqlModificationCommandBatch(
+            [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
+            [NotNull] ISqlGenerationHelper sqlGenerationHelper,
+            // ReSharper disable once SuggestBaseTypeForParameter
+            [NotNull] IMySqlUpdateSqlGenerator updateSqlGenerator,
+            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
+            int? maxBatchSize)
+            : base(
+                commandBuilderFactory,
+                sqlGenerationHelper,
+                updateSqlGenerator,
+                valueBufferFactoryFactory)
         {
-            if (columnModification.UseCurrentValueParameter)
+            if (maxBatchSize.HasValue
+                && maxBatchSize.Value <= 0)
             {
-                parameterCount++;
+                throw new ArgumentOutOfRangeException(nameof(maxBatchSize), RelationalStrings.InvalidMaxBatchSize);
             }
 
-            if (columnModification.UseOriginalValueParameter)
+            _maxBatchSize = Math.Min(maxBatchSize ?? int.MaxValue, MaxRowCount);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected new virtual IMySqlUpdateSqlGenerator UpdateSqlGenerator => (IMySqlUpdateSqlGenerator)base.UpdateSqlGenerator;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override bool CanAddCommand(ModificationCommand modificationCommand)
+        {
+            if (ModificationCommands.Count >= _maxBatchSize)
             {
-                parameterCount++;
+                return false;
+            }
+
+            var additionalParameterCount = CountParameters(modificationCommand);
+
+            if (_parameterCount + additionalParameterCount >= MaxParameterCount)
+            {
+                return false;
+            }
+
+            _parameterCount += additionalParameterCount;
+            return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override bool IsCommandTextValid()
+        {
+            if (--_commandsLeftToLengthCheck < 0)
+            {
+                var commandTextLength = GetCommandText().Length;
+                if (commandTextLength >= MaxScriptLength)
+                {
+                    return false;
+                }
+
+                var avarageCommandLength = commandTextLength / ModificationCommands.Count;
+                var expectedAdditionalCommandCapacity = (MaxScriptLength - commandTextLength) / avarageCommandLength;
+                _commandsLeftToLengthCheck = Math.Max(1, expectedAdditionalCommandCapacity / 4);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override int GetParameterCount()
+            => _parameterCount;
+
+        private static int CountParameters(ModificationCommand modificationCommand)
+        {
+            var parameterCount = 0;
+            foreach (var columnModification in modificationCommand.ColumnModifications)
+            {
+                if (columnModification.UseCurrentValueParameter)
+                {
+                    parameterCount++;
+                }
+
+                if (columnModification.UseOriginalValueParameter)
+                {
+                    parameterCount++;
+                }
+            }
+
+            return parameterCount;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void ResetCommandText()
+        {
+            base.ResetCommandText();
+            _bulkInsertCommands.Clear();
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override string GetCommandText()
+            => base.GetCommandText() + GetBulkInsertCommandText(ModificationCommands.Count);
+
+        private string GetBulkInsertCommandText(int lastIndex)
+        {
+            if (_bulkInsertCommands.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var stringBuilder = new StringBuilder();
+            var resultSetMapping = UpdateSqlGenerator.AppendBulkInsertOperation(stringBuilder, _bulkInsertCommands, lastIndex - _bulkInsertCommands.Count);
+            for (var i = lastIndex - _bulkInsertCommands.Count; i < lastIndex; i++)
+            {
+                CommandResultSet[i] = resultSetMapping;
+            }
+
+            if (resultSetMapping != ResultSetMapping.NoResultSet)
+            {
+                CommandResultSet[lastIndex - 1] = ResultSetMapping.LastInResultSet;
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void UpdateCachedCommandText(int commandPosition)
+        {
+            var newModificationCommand = ModificationCommands[commandPosition];
+
+            if (newModificationCommand.EntityState == EntityState.Added)
+            {
+                if (_bulkInsertCommands.Count > 0
+                    && !CanBeInsertedInSameStatement(_bulkInsertCommands[0], newModificationCommand))
+                {
+                    CachedCommandText.Append(GetBulkInsertCommandText(commandPosition));
+                    _bulkInsertCommands.Clear();
+                }
+                _bulkInsertCommands.Add(newModificationCommand);
+
+                LastCachedCommandIndex = commandPosition;
+            }
+            else
+            {
+                CachedCommandText.Append(GetBulkInsertCommandText(commandPosition));
+                _bulkInsertCommands.Clear();
+
+                base.UpdateCachedCommandText(commandPosition);
             }
         }
 
-        return parameterCount;
+        private static bool CanBeInsertedInSameStatement(ModificationCommand firstCommand, ModificationCommand secondCommand)
+            => string.Equals(firstCommand.TableName, secondCommand.TableName, StringComparison.Ordinal)
+               && string.Equals(firstCommand.Schema, secondCommand.Schema, StringComparison.Ordinal)
+               && firstCommand.ColumnModifications.Where(o => o.IsWrite).Select(o => o.ColumnName).SequenceEqual(
+                   secondCommand.ColumnModifications.Where(o => o.IsWrite).Select(o => o.ColumnName))
+               && firstCommand.ColumnModifications.Where(o => o.IsRead).Select(o => o.ColumnName).SequenceEqual(
+                   secondCommand.ColumnModifications.Where(o => o.IsRead).Select(o => o.ColumnName));
     }
-
-    protected override void ResetCommandText()
-    {
-      base.ResetCommandText();
-      _bulkInsertCommands.Clear();
-    }
-
-    protected override bool IsCommandTextValid()
-    {
-      if (--_commandsLeftToLengthCheck < 0)
-      {
-        var commandTextLength = GetCommandText().Length;
-        if (commandTextLength >= MaxScriptLength)
-        {
-          return false;
-        }
-
-        var avarageCommandLength = commandTextLength / ModificationCommands.Count;
-        var expectedAdditionalCommandCapacity = (MaxScriptLength - commandTextLength) / avarageCommandLength;
-        _commandsLeftToLengthCheck = Math.Max(1, expectedAdditionalCommandCapacity / 4);
-      }
-
-      return true;
-    }
-
-    protected override string GetCommandText()
-      => base.GetCommandText() + GetBulkInsertCommandText(ModificationCommands.Count);
-
-    private string GetBulkInsertCommandText(int lastIndex)
-    {
-      if (_bulkInsertCommands.Count == 0)
-      {
-        return string.Empty;
-      }
-
-      var stringBuilder = new StringBuilder();
-      var grouping = UpdateSqlGenerator.AppendBulkInsertOperation(stringBuilder, _bulkInsertCommands, lastIndex);
-      for (var i = lastIndex - _bulkInsertCommands.Count; i < lastIndex; i++)
-      {
-        CommandResultSet[i] = ResultSetMapping.NoResultSet;
-      }
-
-      if (grouping != ResultSetMapping.NoResultSet)
-      {
-        CommandResultSet[lastIndex - 1] = ResultSetMapping.LastInResultSet;
-      }
-
-      return stringBuilder.ToString();
-    }
-
-	  protected override void UpdateCachedCommandText(int commandPosition)
-	  {
-		  var newModificationCommand = ModificationCommands[commandPosition];
-
-		  if (newModificationCommand.EntityState == EntityState.Added)
-		  {
-			  if (_bulkInsertCommands.Count > 0)
-			  {
-				  CachedCommandText.Append(GetBulkInsertCommandText(commandPosition));
-				  _bulkInsertCommands.Clear();
-			  }
-			  _bulkInsertCommands.Add(newModificationCommand);
-
-			  LastCachedCommandIndex = commandPosition;
-		  }
-		  else
-		  {
-			  CachedCommandText.Append(GetBulkInsertCommandText(commandPosition));
-			  _bulkInsertCommands.Clear();
-
-			  base.UpdateCachedCommandText(commandPosition);
-		  }
-	  }
-
-  }
 }

--- a/src/EFCore.MySql/Utilities/StringBuilderExtensions.cs
+++ b/src/EFCore.MySql/Utilities/StringBuilderExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 
-// ReSharper disable once CheckNamespace
 namespace System.Text
 {
     internal static class StringBuilderExtensions
@@ -12,15 +11,70 @@ namespace System.Text
             this StringBuilder stringBuilder, IEnumerable<string> values, string separator = ", ")
             => stringBuilder.AppendJoin(values, (sb, value) => sb.Append(value), separator);
 
+        public static StringBuilder AppendJoin(
+            this StringBuilder stringBuilder, string separator, params string[] values)
+            => stringBuilder.AppendJoin(values, (sb, value) => sb.Append(value), separator);
+
         public static StringBuilder AppendJoin<T>(
-            this StringBuilder stringBuilder, IEnumerable<T> values, Action<StringBuilder, T> joinAction,
-            string separator)
+            this StringBuilder stringBuilder,
+            IEnumerable<T> values,
+            Action<StringBuilder, T> joinAction,
+            string separator = ", ")
         {
             var appended = false;
 
             foreach (var value in values)
             {
                 joinAction(stringBuilder, value);
+                stringBuilder.Append(separator);
+                appended = true;
+            }
+
+            if (appended)
+            {
+                stringBuilder.Length -= separator.Length;
+            }
+
+            return stringBuilder;
+        }
+
+        public static StringBuilder AppendJoin<T, TParam>(
+            this StringBuilder stringBuilder,
+            IEnumerable<T> values,
+            TParam param,
+            Action<StringBuilder, T, TParam> joinAction,
+            string separator = ", ")
+        {
+            var appended = false;
+
+            foreach (var value in values)
+            {
+                joinAction(stringBuilder, value, param);
+                stringBuilder.Append(separator);
+                appended = true;
+            }
+
+            if (appended)
+            {
+                stringBuilder.Length -= separator.Length;
+            }
+
+            return stringBuilder;
+        }
+
+        public static StringBuilder AppendJoin<T, TParam1, TParam2>(
+            this StringBuilder stringBuilder,
+            IEnumerable<T> values,
+            TParam1 param1,
+            TParam2 param2,
+            Action<StringBuilder, T, TParam1, TParam2> joinAction,
+            string separator = ", ")
+        {
+            var appended = false;
+
+            foreach (var value in values)
+            {
+                joinAction(stringBuilder, value, param1, param2);
                 stringBuilder.Append(separator);
                 appended = true;
             }


### PR DESCRIPTION
Comparing the source of our batch update code to SQL Server's shows that we have diverged a fair amount.  It's time to bring this code up-to-date so that things keep working as expected.

- Current [MySqlUpdateSqlGenerator](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/blob/91f3055931ca034caec943dc413e2d9962288b7d/src/EFCore.MySql/Update/Internal/MySqlUpdateSqlGenerator.cs)
- 2.0.1 WIP [SqlServerUpdateSqlGenerator](https://github.com/aspnet/EntityFrameworkCore/blob/patch/2.0.1/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs)

There is one part of the code that I don't understand that I'd like to address before this ends up merged.  I'll highlight it in a comment.