### PR TITLE
Added Connection Resilliency to Driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ script:
   - echo "Test legacy migrations" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && ./scripts/legacy.sh'
   - echo "Building migrations with EF_DATABASE=pomelo_test2" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_SCHEMA=pomelo_test2 && ./scripts/rebuild.sh'
   - echo "Test with EF_SCHEMA=pomelo_test2" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_SCHEMA=pomelo_test2 && dotnet test -c Release'
-
+  - echo "Test with EF_RETRY_ON_FAILURE=3" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_RETRY_ON_FAILURE=3 && dotnet test -c Release'
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ script:
   - echo "Test scaffolding" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && ./scripts/scaffold.sh; rc=$?; rm -rf Scaffold; exit $rc'
   - echo "Test with EF_BATCH_SIZE=1" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && dotnet test -c Release'
   - echo "Test with EF_BATCH_SIZE=10" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_BATCH_SIZE=10 && dotnet test -c Release'
+  - echo "Test with EF_RETRY_ON_FAILURE=3" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_RETRY_ON_FAILURE=3 && dotnet test -c Release'
   - echo "Test legacy migrations" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && ./scripts/legacy.sh'
   - echo "Building migrations with EF_DATABASE=pomelo_test2" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_SCHEMA=pomelo_test2 && ./scripts/rebuild.sh'
   - echo "Test with EF_SCHEMA=pomelo_test2" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_SCHEMA=pomelo_test2 && dotnet test -c Release'
-  - echo "Test with EF_RETRY_ON_FAILURE=3" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_RETRY_ON_FAILURE=3 && dotnet test -c Release'
 notifications:
   email: false

--- a/src/EFCore.MySql/EFCore.MySql.csproj
+++ b/src/EFCore.MySql/EFCore.MySql.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.0.1-Resilliency</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyName>Pomelo.EntityFrameworkCore.MySql</AssemblyName>
-    <PackageId>Pomelo.EntityFrameworkCore.MySql</PackageId>
+    <AssemblyName>XCell.EntityFrameworkCore.MySql</AssemblyName>
+    <PackageId>XCell.EntityFrameworkCore.MySql</PackageId>
     <PackageTags>Entity Framework Core;entity-framework-core;MySQL;EF;ORM;Data</PackageTags>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/19828814?v=3</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/xcellsoft/Pomelo.EntityFrameworkCore.MySql</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/xcellsoft/Pomelo.EntityFrameworkCore.MySql/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql</RepositoryUrl>
+    <RepositoryUrl>git://github.com/xcellsoft/Pomelo.EntityFrameworkCore.MySql</RepositoryUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
   </PropertyGroup>

--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IBatchExecutor, MySqlBatchExecutor>()
                 .TryAdd<IRelationalDatabaseCreator, MySqlDatabaseCreator>()
                 .TryAdd<IHistoryRepository, MySqlHistoryRepository>()
+                .TryAdd<IExecutionStrategyFactory, MySqlExecutionStrategyFactory>()
                 .TryAdd<IMemberTranslator, MySqlCompositeMemberTranslator>()
                 .TryAdd<ICompositeMethodCallTranslator, MySqlCompositeMethodCallTranslator>()
                 .TryAdd<IQuerySqlGeneratorFactory, MySqlQuerySqlGeneratorFactory>()

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
-
+using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -13,5 +15,28 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             : base(optionsBuilder)
         {
         }
+        /// <summary>
+        ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder EnableRetryOnFailure()
+            => ExecutionStrategy(c => new MySqlRetryingExecutionStrategy(c));
+
+        /// <summary>
+        ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
+            => ExecutionStrategy(c => new MySqlRetryingExecutionStrategy(c, maxRetryCount));
+
+        /// <summary>
+        ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        /// </summary>
+        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
+        /// <param name="maxRetryDelay"> The maximum delay between retries. </param>
+        /// <param name="errorNumbersToAdd"> Additional error codes that should be considered transient. </param>
+        public virtual MySqlDbContextOptionsBuilder EnableRetryOnFailure(
+            int maxRetryCount,
+            TimeSpan maxRetryDelay,
+            [NotNull] ICollection<int> errorNumbersToAdd)
+            => ExecutionStrategy(c => new MySqlRetryingExecutionStrategy(c, maxRetryCount, maxRetryDelay, errorNumbersToAdd));
     }
 }

--- a/src/EFCore.MySql/Internal/MySqlExecutionStrategy.cs
+++ b/src/EFCore.MySql/Internal/MySqlExecutionStrategy.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    public class MySqlExecutionStrategy : IExecutionStrategy
+    {
+        private ExecutionStrategyDependencies Dependencies { get; }
+
+        public MySqlExecutionStrategy(ExecutionStrategyDependencies dependencies)
+        {
+            Dependencies = dependencies;
+        }
+
+        public virtual bool RetriesOnFailure => false;
+
+        public virtual TResult Execute<TState, TResult>(
+            TState state,
+            Func<DbContext, TState, TResult> operation,
+            Func<DbContext, TState, ExecutionResult<TResult>> verifySucceeded)
+        {
+            try
+            {
+                return operation(Dependencies.CurrentDbContext.Context, state);
+            }
+            catch (Exception ex)
+            {
+                if (ExecutionStrategy.CallOnWrappedException(ex, MySqlTransientExceptionDetector.ShouldRetryOn))
+                {
+                    throw new InvalidOperationException("An exception has been raised that is likely due to a transient failure.", ex);
+                }
+
+                throw;
+            }
+        }
+
+        public virtual async Task<TResult> ExecuteAsync<TState, TResult>(
+            TState state,
+            Func<DbContext, TState, CancellationToken, Task<TResult>> operation,
+            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>> verifySucceeded,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await operation(Dependencies.CurrentDbContext.Context, state, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                if (ExecutionStrategy.CallOnWrappedException(ex, MySqlTransientExceptionDetector.ShouldRetryOn))
+                {
+                    throw new InvalidOperationException("An exception has been raised that is likely due to a transient failure.", ex);
+                }
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/EFCore.MySql/Internal/MySqlExecutionStrategyFactory.cs
+++ b/src/EFCore.MySql/Internal/MySqlExecutionStrategyFactory.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    public class MySqlExecutionStrategyFactory : RelationalExecutionStrategyFactory
+    {
+        public MySqlExecutionStrategyFactory(
+            ExecutionStrategyDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        protected override IExecutionStrategy CreateDefaultStrategy(ExecutionStrategyDependencies dependencies)
+            => new MySqlExecutionStrategy(dependencies);
+    }
+}

--- a/src/EFCore.MySql/Internal/MySqlRetryNoDependendiciesExecutionStrategy.cs
+++ b/src/EFCore.MySql/Internal/MySqlRetryNoDependendiciesExecutionStrategy.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.EntityFrameworkCore;
+
+namespace EFCore.MySql.Internal
+{
+    public class MySqlRetryNoDependendiciesExecutionStrategy
+    {
+        private MySqlRetryingExecutionStrategy _mySqlRetryingExecutionStrategy { get; }
+
+        private ICollection<int> _additionalErrorNumbers { get; set; }
+
+        private int _maxRetryCount { get; set; }
+
+        private TimeSpan _maxRetryDelay { get; set; }
+
+        /// <summary>
+        /// Configure for only 1 attempt.
+        /// </summary>        
+        public MySqlRetryNoDependendiciesExecutionStrategy()
+        {
+            _maxRetryCount = 1;
+            _maxRetryDelay = TimeSpan.FromMilliseconds(0);
+        }
+
+        public MySqlRetryNoDependendiciesExecutionStrategy(MySqlRetryingExecutionStrategy mySqlRetryingExecutionStrategy)
+        {
+            _mySqlRetryingExecutionStrategy = mySqlRetryingExecutionStrategy;
+            _additionalErrorNumbers = mySqlRetryingExecutionStrategy.AdditionalErrorNumbers;
+            _maxRetryCount = Convert.ToInt32(GetProtectedProperty(mySqlRetryingExecutionStrategy, "MaxRetryCount"));
+            _maxRetryDelay = (TimeSpan)GetProtectedProperty(mySqlRetryingExecutionStrategy, "MaxRetryDelay");
+        }
+
+        /// <summary>
+        /// Get property value from a protected class field
+        /// </summary>
+        /// <param name="fromObject"></param>
+        /// <param name="property"></param>
+        /// <returns></returns>
+        private object GetProtectedProperty(Object fromObject, string property)
+        {
+
+            Type type = fromObject.GetType();
+            System.Reflection.PropertyInfo propertyInfo = type.GetProperty(property,
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.GetProperty);
+
+            return propertyInfo.GetValue(fromObject);
+        }
+
+        /// <summary>
+        /// Execute the passed action and follow the retry logic defined in the MySqlRetryingExecutionStrategy class.
+        /// </summary>
+        /// <param name="action">code to execute</param>
+        /// <param name="mySqlRetryingExecutionStrategy">execution strategy missing the ExecutionStrategyDependancies</param>
+        public void Execute(Action action)
+        {
+            if (_maxRetryCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(_maxRetryCount));
+            }
+
+            var tryCount = _maxRetryCount;
+
+            while (true)
+            {
+                try
+                {
+                    action();
+                    break; // success!
+                }
+                catch (Exception exception)
+                {
+                    if (--tryCount == 0)
+                        throw;
+
+                    if (!_mySqlRetryingExecutionStrategy.ShouldRetryOnPublic(exception))
+                    {
+                        throw;
+                    }
+
+                    Thread.Sleep(_maxRetryDelay);
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore.MySql/Internal/MySqlTransientExceptionDetector.cs
+++ b/src/EFCore.MySql/Internal/MySqlTransientExceptionDetector.cs
@@ -1,0 +1,18 @@
+using MySql.Data.MySqlClient;
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    /// <summary>
+    ///     Detects the exceptions caused by PostgreSQL or network transient failures.
+    /// </summary>
+    public class MySqlTransientExceptionDetector
+    {
+        public static bool ShouldRetryOn(Exception ex)
+            => ((ex as MySqlException)?.Number > 2000 && (ex as MySqlException)?.Number <= 2027)
+                || ((ex as MySqlException)?.Number > 2047 && (ex as MySqlException)?.Number <= 2050)
+                || (ex as MySqlException)?.Number == 0
+                || ex is TimeoutException;
+    }
+}

--- a/src/EFCore.MySql/Internal/MySqlTransientExceptionDetector.cs
+++ b/src/EFCore.MySql/Internal/MySqlTransientExceptionDetector.cs
@@ -10,8 +10,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     public class MySqlTransientExceptionDetector
     {
         public static bool ShouldRetryOn(Exception ex)
-            => ((ex as MySqlException)?.Number > 2000 && (ex as MySqlException)?.Number <= 2027)
-                || ((ex as MySqlException)?.Number > 2047 && (ex as MySqlException)?.Number <= 2050)
+            => ((ex as MySqlException)?.Number >= 2000 && (ex as MySqlException)?.Number <= 2027)
+                || ((ex as MySqlException)?.Number >= 2047 && (ex as MySqlException)?.Number <= 2050)
                 || (ex as MySqlException)?.Number == 0
                 || ex is TimeoutException;
     }

--- a/src/EFCore.MySql/MySqlRetryingExecutionStrategy.cs
+++ b/src/EFCore.MySql/MySqlRetryingExecutionStrategy.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using MySql.Data.MySqlClient;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class MySqlRetryingExecutionStrategy : ExecutionStrategy
+    {
+        public readonly ICollection<int> AdditionalErrorNumbers;
+
+        /// <summary>
+        ///     Creates a new instance of <see cref="MySqlRetryingExecutionStrategy" />.
+        /// </summary>
+        /// <param name="context"> The context on which the operations will be invoked. </param>
+        /// <remarks>
+        ///     The default retry limit is 6, which means that the total amount of time spent before failing is about a minute.
+        /// </remarks>
+        public MySqlRetryingExecutionStrategy(
+            DbContext context)
+            : this(context, DefaultMaxRetryCount)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a new instance of <see cref="MySqlRetryingExecutionStrategy" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing service dependencies. </param>
+        public MySqlRetryingExecutionStrategy(
+            ExecutionStrategyDependencies dependencies)
+            : this(dependencies, DefaultMaxRetryCount)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a new instance of <see cref="MySqlRetryingExecutionStrategy" />.
+        /// </summary>
+        /// <param name="context"> The context on which the operations will be invoked. </param>
+        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
+        public MySqlRetryingExecutionStrategy(
+            DbContext context,
+            int maxRetryCount)
+            : this(context, maxRetryCount, DefaultMaxDelay, errorNumbersToAdd: null)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a new instance of <see cref="MySqlRetryingExecutionStrategy" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing service dependencies. </param>
+        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
+        public MySqlRetryingExecutionStrategy(
+            ExecutionStrategyDependencies dependencies,
+            int maxRetryCount)
+            : this(dependencies, maxRetryCount, DefaultMaxDelay, errorNumbersToAdd: null)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a new instance of <see cref="MySqlRetryingExecutionStrategy" />.
+        /// </summary>
+        /// <param name="context"> The context on which the operations will be invoked. </param>
+        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
+        /// <param name="maxRetryDelay"> The maximum delay between retries. </param>
+        /// <param name="errorNumbersToAdd"> Additional SQL error numbers that should be considered transient. </param>
+        public MySqlRetryingExecutionStrategy(
+            DbContext context,
+            int maxRetryCount,
+            TimeSpan maxRetryDelay,
+             ICollection<int> errorNumbersToAdd)
+            : base(
+                context,
+                maxRetryCount,
+                maxRetryDelay)
+        {
+            AdditionalErrorNumbers = errorNumbersToAdd;
+        }
+
+        /// <summary>
+        ///     Creates a new instance of <see cref="MySqlRetryingExecutionStrategy" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing service dependencies. </param>
+        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
+        /// <param name="maxRetryDelay"> The maximum delay between retries. </param>
+        /// <param name="errorNumbersToAdd"> Additional SQL error numbers that should be considered transient. </param>
+        public MySqlRetryingExecutionStrategy(
+            ExecutionStrategyDependencies dependencies,
+            int maxRetryCount,
+            TimeSpan maxRetryDelay,
+             ICollection<int> errorNumbersToAdd)
+            : base(dependencies, maxRetryCount, maxRetryDelay)
+        {
+            AdditionalErrorNumbers = errorNumbersToAdd;
+        }
+
+        /// <summary>
+        /// Public version of ShouldRetryOn since we cannot change the existing one as it's an override.
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        public bool ShouldRetryOnPublic(Exception exception)
+        {
+            return ShouldRetryOn(exception);
+        }
+
+        protected override bool ShouldRetryOn(Exception exception)
+        {
+            if (AdditionalErrorNumbers != null)
+            {
+                if (exception is MySqlException sqlException)
+                {
+                    if(AdditionalErrorNumbers.Contains(((MySqlException)exception).Number)) {
+                        return true;
+                    }
+                }
+            }
+
+            return MySqlTransientExceptionDetector.ShouldRetryOn(exception);
+        }
+
+        protected override TimeSpan? GetNextDelay(Exception lastException)
+        {
+            var baseDelay = base.GetNextDelay(lastException);
+            if (baseDelay == null)
+            {
+                return null;
+            }
+
+            return baseDelay;
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/AppConfig.cs
+++ b/test/EFCore.MySql.FunctionalTests/AppConfig.cs
@@ -11,6 +11,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 	    public static readonly int EfBatchSize = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EF_BATCH_SIZE"))
 		    ? Convert.ToInt32(Environment.GetEnvironmentVariable("EF_BATCH_SIZE")) : 1;
 
+        public static readonly int EfRetryOnFailure = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EF_RETRY_ON_FAILURE"))
+		    ? Convert.ToInt32(Environment.GetEnvironmentVariable("EF_RETRY_ON_FAILURE")) : 0;
+
         public static readonly string EfSchema = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EF_SCHEMA"))
             ? Environment.GetEnvironmentVariable("EF_SCHEMA") : null;
 

--- a/test/EFCore.MySql.FunctionalTests/Models/GeneratedTypes.cs
+++ b/test/EFCore.MySql.FunctionalTests/Models/GeneratedTypes.cs
@@ -21,25 +21,15 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Models
 
 				entity.Property(m => m.Name)
 					.ValueGeneratedOnAddOrUpdate()
-					.HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
-						`Names` ->> ""$[0]""
-					) VIRTUAL");
+					.HasColumnType("VARCHAR(63) GENERATED ALWAYS AS (`Names` ->> \"$[0]\") VIRTUAL");
 
 				entity.Property(m => m.Email)
 					.ValueGeneratedOnAddOrUpdate()
-					.HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
-						`ContactInfo` ->> ""$.Email""
-					) VIRTUAL");
+					.HasColumnType("VARCHAR(63) GENERATED ALWAYS AS (`ContactInfo` ->> \"$.Email\") VIRTUAL");
 
 				entity.Property(m => m.Address)
 					.ValueGeneratedOnAddOrUpdate()
-					.HasColumnType(@"VARCHAR(63) GENERATED ALWAYS AS (
-						CONCAT_WS(', ',
-							`ContactInfo` ->> ""$.Address"",
-                            `ContactInfo` ->> ""$.City"",
-                            `ContactInfo` ->> ""$.State"",
-                            `ContactInfo` ->> ""$.Zip""
-						)) STORED");
+					.HasColumnType("VARCHAR(63) GENERATED ALWAYS AS (CONCAT_WS(', ',`ContactInfo` ->> \"$.Address\",`ContactInfo` ->> \"$.City\",`ContactInfo` ->> \"$.State\",`ContactInfo` ->> \"$.Zip\")) STORED");
 			});
 		}
 	}

--- a/test/EFCore.MySql.FunctionalTests/Startup.cs
+++ b/test/EFCore.MySql.FunctionalTests/Startup.cs
@@ -47,15 +47,40 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         {
             if (connection == null)
             {
-                services.AddDbContextPool<AppDb>(
-                    options => options.UseMySql(AppConfig.Config["Data:ConnectionString"],
-                        mysqlOptions => mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize)));
+                if (AppConfig.EfRetryOnFailure > 0)
+                {
+                    services.AddDbContextPool<AppDb>(
+                        options => options.UseMySql(AppConfig.Config["Data:ConnectionString"],
+                            mysqlOptions => 
+                            {
+                                mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize);
+                                mysqlOptions.EnableRetryOnFailure(AppConfig.EfRetryOnFailure, TimeSpan.FromSeconds(5), null);
+                            }));
+                }
+                else
+                {
+                    services.AddDbContextPool<AppDb>(
+                        options => options.UseMySql(AppConfig.Config["Data:ConnectionString"],
+                            mysqlOptions => mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize)));
+                }
             }
             else
             {
-                services.AddDbContext<AppDb>(
-                    options => options.UseMySql(connection,
-                        mysqlOptions => mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize)));
+                if (AppConfig.EfRetryOnFailure > 0)
+                {
+                    services.AddDbContext<AppDb>(
+                        options => options.UseMySql(connection,
+                            mysqlOptions => {
+                                mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize);
+                                mysqlOptions.EnableRetryOnFailure(AppConfig.EfRetryOnFailure, TimeSpan.FromSeconds(5), null);
+                            }));
+                }
+                else
+                {
+                    services.AddDbContext<AppDb>(
+                        options => options.UseMySql(connection,
+                            mysqlOptions => mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize)));
+                }
             }
         }
 


### PR DESCRIPTION
Connection resiliency has been added to the driver using the pattern that the EF Core SQL Server driver utilizes.

MySql Errors 2000-2027, 2047-2050 and 0 are automatically handled. If have others you would like to add or remove this can be done in the MySqlTransientExceptionDetector.cs. I tried to get all that would deal with transient connection/server issues.

**High level overview of the changes:**

**[New] EFCore.MySql\MySqlRetryingExecutionStrategy.cs**
This was copied straight over and name changed, the ShouldRetryOn was modified to deal with the MySqlException type.

**[Modified] EFCore.MySql\Extensions\MySqlServiceCollectionExtensions.cs**
Added the MySqlExecutionStrategyFactory to dependency injection.

**[Modified] EFCore.MySql\Infrastructure\MySqlDbContextOptionsBuilder.cs**

Added EnableRetryOnFailure option similar to SqlServer so we can do 3 varients when building the configuration options:

1. Specify number of retries, how long of delay between retries and additional errors to trap.

```
var addErrors = new Collection<int>();
addErrors.Add(1);
addErrors.Add(2);
options.UseMySql(tenantConnectionString.ConnectionString,
   o => o.EnableRetryOnFailure(2, TimeSpan.FromSeconds(5),addErrors));
```

2. Specify only number of retries.

```
options.UseMySql(tenantConnectionString.ConnectionString,
   o => o.EnableRetryOnFailure(2));
```

3. Default to system defined 6 retries.

```
options.UseMySql(tenantConnectionString.ConnectionString,
   o => o.EnableRetryOnFailure());
```

**[New] EFCore.MySql\Internal\MySqlExecutionStrategy.cs**
Straight copy with name change only

**[New ] EFCore.MySql\Internal\MySqlExecutionStrategyFactory.cs**
Straight copy with name change only

**[Modified] EFCore.MySql\Internal\MySqlOptions.cs**
Had to incorporate some special handling so that the connection operation called from this class could also have resilience as these direct calls to the database did not exist in the sql server one and are outside of the EF Core default executionstrategy. I see some other connect.Open() in this file which may need to be wrapped in the future.

**[New] EFCore.MySql\Internal\MySqlRetryNoDependendiciesExecutionStrategy.cs**
This is a special class to deal with the connection resiliency in the MySqlOptions.cs class without having access to ExecutionStrategyDependency.

**[New] EFCore.MySql\Internal\MySqlTransientExceptionDetector.cs**
New class copied from Sql Server implementation and configured to retry errors 2000-2027, 2047-2050 and 0.

**[Modified] EFCore.MySql\Storage\Internal\MySqlConnectionSettings.cs**
Added connection resiliency as this class falls outside of standard EF Core execution strategy.


