### PR TITLE
Added exponential backoff based on EF Core ExecutionStrategy code.

### DIFF
--- a/src/EFCore.MySql/Internal/MySqlRetryNoDependendiciesExecutionStrategy.cs
+++ b/src/EFCore.MySql/Internal/MySqlRetryNoDependendiciesExecutionStrategy.cs
@@ -36,7 +36,7 @@ namespace EFCore.MySql.Internal
         /// <summary>
         ///     A pseudo-random number generator that can be used to vary the delay between retries.
         /// </summary>
-        protected virtual Random Random { get; } = new Random();
+        private static Random Random { get; } = new Random();
 
 
         /// <summary>

--- a/src/EFCore.MySql/Internal/MySqlRetryNoDependendiciesExecutionStrategy.cs
+++ b/src/EFCore.MySql/Internal/MySqlRetryNoDependendiciesExecutionStrategy.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EFCore.MySql.Internal
 {
@@ -14,6 +17,27 @@ namespace EFCore.MySql.Internal
         private int _maxRetryCount { get; set; }
 
         private TimeSpan _maxRetryDelay { get; set; }
+
+        /// <summary>
+        ///     The default maximum random factor, must not be lesser than 1.
+        /// </summary>
+        private const double DefaultRandomFactor = 1.1;
+
+        /// <summary>
+        ///     The default base for the exponential function used to compute the delay between retries, must be positive.
+        /// </summary>
+        private const double DefaultExponentialBase = 2;
+
+        /// <summary>
+        ///     The default coefficient for the exponential function used to compute the delay between retries, must be nonnegative.
+        /// </summary>
+        private static readonly TimeSpan _defaultCoefficient = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        ///     A pseudo-random number generator that can be used to vary the delay between retries.
+        /// </summary>
+        protected virtual Random Random { get; } = new Random();
+
 
         /// <summary>
         /// Configure for only 1 attempt.
@@ -62,7 +86,7 @@ namespace EFCore.MySql.Internal
                 throw new ArgumentOutOfRangeException(nameof(_maxRetryCount));
             }
 
-            var tryCount = _maxRetryCount;
+            var tryCount = 0;
 
             while (true)
             {
@@ -73,17 +97,54 @@ namespace EFCore.MySql.Internal
                 }
                 catch (Exception exception)
                 {
-                    if (--tryCount == 0)
-                        throw;
-
                     if (!_mySqlRetryingExecutionStrategy.ShouldRetryOnPublic(exception))
                     {
                         throw;
                     }
 
-                    Thread.Sleep(_maxRetryDelay);
+                    var delay = GetNextDelay(tryCount);
+
+                    if (delay == null)
+                    {
+                        throw new RetryLimitExceededException(CoreStrings.RetryLimitExceeded(_maxRetryCount, GetType().Name), exception);
+                    }
+                    else
+                    {
+                        using (var waitEvent = new ManualResetEventSlim(false))
+                        {
+                            waitEvent.WaitHandle.WaitOne(delay.Value);
+                        }     
+                    }
+                    
+                    tryCount++;
                 }
             }
         }
+
+        /// <summary>
+        ///     Determines whether the operation should be retried and the delay before the next attempt.
+        /// </summary>
+        /// <param name="currentRetryCount">Current retry count</param>
+        /// <returns>
+        ///     Returns the delay indicating how long to wait for before the next execution attempt if the operation should be retried;
+        ///     <c>null</c> otherwise
+        /// </returns>
+
+        protected virtual TimeSpan? GetNextDelay(int currentRetryCount)
+        {
+            if (currentRetryCount < _maxRetryCount)
+            {
+                var delta = (Math.Pow(DefaultExponentialBase, currentRetryCount) - 1.0)
+                            * (1.0 + Random.NextDouble() * (DefaultRandomFactor - 1.0));
+
+                var delay = Math.Min(
+                    _defaultCoefficient.TotalMilliseconds * delta,
+                    _maxRetryDelay.TotalMilliseconds);
+
+                return TimeSpan.FromMilliseconds(delay);
+            }
+
+            return null;
+        }        
     }
 }


### PR DESCRIPTION
Exponential Backoff is now added to the MySqlRetryNoDependendiciesExecutionStrategy class that supports the MySqlConnectionSettings.GetSettings method.

The code for this was copied from the ExecutionStrategy class in EF Core.

Take note that the maxRetryDelay in EF Core is not the cumulative maximum amount of time for retry operations as a whole. It is actually the maximum amount of delay time between attempts and as the exponential backoff grows it can hit this limit and then that would be the maximum amount of time between retries.

For Example, I have maxRetryCount=15 and maxRetryDelay=5 seconds, here is how that plays out:

Attempt: 1, fail then  0 second delay (the formula always does an immediate attempt with no delay)
Attempt: 2, fail then  1.025 second delay
Attempt: 3, fail then  3.29 second delay
Attempt: 4, fail then  5 second delay
Attempt: 5, fail then  5 second delay
Attempt: 6, fail then  5 second delay
Attempt: 7, fail then  5 second delay

...and so on and so forth, once the formula reaches the maxRetryDelay it uses that exclusively moving forward.

Thanks!
-Chris
