### PR TITLE
Fixed #393 Uses the model for column def for rename 

### DIFF
--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -288,6 +288,14 @@ END;" + EOL +
                 Sql);
         }
 
+        public override void RenameColumnOperation_works()
+        {
+            base.RenameColumnOperation_works();
+
+            Assert.Equal("ALTER TABLE `People` CHANGE `Name` `NameNew` varchar (255);" + EOL,
+                Sql);
+        }
+
         public virtual void CreateDatabaseOperation()
         {
             Generate(new MySqlCreateDatabaseOperation { Name = "Northwind" });

--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -309,7 +309,23 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests.Migrations
                     Table = "People"
                 });
         }
-        
+
+        [Fact]
+        public virtual void RenameColumnOperation_works()
+        {
+            Generate(
+                modelBuilder => modelBuilder.Entity("People")
+                    .Property<string>("Name")
+                    .HasColumnName("NameNew")
+                    .HasColumnType("varchar (255)"),
+                new RenameColumnOperation
+                {
+                    Name = "Name",
+                    NewName = "NameNew",
+                    Table = "People"
+                });
+        }
+
         [Fact]
         public virtual void CreateTableOperation()
         {


### PR DESCRIPTION
Used model information for the change column name migration operation
Fixes #393 

I have a project at [Example Repo](https://github.com/johnnynibbles/PomeloMySqlError) that demonstrates it.
