### PR TITLE
Change test runner to 'dotnet xunit'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ before_install:
 
 script:
   - docker exec -it dotnet sh -c 'cd /dotnet && dotnet restore'
-  - docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.Tests && dotnet test -c Release'
+  - docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.Tests && dotnet xunit -c Release'
   - echo "Building migrations" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && cp config.json.example config.json && sed -i "s/127.0.0.1/mysql/g" config.json && ./scripts/rebuild.sh'
   - echo "Test applying migrations" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && dotnet run -c Release testMigrate'
   - echo "Test scaffolding" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && ./scripts/scaffold.sh; rc=$?; rm -rf Scaffold; exit $rc'
-  - echo "Test with EF_BATCH_SIZE=1" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && dotnet test -c Release'
-  - echo "Test with EF_BATCH_SIZE=10" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_BATCH_SIZE=10 && dotnet test -c Release'
-  - echo "Test with EF_RETRY_ON_FAILURE=3" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_RETRY_ON_FAILURE=3 && dotnet test -c Release'
+  - echo "Test with EF_BATCH_SIZE=1" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && dotnet xunit -c Release'
+  - echo "Test with EF_BATCH_SIZE=10" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_BATCH_SIZE=10 && dotnet xunit -c Release'
+  - echo "Test with EF_RETRY_ON_FAILURE=3" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_RETRY_ON_FAILURE=3 && dotnet xunit -c Release'
   - echo "Test legacy migrations" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && ./scripts/legacy.sh'
   - echo "Building migrations with EF_DATABASE=pomelo_test2" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_SCHEMA=pomelo_test2 && ./scripts/rebuild.sh'
-  - echo "Test with EF_SCHEMA=pomelo_test2" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_SCHEMA=pomelo_test2 && dotnet test -c Release'
+  - echo "Test with EF_SCHEMA=pomelo_test2" && docker exec -it dotnet sh -c 'cd /dotnet/test/EFCore.MySql.FunctionalTests && export EF_SCHEMA=pomelo_test2 && dotnet xunit -c Release'
 notifications:
   email: false

--- a/test/EFCore.MySql.FunctionalTests/scripts/legacy.sh
+++ b/test/EFCore.MySql.FunctionalTests/scripts/legacy.sh
@@ -15,5 +15,5 @@ do
     done
     dotnet ef migrations add current
     dotnet ef database update
-    dotnet test
+    dotnet xunit
 done

--- a/test/EFCore.MySql.Tests/EFCore.MySql.Tests.csproj
+++ b/test/EFCore.MySql.Tests/EFCore.MySql.Tests.csproj
@@ -16,9 +16,8 @@
   <ItemGroup>
     <!--testing packages-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!--app packages-->
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.1" />
@@ -26,6 +25,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorMySql55Test.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorMySql55Test.cs
@@ -77,7 +77,7 @@ CREATE TABLE `People` (
             return optionsBuilder.Options;
         }
 
-
+        [Fact]
         public override void RenameIndexOperation_works()
         {
             base.RenameIndexOperation_works();

--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -126,6 +126,7 @@ namespace EFCore.MySql.Tests.Migrations
                 Sql);
         }
 
+        [Fact]
         public override void AddColumnOperation_without_column_type()
         {
             base.AddColumnOperation_without_column_type();
@@ -135,6 +136,7 @@ namespace EFCore.MySql.Tests.Migrations
                 Sql);
         }
 
+        [Fact]
         public override void AddColumnOperation_with_maxLength()
         {
             base.AddColumnOperation_with_maxLength();
@@ -144,6 +146,7 @@ namespace EFCore.MySql.Tests.Migrations
                 Sql);
         }
 
+        [Fact]
         public override void AddForeignKeyOperation_with_name()
         {
             base.AddForeignKeyOperation_with_name();
@@ -153,6 +156,7 @@ namespace EFCore.MySql.Tests.Migrations
                 Sql);
         }
 
+        [Fact]
         public override void AddForeignKeyOperation_without_name()
         {
             base.AddForeignKeyOperation_without_name();
@@ -162,6 +166,7 @@ namespace EFCore.MySql.Tests.Migrations
                 Sql);
         }
 
+        [Fact]
         public override void AddPrimaryKeyOperation_with_name()
         {
             base.AddPrimaryKeyOperation_with_name();
@@ -171,6 +176,7 @@ namespace EFCore.MySql.Tests.Migrations
                 Sql);
         }
 
+        [Fact]
         public override void AddPrimaryKeyOperation_without_name()
         {
             base.AddPrimaryKeyOperation_without_name();
@@ -224,6 +230,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void AddUniqueConstraintOperation_with_name()
         {
             base.AddUniqueConstraintOperation_with_name();
@@ -233,6 +240,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void AddUniqueConstraintOperation_without_name()
         {
             base.AddUniqueConstraintOperation_without_name();
@@ -242,6 +250,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void CreateIndexOperation_unique()
         {
             base.CreateIndexOperation_unique();
@@ -251,6 +260,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void CreateIndexOperation_fulltext()
         {
             base.CreateIndexOperation_fulltext();
@@ -260,6 +270,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void CreateIndexOperation_spatial()
         {
             base.CreateIndexOperation_spatial();
@@ -269,6 +280,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void CreateIndexOperation_nonunique()
         {
             base.CreateIndexOperation_nonunique();
@@ -278,6 +290,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void RenameIndexOperation_works()
         {
             base.RenameIndexOperation_works();
@@ -286,15 +299,17 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public virtual void CreateDatabaseOperation()
         {
             Generate(new MySqlCreateDatabaseOperation { Name = "Northwind" });
 
             Assert.Equal(
-                @"CREATE DATABASE  `Northwind`;" + EOL,
+                @"CREATE DATABASE `Northwind`;" + EOL,
                 Sql);
         }
 
+        [Fact]
         public override void CreateTableOperation()
         {
             base.CreateTableOperation();
@@ -311,6 +326,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void CreateTableUlongAi()
         {
             base.CreateTableUlongAi();
@@ -323,6 +339,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void DropColumnOperation()
         {
             base.DropColumnOperation();
@@ -332,6 +349,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void DropForeignKeyOperation()
         {
             base.DropForeignKeyOperation();
@@ -341,6 +359,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void DropPrimaryKeyOperation()
         {
             base.DropPrimaryKeyOperation();
@@ -390,6 +409,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void DropTableOperation()
         {
             base.DropTableOperation();
@@ -399,6 +419,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void DropUniqueConstraintOperation()
         {
             base.DropUniqueConstraintOperation();
@@ -408,6 +429,7 @@ END;" + EOL +
                 Sql);
         }
 
+        [Fact]
         public override void SqlOperation()
         {
             base.SqlOperation();
@@ -419,6 +441,7 @@ END;" + EOL +
 
         #region AlterColumn
 
+        [Fact]
         public override void AlterColumnOperation()
         {
             base.AlterColumnOperation();
@@ -428,6 +451,7 @@ END;" + EOL +
             Sql, false, true, true);
         }
 
+        [Fact]
         public override void AlterColumnOperation_without_column_type()
         {
             base.AlterColumnOperation_without_column_type();


### PR DESCRIPTION
The `dotnet xunit` command runs tests faster than `dotnet test`, and provides some other XUnit specific options if needed.

```
time dotnet xunit
real	0m8.332s
user	0m9.615s
sys	0m1.350s

time dotnet test
real	0m16.165s
user	0m18.395s
sys	0m1.949s
```