### PR TITLE
Move server version to MySqlDbContextOptionsBuilder

### DIFF
--- a/src/EFCore.MySql/EFCore.MySql.csproj
+++ b/src/EFCore.MySql/EFCore.MySql.csproj
@@ -3,6 +3,7 @@
     <VersionPrefix>2.1.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>7.2</LangVersion>
     <AssemblyName>Pomelo.EntityFrameworkCore.MySql</AssemblyName>
     <PackageId>Pomelo.EntityFrameworkCore.MySql</PackageId>
     <PackageTags>Entity Framework Core;entity-framework-core;MySQL;EF;ORM;Data</PackageTags>

--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -10,6 +10,7 @@ namespace EFCore.MySql.Infrastructure.Internal
     public interface IMySqlOptions : ISingletonOptions
     {
         MySqlConnectionSettings ConnectionSettings { get; }
+        ServerVersion ServerVersion { get; }
 
         string GetCreateTable(ISqlGenerationHelper sqlGenerationHelper, string schema, string table);
     }

--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System.Text;
+using EFCore.MySql.Storage.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -10,23 +12,90 @@ namespace EFCore.MySql.Infrastructure.Internal
 {
     public sealed class MySqlOptionsExtension : RelationalOptionsExtension
     {
+        private long? _serviceProviderHash;
+        private string _logFragment;
+
         public MySqlOptionsExtension()
         {
         }
 
-        public MySqlOptionsExtension([NotNull] RelationalOptionsExtension copyFrom)
+        public MySqlOptionsExtension([NotNull] MySqlOptionsExtension copyFrom)
             : base(copyFrom)
         {
+            ServerVersion = copyFrom.ServerVersion;
         }
 
         protected override RelationalOptionsExtension Clone()
             => new MySqlOptionsExtension(this);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ServerVersion ServerVersion { get; private set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public MySqlOptionsExtension WithServerVersion(ServerVersion serverVersion)
+        {
+            var clone = (MySqlOptionsExtension)Clone();
+
+            clone.ServerVersion = serverVersion;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override long GetServiceProviderHashCode()
+        {
+            if (_serviceProviderHash == null)
+            {
+                _serviceProviderHash = (base.GetServiceProviderHashCode() * 397) ^ (ServerVersion?.GetHashCode() ?? 0L);
+            }
+
+            return _serviceProviderHash.Value;
+        }
 
         public override bool ApplyServices(IServiceCollection services)
         {
             Check.NotNull(services, nameof(services));
             services.AddEntityFrameworkMySql();
             return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override string LogFragment
+        {
+            get
+            {
+                if (_logFragment == null)
+                {
+                    var builder = new StringBuilder();
+
+                    builder.Append(base.LogFragment);
+
+                    if (ServerVersion != null)
+                    {
+                        builder.Append("ServerVersion ")
+                            .Append(ServerVersion.Version)
+                            .Append(" ")
+                            .Append(ServerVersion.Type)
+                            .Append(" ");
+                    }
+
+                    _logFragment = builder.ToString();
+                }
+
+                return _logFragment;
+            }
         }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using EFCore.MySql.Infrastructure;
 using EFCore.MySql.Infrastructure.Internal;
+using EFCore.MySql.Storage.Internal;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -15,6 +18,19 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             : base(optionsBuilder)
         {
         }
+
+        /// <summary>
+        ///     Configures the target server version and type.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder ServerVersion(Version version, ServerType type)
+        => WithOption(e => e.WithServerVersion(new ServerVersion(version, type)));
+
+        /// <summary>
+        ///     Configures the target server version and type.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder ServerVersion(string serverVersion)
+            => WithOption(e => e.WithServerVersion(new ServerVersion(serverVersion)));
+
         /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
         /// </summary>

--- a/src/EFCore.MySql/Infrastructure/ServerType.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+namespace EFCore.MySql.Infrastructure
+{
+    public enum ServerType
+    {
+        MySql,
+        MariaDb
+    }
+}

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (operation.NewName != null)
             {
-                if (_options.ConnectionSettings.ServerVersion.SupportsRenameIndex)
+                if (_options.ServerVersion.SupportsRenameIndex)
                 {
                     builder.Append("ALTER TABLE ")
                         .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
@@ -445,7 +445,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         autoIncrement = true;
                         break;
                     case "datetime":
-                        if (!_options.ConnectionSettings.ServerVersion.SupportsDateTime6)
+                        if (!_options.ServerVersion.SupportsDateTime6)
                             throw new InvalidOperationException(
                                 $"Error in {table}.{name}: DATETIME does not support values generated " +
                                 "on Add or Update in MySql <= 5.5, try explicitly setting the column type to TIMESTAMP");
@@ -462,7 +462,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 switch (matchType)
                 {
                     case "datetime":
-                        if (!_options.ConnectionSettings.ServerVersion.SupportsDateTime6)
+                        if (!_options.ServerVersion.SupportsDateTime6)
                         {
                             throw new InvalidOperationException($"Error in {table}.{name}: DATETIME does not support values generated " +
                                 "on Add or Update in MySql <= 5.5, try explicitly setting the column type to TIMESTAMP");

--- a/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Concurrent;
-using System.Data;
 using System.Data.Common;
 using MySql.Data.MySqlClient;
 
@@ -11,74 +8,20 @@ namespace EFCore.MySql.Storage.Internal
 {
     public class MySqlConnectionSettings
     {
-        private static readonly ConcurrentDictionary<string, MySqlConnectionSettings> Settings
-            = new ConcurrentDictionary<string, MySqlConnectionSettings>();
-
-        private static MySqlConnectionStringBuilder _settingsCsb(MySqlConnectionStringBuilder csb)
-        {
-            return new MySqlConnectionStringBuilder
-            {
-                Server = csb.Server,
-                Port = csb.Port,
-                OldGuids = csb.OldGuids,
-                TreatTinyAsBoolean = csb.TreatTinyAsBoolean,
-            };
-        }
-
         public static MySqlConnectionSettings GetSettings(string connectionString)
-        {
-            var csb = new MySqlConnectionStringBuilder(connectionString);
-            var settingsCsb = _settingsCsb(csb);
-            return Settings.GetOrAdd(settingsCsb.ConnectionString, key =>
-            {
-                csb.Database = "";
-                csb.Pooling = false;
-                ServerVersion version;
-                using (var schemalessConnection = new MySqlConnection(csb.ConnectionString))
-                {
-                    schemalessConnection.Open();
-                    version = new ServerVersion(schemalessConnection.ServerVersion);
-                }
-                return new MySqlConnectionSettings(settingsCsb, version);
-            });
-        }
+            => new MySqlConnectionSettings(connectionString);
 
         public static MySqlConnectionSettings GetSettings(DbConnection connection)
-        {
-            var csb = new MySqlConnectionStringBuilder(connection.ConnectionString);
-            var settingsCsb = _settingsCsb(csb);
-            return Settings.GetOrAdd(settingsCsb.ConnectionString, key =>
-            {
-                ServerVersion version;
-                if (connection.State == ConnectionState.Closed)
-                {
-                    csb.Database = "";
-                    csb.Pooling = false;
-                    using (var schemalessConnection = new MySqlConnection(csb.ConnectionString))
-                    {
-                        schemalessConnection.Open();
-                        version = new ServerVersion(schemalessConnection.ServerVersion);
-                    }
-                }
-                else
-                {
-                    version = new ServerVersion(connection.ServerVersion);
-                }
+            => new MySqlConnectionSettings(connection.ConnectionString);
 
-                return new MySqlConnectionSettings(settingsCsb, version);
-            });
-        }
-
-        internal MySqlConnectionSettings(MySqlConnectionStringBuilder settingsCsb, ServerVersion serverVersion)
+        internal MySqlConnectionSettings(string connectionString)
         {
-            // Settings from the connection string
-            OldGuids = settingsCsb.OldGuids;
-            TreatTinyAsBoolean = settingsCsb.TreatTinyAsBoolean;
-            ServerVersion = serverVersion;
+            var csb = new MySqlConnectionStringBuilder(connectionString);
+            OldGuids = csb.OldGuids;
+            TreatTinyAsBoolean = csb.TreatTinyAsBoolean;
         }
 
         public readonly bool OldGuids;
         public readonly bool TreatTinyAsBoolean;
-        public readonly ServerVersion ServerVersion;
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlSmartTypeMapper.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlSmartTypeMapper.cs
@@ -64,7 +64,7 @@ namespace EFCore.MySql.Storage.Internal
             }
 
             // SupportsDateTime6
-            if (!_options.ConnectionSettings.ServerVersion.SupportsDateTime6)
+            if (!_options.ServerVersion.SupportsDateTime6)
             {
                 if (mapping.StoreType == "datetime(6)" && mapping.ClrType == typeof(DateTime))
                 {

--- a/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text.RegularExpressions;
+using EFCore.MySql.Infrastructure;
 
 namespace EFCore.MySql.Storage.Internal
 {
@@ -36,6 +37,12 @@ namespace EFCore.MySql.Storage.Internal
             }
         }
 
+        public ServerVersion(Version version, ServerType type)
+        {
+            Version = version;
+            Type = type;
+        }
+
         public readonly ServerType Type;
 
         public readonly Version Version;
@@ -55,11 +62,16 @@ namespace EFCore.MySql.Storage.Internal
                 return false;
             }
         }
-    }
+        public override bool Equals(object obj)
+            => !(obj is null)
+               && obj is ServerVersion version
+               && Equals(version);
 
-    public enum ServerType
-    {
-        MySql,
-        MariaDb
+        private bool Equals(ServerVersion other)
+            => Version.Equals(other.Version)
+               && Type == other.Type;
+
+        public override int GetHashCode()
+            => (Version.GetHashCode() * 397) ^ Type.GetHashCode();
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/EFCore.MySql.FunctionalTests.csproj
+++ b/test/EFCore.MySql.FunctionalTests/EFCore.MySql.FunctionalTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>7.2</LangVersion>
     <AssemblyName>EFCore.MySql.FunctionalTests</AssemblyName>
     <StartupObject>EFCore.MySql.FunctionalTests.Program</StartupObject>
     <OutputType>Exe</OutputType>

--- a/test/EFCore.MySql.FunctionalTests/Startup.cs
+++ b/test/EFCore.MySql.FunctionalTests/Startup.cs
@@ -51,6 +51,7 @@ namespace EFCore.MySql.FunctionalTests
                         mysqlOptions =>
                         {
                             mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize);
+                            mysqlOptions.ServerVersion(AppConfig.Config["Data:ServerVersion"]);
                             if (AppConfig.EfRetryOnFailure > 0)
                                 mysqlOptions.EnableRetryOnFailure(AppConfig.EfRetryOnFailure, TimeSpan.FromSeconds(5), null);
                         }
@@ -63,6 +64,7 @@ namespace EFCore.MySql.FunctionalTests
                         mysqlOptions =>
                         {
                             mysqlOptions.MaxBatchSize(AppConfig.EfBatchSize);
+                            mysqlOptions.ServerVersion(AppConfig.Config["Data:ServerVersion"]);
                             if (AppConfig.EfRetryOnFailure > 0)
                                 mysqlOptions.EnableRetryOnFailure(AppConfig.EfRetryOnFailure, TimeSpan.FromSeconds(5), null);
                         }

--- a/test/EFCore.MySql.FunctionalTests/config.json.example
+++ b/test/EFCore.MySql.FunctionalTests/config.json.example
@@ -1,5 +1,6 @@
 ﻿{
   "Data": {
-    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;database=pomelo_test;"
+    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;database=pomelo_test;",
+    "ServerVersion": "8.0.0-mysql"
   }
 }

--- a/test/EFCore.MySql.Tests/EFCore.MySql.Tests.csproj
+++ b/test/EFCore.MySql.Tests/EFCore.MySql.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>7.2</LangVersion>
     <AssemblyName>EFCore.MySql.Tests</AssemblyName>
     <PackageId>EFCore.MySql.Tests</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorMySql55Test.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorMySql55Test.cs
@@ -26,7 +26,9 @@ namespace EFCore.MySql.Tests.Migrations
             {
                 var mySqlOptions = new Mock<IMySqlOptions>();
                 mySqlOptions.SetupGet(opts => opts.ConnectionSettings).Returns(
-                    new MySqlConnectionSettings(new MySqlConnectionStringBuilder(), new ServerVersion("5.5.2")));
+                    new MySqlConnectionSettings(new MySqlConnectionStringBuilder().ToString()));
+                mySqlOptions
+                    .SetupGet(fn => fn.ServerVersion).Returns(new ServerVersion("5.5.2"));
                 mySqlOptions
                     .Setup(fn =>
                         fn.GetCreateTable(It.IsAny<ISqlGenerationHelper>(), It.IsAny<string>(), It.IsAny<string>()))

--- a/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -52,7 +52,10 @@ namespace EFCore.MySql.Tests.Migrations
 
                 var mySqlOptions = new Mock<IMySqlOptions>();
                 mySqlOptions.SetupGet(opts => opts.ConnectionSettings).Returns(
-                    new MySqlConnectionSettings(new MySqlConnectionStringBuilder(), new ServerVersion("5.7.18")));
+                    new MySqlConnectionSettings(new MySqlConnectionStringBuilder().ToString()));
+
+                mySqlOptions
+                    .SetupGet(fn => fn.ServerVersion).Returns(new ServerVersion("5.7.18"));
 
                 return new MySqlMigrationsSqlGenerator(
                     migrationsSqlGeneratorDependencies,

--- a/test/EFCore.MySql.Tests/Migrations/ServerVersionTest.cs
+++ b/test/EFCore.MySql.Tests/Migrations/ServerVersionTest.cs
@@ -1,4 +1,5 @@
 using System;
+using EFCore.MySql.Infrastructure;
 using EFCore.MySql.Storage.Internal;
 using Xunit;
 

--- a/test/EFCore.MySql.UpstreamFunctionalTests/EFCore.MySql.UpstreamFunctionalTests.csproj
+++ b/test/EFCore.MySql.UpstreamFunctionalTests/EFCore.MySql.UpstreamFunctionalTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EFCore.MySql.UpstreamFunctionalTests/TestUtilities/MySqlTestStore.cs
+++ b/test/EFCore.MySql.UpstreamFunctionalTests/TestUtilities/MySqlTestStore.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.IO;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.Configuration;
 using MySql.Data.MySqlClient;
@@ -46,8 +47,13 @@ namespace EFCore.MySql.UpstreamFunctionalTests.TestUtilities
 
         public override DbContextOptionsBuilder AddProviderOptions(DbContextOptionsBuilder builder)
             => _useConnectionString
-                ? builder.UseMySql(ConnectionString, b => b.CommandTimeout(CommandTimeout))
-                : builder.UseMySql(Connection, b => b.CommandTimeout(CommandTimeout));
+                ? builder.UseMySql(ConnectionString, AddOptions)
+                : builder.UseMySql(Connection, AddOptions);
+
+        private static void AddOptions(MySqlDbContextOptionsBuilder builder)
+        {
+            builder.CommandTimeout(CommandTimeout).ServerVersion(LazyConfig.Value["Data:ServerVersion"]);
+        }
 
         public MySqlTestStore InitializeMySql(IServiceProvider serviceProvider, Func<DbContext> createContext, Action<DbContext> seed)
             => (MySqlTestStore)Initialize(serviceProvider, createContext, seed);

--- a/test/EFCore.MySql.UpstreamFunctionalTests/config.json.example
+++ b/test/EFCore.MySql.UpstreamFunctionalTests/config.json.example
@@ -1,5 +1,6 @@
 ﻿{
   "Data": {
-    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;"
+    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;",
+    "ServerVersion": "8.0.0-mysql"
   }
 }


### PR DESCRIPTION
This allows type mapping and model building without a database connection and prevents the credentials being stripped out from the connection string too early during migrations.

Fixes #272 


