### PR TITLE
Introduce custom type mapping for old guid literals.

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlByteArrayTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlByteArrayTypeMapping.cs
@@ -4,10 +4,9 @@
 using System;
 using System.Data;
 using System.Data.Common;
-using System.Globalization;
-using System.Text;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {
@@ -116,17 +115,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         /// <returns>
         ///     The generated string.
         /// </returns>
-        protected override string GenerateNonNullSqlLiteral(object value)
-        {
-            var builder = new StringBuilder();
-            builder.Append("0x");
-
-            foreach (var @byte in (byte[])value)
-            {
-                builder.Append(@byte.ToString("X2", CultureInfo.InvariantCulture));
-            }
-
-            return builder.ToString();
-        }
+        protected override string GenerateNonNullSqlLiteral(object value) => ByteArrayFormatter.ToHex((byte[])value);
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlOldGuidTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlOldGuidTypeMapping.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Pomelo.EntityFrameworkCore.MySql.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    internal sealed class MySqlOldGuidTypeMapping : GuidTypeMapping
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MySqlOldGuidTypeMapping" /> class.
+        /// </summary>
+        public MySqlOldGuidTypeMapping() : base("binary(16)", System.Data.DbType.Guid) { }
+
+        /// <summary>
+        ///     Generates the SQL representation of a literal value.
+        /// </summary>
+        /// <param name="value">The literal value.</param>
+        /// <returns>
+        ///     The generated string.
+        /// </returns>
+        protected sealed override string GenerateNonNullSqlLiteral([CanBeNull] object value) => ByteArrayFormatter.ToHex(((Guid)value).ToByteArray());
+    }
+}

--- a/src/EFCore.MySql/Storage/Internal/MySqlOldGuidTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlOldGuidTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -11,12 +12,19 @@ namespace Microsoft.EntityFrameworkCore.Storage
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    internal sealed class MySqlOldGuidTypeMapping : GuidTypeMapping
+    public class MySqlOldGuidTypeMapping : GuidTypeMapping
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="MySqlOldGuidTypeMapping" /> class.
         /// </summary>
         public MySqlOldGuidTypeMapping() : base("binary(16)", System.Data.DbType.Guid) { }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MySqlOldGuidTypeMapping" />
+        ///     class from a <see cref="RelationalTypeMappingParameters"/> instance.
+        /// </summary>
+        /// <param name="parmeters"></param>
+        protected MySqlOldGuidTypeMapping(RelationalTypeMappingParameters parameters) : base(parameters) { }
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.
@@ -25,6 +33,21 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns>
         ///     The generated string.
         /// </returns>
-        protected sealed override string GenerateNonNullSqlLiteral([CanBeNull] object value) => ByteArrayFormatter.ToHex(((Guid)value).ToByteArray());
+        protected sealed override string GenerateNonNullSqlLiteral([CanBeNull] object value)
+            => ByteArrayFormatter.ToHex(((Guid)value).ToByteArray());
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override RelationalTypeMapping Clone(string storeType, int? size)
+            => new MySqlOldGuidTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override CoreTypeMapping Clone(ValueConverter converter)
+            => new MySqlOldGuidTypeMapping(Parameters.WithComposedConverter(converter));
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -69,7 +69,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         // guid
 	    private readonly GuidTypeMapping _uniqueidentifier   = new GuidTypeMapping("char(36)", DbType.Guid);
-        private readonly GuidTypeMapping _oldGuid            = new GuidTypeMapping("binary(16)", DbType.Guid);
+        private readonly GuidTypeMapping _oldGuid            = new MySqlOldGuidTypeMapping();
 
         readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings;
         readonly Dictionary<string, RelationalTypeMapping> _unicodeStoreTypeMappings;

--- a/src/EFCore.MySql/Utilities/ByteArrayFormatter.cs
+++ b/src/EFCore.MySql/Utilities/ByteArrayFormatter.cs
@@ -1,0 +1,31 @@
+﻿using System.Text;
+using JetBrains.Annotations;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Utilities
+{
+    internal static class ByteArrayFormatter
+    {
+        private static readonly char[] _lookup = new char[16]
+        {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+        };
+
+        public static string ToHex([NotNull] byte[] b)
+        {
+            if (b.Length == 0)
+            {
+                return "X''";
+            }
+
+            var builder = new StringBuilder("0x", 2 + (b.Length * 2));
+            for (var i = 0; i < b.Length; i++)
+            {
+                var b1 = (byte)(b[i] >> 4);
+                var b2 = (byte)(b[i] & 0xF);
+                builder.Append(_lookup[b1]);
+                builder.Append(_lookup[b2]);
+            }
+            return builder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
The entity framework does not parameterize guids when they are put into a "IN" expression. They are generated as literals and put as a part of the SQL. This addresses issue #461 . Ultimately the fix is fairly straight forward: when using the old guid way, override the type mapping to provide an explicit implementation for the literal. I have run some preliminary tests:

Query looks like this:
``` c#
var records = await context.GuidsTest
    .Where(x => shouldExistListOfGuids.Contains(x.NotNullGuid))
    .ToListAsync();
```

schema is:

```
CREATE TABLE `GuidsTest` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `notNullGuid` binary(16) NOT NULL,
  `nullGuid` binary(16) DEFAULT NULL,
  PRIMARY KEY (`id`)
```

**Without** the fix, not oldguids:
```
      SELECT x.Id, x.NotNullGuid, x.NullGuid
      FROM GuidsTest AS x
      WHERE x.NotNullGuid IN ('01234567-1234-1234-1234-123456789012')
Record count: 1
```
Works as expcted. **With** the fix, not oldguids:
```
      SELECT x.Id, x.NotNullGuid, x.NullGuid
      FROM GuidsTest AS x
      WHERE x.NotNullGuid IN ('01234567-1234-1234-1234-123456789012')
Record count: 1
```
Works as expected. So this does not regress the non-oldguids case.

**Without** the fix, oldguids (This is the broken one):
```
      SELECT x.Id, x.NotNullGuid, x.NullGuid
      FROM GuidsTest AS x
      WHERE x.NotNullGuid IN ('01234567-1234-1234-1234-123456789012')
Record count: 0
```

And finally with the fix, old guids:
```
      SELECT x.Id, x.NotNullGuid, x.NullGuid
      FROM GuidsTest AS x
      WHERE x.NotNullGuid IN (0x67452301341234121234123456789012)
Record count: 1
```
Hooray! it works by doing a hex literal. For sanity sake, it also works with nullable guids:
```
      SELECT x.Id, x.NotNullGuid, x.NullGuid
      FROM GuidsTest AS x
      WHERE x.NullGuid IN (0x47382910291029101029102938475610)
Record count: 1
```

This fix also introduces a common binary formatter for the guids and the binary data type.

Select code:
``` c#
var first = await context.BinaryTest
                .Where(x => shouldExistListOfBinaryArrays.Contains(x.BinaryColumn)).ToListAsync();
```
Schema:
```
CREATE TABLE `BinaryTest` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `binarycolumn` varbinary(10) NOT NULL,
  PRIMARY KEY (`id`)
```

Here is it working when empty:
```
      SELECT x.Id, x.BinaryColumn
      FROM BinaryTest AS x
      WHERE x.BinaryColumn IN (X'')
Binary record count: 1
```

Note that '0x' would not be valid, so I used the X'' syntax. Binary generation with stuff in it:
```
      SELECT x.Id, x.BinaryColumn
      FROM BinaryTest AS x
      WHERE x.BinaryColumn IN (0xCAFEBABE)
Binary record count: 1
```