### PR TITLE
fix syntax for generated column. fixes #599

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -998,44 +998,54 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 }
             }
 
-            base.ColumnDefinition(
-                schema,
-                table,
-                name,
-                clrType,
-                type,
-                unicode,
-                maxLength,
-                fixedLength,
-                rowVersion,
-                nullable,
-                identity
-                    ? null
-                    : defaultValue,
-                defaultValueSql,
-                computedColumnSql,
-                annotatable,
-                model,
-                builder);
-
-            if (autoIncrement)
+            if (computedColumnSql == null)
             {
-                builder.Append(" AUTO_INCREMENT");
+                base.ColumnDefinition(
+                    schema,
+                    table,
+                    name,
+                    clrType,
+                    type,
+                    unicode,
+                    maxLength,
+                    fixedLength,
+                    rowVersion,
+                    nullable,
+                    identity
+                        ? null
+                        : defaultValue,
+                    defaultValueSql,
+                    computedColumnSql,
+                    annotatable,
+                    model,
+                    builder);
+
+                if (autoIncrement)
+                {
+                    builder.Append(" AUTO_INCREMENT");
+                }
+                else
+                {
+                    if (onUpdateSql != null)
+                    {
+                        builder
+                            .Append(" ON UPDATE ")
+                            .Append(onUpdateSql);
+                    }
+                }
             }
             else
             {
-                if (onUpdateSql != null)
+                builder
+                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(name))
+                    .Append(" ")
+                    .Append(type ?? GetColumnType(schema, table, name, clrType, unicode, maxLength, fixedLength, rowVersion, model));
+                builder
+                    .Append(" AS ")
+                    .Append($"({computedColumnSql})");
+                if (nullable)
                 {
-                    builder
-                        .Append(" ON UPDATE ")
-                        .Append(onUpdateSql);
-                }
-
-                if (computedColumnSql != null)
-                {
-                    builder
-                        .Append(" AS ")
-                        .Append(computedColumnSql);
+                    builder.Append(" NULL");
                 }
             }
         }

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
@@ -316,7 +316,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.AddColumnOperation_with_computed_column_SQL();
 
             Assert.Equal(
-                @"ALTER TABLE `People` ADD `Birthday` date NULL AS CURRENT_TIMESTAMP;" + EOL,
+                @"ALTER TABLE `People` ADD `Birthday` date AS (CURRENT_TIMESTAMP) NULL;" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
The spec test for the operation referenced in #599, `AddColumnOperation_with_computed_column_SQL`, contained the invalid MySQL syntax:
```
ALTER TABLE `People` ADD `Birthday` date NULL AS CURRENT_TIMESTAMP;
```
which should be
```
ALTER TABLE `People` ADD `Birthday` date AS (CURRENT_TIMESTAMP) NULL;
```
as both placing the nullability constraint after the value expression and the parentheses around the value expression are required. This statement still actually won't execute because CURRENT_TIMESTAMP is a nondeterministic function, which is [not allowed](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html) for generated columns in MySQL, but it is syntactically valid.

Unfortunately the placement of the nullability constraint here is different from ordinary column definitions, so we can't use MigrationsSqlGenerator.ColumnDefinition. I instead copied the relevant statement from there to get the type definition and so on.