### PR TITLE
Truncate foreign key and index names to 64 characters in old migrations.

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -375,6 +375,24 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         /// <summary>
+        ///     Builds commands for the given <see cref="CreateIndexOperation" /> by making calls on the given
+        ///     <see cref="MigrationCommandListBuilder" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
+        /// <param name="terminate"> Indicates whether or not to terminate the command after generating SQL for the operation. </param>
+        protected override void Generate(
+            CreateIndexOperation operation,
+            IModel model,
+            MigrationCommandListBuilder builder,
+            bool terminate)
+        {
+            operation.Name = Truncate(operation.Name, 64);
+            base.Generate(operation, model, builder, terminate);
+        }
+
+        /// <summary>
         ///     Builds commands for the given <see cref="EnsureSchemaOperation" />
         ///     by making calls on the given <see cref="MigrationCommandListBuilder" />.
         /// </summary>
@@ -1216,6 +1234,21 @@ END;".Replace("\r", string.Empty).Replace("\n", Environment.NewLine));
         }
 
         /// <summary>
+        ///     Generates a SQL fragment for a foreign key constraint of an <see cref="AddForeignKeyOperation" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to add the SQL fragment. </param>
+        protected override void ForeignKeyConstraint(
+            AddForeignKeyOperation operation,
+            IModel model,
+            MigrationCommandListBuilder builder)
+        {
+            operation.Name = Truncate(operation.Name, 64);
+            base.ForeignKeyConstraint(operation, model, builder);
+        }
+
+        /// <summary>
         ///     Generates a SQL fragment for traits of an index from a <see cref="CreateIndexOperation" />,
         ///     <see cref="AddPrimaryKeyOperation" />, or <see cref="AddUniqueConstraintOperation" />.
         /// </summary>
@@ -1351,5 +1384,16 @@ END;".Replace("\r", string.Empty).Replace("\n", Environment.NewLine));
 
         private string IntegerConstant(long value)
             => string.Format(CultureInfo.InvariantCulture, "{0}", value);
+
+        private static string Truncate(string source, int maxLength)
+        {
+            if (source == null
+                || source.Length <= maxLength)
+            {
+                return source;
+            }
+
+            return source.Substring(0, maxLength);
+        }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
@@ -502,6 +502,28 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 Sql);
         }
 
+        [Fact]
+        public virtual void AddForeignKeyOperation_with_long_name()
+        {
+            Generate(
+                new AddForeignKeyOperation
+                {
+                    Table = "People",
+                    Schema = "dbo",
+                    Name = "FK_ASuperLongForeignKeyNameThatIsDefinetelyNotGoingToFitInThe64CharactersLimit",
+                    Columns = new[] {"EmployerId1", "EmployerId2"},
+                    PrincipalTable = "Companies",
+                    PrincipalSchema = "hr",
+                    PrincipalColumns = new[] {"Id1", "Id2"},
+                    OnDelete = ReferentialAction.Cascade
+                });
+
+            Assert.Equal(
+                "ALTER TABLE `dbo`.`People` ADD CONSTRAINT `FK_ASuperLongForeignKeyNameThatIsDefinetelyNotGoingToFitInThe64C` FOREIGN KEY (`EmployerId1`, `EmployerId2`) REFERENCES `hr`.`Companies` (`Id1`, `Id2`) ON DELETE CASCADE;" +
+                EOL,
+                Sql);
+        }
+
         public override void AddForeignKeyOperation_without_name()
         {
             base.AddForeignKeyOperation_without_name();
@@ -661,6 +683,23 @@ DROP PROCEDURE IF EXISTS POMELO_AFTER_ADD_PRIMARY_KEY;".Replace("\r", string.Emp
 
             Assert.Equal(
                 "CREATE INDEX `IX_People_Name` ON `People` (`Name`);" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_with_long_name()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_ASuperLongForeignKeyNameThatIsDefinetelyNotGoingToFitInThe64CharactersLimit",
+                    Table = "People",
+                    Columns = new[] {"Name"},
+                    IsUnique = false
+                });
+
+            Assert.Equal(
+                "CREATE INDEX `IX_ASuperLongForeignKeyNameThatIsDefinetelyNotGoingToFitInThe64C` ON `People` (`Name`);" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
Fixes #590

