### PR TITLE
Bump MySqlConnector version to 0.42.2

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,7 @@
     <MicrosoftEntityFrameworkCoreRelationalVersion>2.1.0</MicrosoftEntityFrameworkCoreRelationalVersion>
     <MicrosoftEntityFrameworkCoreDesignVersion>2.1.0</MicrosoftEntityFrameworkCoreDesignVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>2.1.0</MicrosoftExtensionsLoggingConsoleVersion>
-    <MySqlConnectorVersion>0.40.4</MySqlConnectorVersion>
+    <MySqlConnectorVersion>0.42.1</MySqlConnectorVersion>
     <PomeloJsonObjectVersion>1.1.1</PomeloJsonObjectVersion>
     <!-- Shared Test Dependencies -->
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,7 @@
     <MicrosoftEntityFrameworkCoreRelationalVersion>2.1.0</MicrosoftEntityFrameworkCoreRelationalVersion>
     <MicrosoftEntityFrameworkCoreDesignVersion>2.1.0</MicrosoftEntityFrameworkCoreDesignVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>2.1.0</MicrosoftExtensionsLoggingConsoleVersion>
-    <MySqlConnectorVersion>0.42.1</MySqlConnectorVersion>
+    <MySqlConnectorVersion>0.42.2</MySqlConnectorVersion>
     <PomeloJsonObjectVersion>1.1.1</PomeloJsonObjectVersion>
     <!-- Shared Test Dependencies -->
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>


### PR DESCRIPTION
MySqlConnector updates [rather frequently](https://github.com/mysql-net/MySqlConnector/releases) and has added a number of bug fixes and performance improvements in the past month since 0.40.4 came out. Notably with version 0.40.4, attempting to query any spatial column resulted in a `NotImplementedException`, but [as of 0.42.1](https://github.com/mysql-net/MySqlConnector/issues/70#issuecomment-397828054) it is possible to map them as `byte[]`, which matches the behavior of Connector/NET and MySql.Data.EntityFrameworkCore.