### PR TITLE
Fix Memory Consumption

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,7 @@
     <MicrosoftEntityFrameworkCoreRelationalVersion>2.1.1</MicrosoftEntityFrameworkCoreRelationalVersion>
     <MicrosoftEntityFrameworkCoreDesignVersion>2.1.1</MicrosoftEntityFrameworkCoreDesignVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
-    <MySqlConnectorVersion>0.42.2</MySqlConnectorVersion>
+    <MySqlConnectorVersion>0.42.1</MySqlConnectorVersion>
     <PomeloJsonObjectVersion>1.1.1</PomeloJsonObjectVersion>
     <!-- Shared Test Dependencies -->
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>

--- a/test/EFCore.MySql.IntegrationTests/Commands/TestPerformanceCommand.cs
+++ b/test/EFCore.MySql.IntegrationTests/Commands/TestPerformanceCommand.cs
@@ -10,7 +10,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands{
+namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands
+{
 
     public class TestPerformanceCommand : ITestPerformanceCommand
     {
@@ -22,32 +23,28 @@ namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands{
             _db = db;
         }
 
-        private Lazy<ServiceProvider> _serviceProvider = new Lazy<ServiceProvider>(() => {
+        private Lazy<ServiceProvider> _serviceProvider = new Lazy<ServiceProvider>(() =>
+        {
             var serviceCollection = new ServiceCollection();
-                serviceCollection
-                    .AddLogging()
-                    .AddScoped<ITestPerformanceRunner, TestPerformanceRunner>();
-                Startup.ConfigureEntityFramework(serviceCollection);
+            serviceCollection
+                .AddLogging()
+                .AddScoped<ITestPerformanceRunner, TestPerformanceRunner>();
+            Startup.ConfigureEntityFramework(serviceCollection);
 
-                var serviceProvider = serviceCollection.BuildServiceProvider();
-                serviceProvider
-                    .GetService<ILoggerFactory>()
-                    .AddConsole(AppConfig.Config.GetSection("Logging"));
-                return serviceProvider;
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            serviceProvider
+                .GetService<ILoggerFactory>()
+                .AddConsole(AppConfig.Config.GetSection("Logging"));
+            return serviceProvider;
         });
 
         public void Run(int iterations, int concurrency, int ops)
         {
-            void LogMemory()
-            {
-                Console.WriteLine("Managed Memory: " + GC.GetTotalMemory(false) / (1024 * 1024) + "MiB");
-                Console.WriteLine();
-            }
-
-            Console.WriteLine("EF_BATCH_SIZE is " + AppConfig.EfBatchSize);
+            Console.WriteLine("Testing with EF_BATCH_SIZE=" + AppConfig.EfBatchSize);
+            Console.WriteLine();
 
             var recordNum = 0;
-            async Task InsertOne(AppDb db)
+            async Task Insert1(AppDb db)
             {
                 var blog = new Blog
                 {
@@ -58,38 +55,24 @@ namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands{
             }
 
             var selected = new ConcurrentQueue<string>();
-            async Task SelectOne(AppDb db)
+            async Task Select1(AppDb db)
             {
-                var blog = await db.Blogs.OrderBy(m => m.Id).FirstOrDefaultAsync();
-                selected.Enqueue(blog.Title);
-            }
-
-            Task InsertOneHundred(AppDb db)
-            {
-                for (var i = 0; i < 100; ++i)
+                var blog = await db.Blogs.Skip(selected.Count).Take(1).OrderBy(m => m.Id).FirstOrDefaultAsync();
+                if (blog != null)
                 {
-                    var blog = new Blog
-                    {
-                        Title = "test " + Interlocked.Increment(ref recordNum)
-                    };
-                    db.Blogs.Add(blog);
+                    selected.Enqueue(blog.Title);
                 }
-
-                db.SaveChanges();
-                return Task.CompletedTask;
             }
 
             var updatedNum = 0;
-            Task UpdateFirstHundred(AppDb db)
+            async Task Update1(AppDb db)
             {
-                var blogs = db.Blogs.Take(100).ToList();
-                foreach (var blog in blogs)
+                var blog = await db.Blogs.Skip(selected.Count).Take(1).OrderBy(m => m.Id).FirstOrDefaultAsync();
+                if (blog != null)
                 {
                     blog.Title = "updated " + Interlocked.Increment(ref updatedNum);
                 }
-
-                db.SaveChanges();
-                return Task.CompletedTask;
+                await db.SaveChangesAsync();
             }
 
             var sleepNum = 0;
@@ -100,32 +83,76 @@ namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands{
                 Interlocked.Increment(ref sleepNum);
             }
 
+            async Task Insert100(AppDb db)
+            {
+                for (var i = 0; i < 100; i++)
+                {
+                    var blog = new Blog
+                    {
+                        Title = "test " + Interlocked.Increment(ref recordNum)
+                    };
+                    db.Blogs.Add(blog);
+                }
+                await db.SaveChangesAsync();
+            }
+
+            async Task Update100(AppDb db)
+            {
+                var blogs = await db.Blogs.Skip(updatedNum).Take(100).OrderBy(m => m.Id).ToListAsync();
+                foreach (var blog in blogs)
+                {
+                    blog.Title = "updated " + Interlocked.Increment(ref updatedNum);
+                }
+                await db.SaveChangesAsync();
+            }
+
+            async Task Select100(AppDb db)
+            {
+                var blogs = await db.Blogs.Skip(selected.Count).Take(100).OrderBy(m => m.Id).ToListAsync();
+                foreach (var blog in blogs)
+                {
+                    selected.Enqueue(blog.Title);
+                }
+            }
+
             _db.Database.ExecuteSqlCommand("DELETE FROM `" + _db.Model.FindEntityType(typeof(Blog)).Relational().TableName + "`");
 
-            PerfTest(InsertOne, "Insert One", iterations, concurrency, ops).GetAwaiter().GetResult();
-            Console.WriteLine("Records Inserted: " + _db.Blogs.Count());
+            PerfTest(Insert1, "Insert 1", iterations, concurrency, ops).GetAwaiter().GetResult();
+            var insertCount = _db.Blogs.Count();
+            Console.WriteLine("Records Inserted: " + insertCount);
             Console.WriteLine();
 
-            PerfTest(SelectOne, "Select One", iterations, concurrency, ops).GetAwaiter().GetResult();
-            Console.WriteLine("Records Selected: " +selected.Count);
+            PerfTest(Update1, "Update 1", iterations, concurrency, ops).GetAwaiter().GetResult();
+            var updateCount = updatedNum;
+            Console.WriteLine("Records Updated: " + updateCount);
+            Console.WriteLine();
+
+            PerfTest(Select1, "Select 1", iterations, concurrency, ops).GetAwaiter().GetResult();
+            var selectCount = selected.Count;
+            Console.WriteLine("Records Selected: " + selectCount);
             string firstRecord;
             if (selected.TryDequeue(out firstRecord))
                 Console.WriteLine("First Record: " + firstRecord);
             Console.WriteLine();
 
-            PerfTest(InsertOneHundred, "Insert 100", iterations, concurrency, ops).GetAwaiter().GetResult();
-            LogMemory();
-            GC.Collect();
-
-            PerfTest(UpdateFirstHundred, "Update 100", iterations, concurrency, ops).GetAwaiter().GetResult();
-            LogMemory();
-            GC.Collect();
-
             PerfTest(SleepMillisecond, "Sleep 1ms", iterations, concurrency, ops).GetAwaiter().GetResult();
             Console.WriteLine("Total Sleep Commands: " + sleepNum);
             Console.WriteLine();
 
-            LogMemory();
+            PerfTest(Insert100, "Insert 100", iterations, concurrency, 1).GetAwaiter().GetResult();
+            insertCount = _db.Blogs.Count() - insertCount;
+            Console.WriteLine("Records Inserted: " + insertCount);
+            Console.WriteLine();
+
+            PerfTest(Update100, "Update 100", iterations, concurrency, 1).GetAwaiter().GetResult();
+            updateCount = updatedNum - updateCount;
+            Console.WriteLine("Records Updated: " + updateCount);
+            Console.WriteLine();
+
+            PerfTest(Select100, "Select 100", iterations, concurrency, 1).GetAwaiter().GetResult();
+            selectCount = selected.Count - selectCount;
+            Console.WriteLine("Records Selected: " + selectCount);
+            Console.WriteLine();
         }
 
         public async Task PerfTest(Func<AppDb, Task> test, string testName, int iterations, int concurrency, int ops)
@@ -135,6 +162,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands{
 
             for (var iteration = 0; iteration < iterations; iteration++)
             {
+                GC.Collect();
                 // run the timed tests
                 var tasks = new List<Task>();
                 var start = DateTime.UtcNow;
@@ -142,7 +170,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands{
                 {
                     var scope = _serviceProvider.Value.CreateScope();
                     var testPerformanceRunner = scope.ServiceProvider.GetService<ITestPerformanceRunner>();
-                    async Task callable() {
+                    async Task callable()
+                    {
                         await testPerformanceRunner.ConnectionTask(test, ops);
                         scope.Dispose();
                     };
@@ -154,7 +183,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands{
                 memoryResults.Add(managedMemory);
                 timers.Add(DateTime.UtcNow - start);
             }
-            
+
             Console.WriteLine("Test:                     " + testName);
             Console.WriteLine("Iterations:               " + iterations);
             Console.WriteLine("Concurrency:              " + concurrency);


### PR DESCRIPTION
- Fixes #633
- Looks like the problem is in MySqlConnector 0.42.2

/cc @bgrainger 

**MySqlConnector 0.42.1** (normal operation)
```
Pomelo.EntityFrameworkCore.MySql/test/EFCore.MySql.IntegrationTests$ export EF_BATCH_SIZE=50; dotnet run testPerformance 1 1 1

Test:                     Insert 100
Iterations:               1
Concurrency:              1
Operations:               1
Times (Min, Average, Max) 00:00:00.0245872, 00:00:00.0245872, 00:00:00.0245872
Memory (Min, Avg, Max)    4.00, 4.00, 4.00 MiB

Records Inserted: 100

Test:                     Update 100
Iterations:               1
Concurrency:              1
Operations:               1
Times (Min, Average, Max) 00:00:00.0234958, 00:00:00.0234958, 00:00:00.0234958
Memory (Min, Avg, Max)    4.23, 4.23, 4.23 MiB

Records Updated: 100
```

**MySqlConnector 0.42.2** (huge memory consumption)
```
Pomelo.EntityFrameworkCore.MySql/test/EFCore.MySql.IntegrationTests$ export EF_BATCH_SIZE=50; dotnet run testPerformance 1 1 1

Test:                     Insert 100
Iterations:               1
Concurrency:              1
Operations:               1
Times (Min, Average, Max) 00:00:01.3850176, 00:00:01.3850176, 00:00:01.3850176
Memory (Min, Avg, Max)    2979.07, 2979.07, 2979.07 MiB

Records Inserted: 100

Test:                     Update 100
Iterations:               1
Concurrency:              1
Operations:               1
Times (Min, Average, Max) 00:00:01.3527789, 00:00:01.3527789, 00:00:01.3527789
Memory (Min, Avg, Max)    5379.40, 5379.40, 5379.40 MiB

Records Updated: 100
```