### PR TITLE
Use Microsoft.AspNetCore.App instead Microsoft.AspNetCore.All

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Ensure that your `.csproj` file has the following references.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.1" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.1.1" />
   </ItemGroup>
   


### PR DESCRIPTION
According to microsoft, net core should use Microsoft.AspNetCore.App and not Microsoft.AspNetCore.All.

More info in the migration documentation https://docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-2.1
