### PR TITLE
escape string literals analogously to parameter values

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ namespace YourNamespace // replace "YourNamespace" with the namespace of your ap
     }
 }
 ```
+#### NO_BACKSLASH_ESCAPES
+The escaping style can be configured to support SQL mode [NO_BACKSLASH_ESCAPES](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_backslash_escapes) by adding `.DisableBackslashEscaping()` to your MySQL option configuration.
+```csharp
+mysqlOptions =>
+{
+    mysqlOptions
+    .ServerVersion(new Version(5, 7, 17), ServerType.MySql); // replace with your Server Version and Type
+    //further MySQL option configurations go here
+    .DisableBackslashEscaping();
+}
+```
+**PLEASE NOTE** This option does not set the SQL mode and will not check if it matches the actual database configuration either. Do not use this option unless you are absolutely sure it will always be set when queries are performed on the context. 
+As of today, it also **does not apply** to parameter values in insert or update statements; do not use it when the context is used to update entries.
 
 View our [MySql Provider Configuration Options Wiki Page](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/wiki/MySql-Provider-Configuration-Options) for a complete list of supported options.
 

--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -13,5 +13,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         CharSetBehavior CharSetBehavior { get; }
         CharSetInfo AnsiCharSetInfo { get; }
         CharSetInfo UnicodeCharSetInfo { get; }
+        bool NoBackslashEscapes { get; }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -26,6 +26,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             NullableCharSetBehavior = copyFrom.NullableCharSetBehavior;
             AnsiCharSetInfo = copyFrom.AnsiCharSetInfo;
             UnicodeCharSetInfo = copyFrom.UnicodeCharSetInfo;
+            NoBackslashEscapes = copyFrom.NoBackslashEscapes;
         }
 
         protected override RelationalOptionsExtension Clone()
@@ -56,6 +57,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         /// </summary>
         public CharSetInfo UnicodeCharSetInfo { get; private set; }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public bool NoBackslashEscapes { get; private set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -113,6 +119,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public MySqlOptionsExtension DisableBackslashEscaping()
+        {
+            var clone = (MySqlOptionsExtension)Clone();
+            clone.NoBackslashEscapes = true;
+            return clone;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public override long GetServiceProviderHashCode()
         {
             if (_serviceProviderHash == null)
@@ -121,6 +138,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                 _serviceProviderHash = (_serviceProviderHash * 397) ^ (NullableCharSetBehavior?.GetHashCode() ?? 0L);
                 _serviceProviderHash = (_serviceProviderHash * 397) ^ (AnsiCharSetInfo?.GetHashCode() ?? 0L);
                 _serviceProviderHash = (_serviceProviderHash * 397) ^ (UnicodeCharSetInfo?.GetHashCode() ?? 0L);
+                _serviceProviderHash = (_serviceProviderHash * 397) ^ NoBackslashEscapes.GetHashCode();
             }
 
             return _serviceProviderHash.Value;

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -62,6 +62,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => ExecutionStrategy(c => new MySqlRetryingExecutionStrategy(c, maxRetryCount));
 
         /// <summary>
+        ///     Configures string escaping in SQL query generation to ignore backslashes.
+        ///     This applies to both constant and parameter values (i. e. user input, potentially).
+        ///     Use this option if SQL mode NO_BACKSLASH_ESCAPES is guaranteed to be active.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder DisableBackslashEscaping() =>
+            WithOption(e => e.DisableBackslashEscaping());
+
+        /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
         /// </summary>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>

--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -31,6 +31,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             CharSetBehavior = mySqlOptions.NullableCharSetBehavior ?? CharSetBehavior;
             AnsiCharSetInfo = mySqlOptions.AnsiCharSetInfo ?? AnsiCharSetInfo;
             UnicodeCharSetInfo = mySqlOptions.UnicodeCharSetInfo ?? UnicodeCharSetInfo;
+            NoBackslashEscapes = mySqlOptions.NoBackslashEscapes;
         }
 
         public virtual void Validate(IDbContextOptions options)
@@ -77,5 +78,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
         public virtual CharSetBehavior CharSetBehavior { get; private set; }
         public virtual CharSetInfo AnsiCharSetInfo { get; private set; }
         public virtual CharSetInfo UnicodeCharSetInfo { get; private set; }
+        public virtual bool NoBackslashEscapes { get; private set; }
     }
 }

--- a/src/EFCore.MySql/Query/Sql/Internal/MySqlQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.MySql/Query/Sql/Internal/MySqlQuerySqlGeneratorFactory.cs
@@ -5,19 +5,23 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Sql.Internal
 {
     public class MySqlQuerySqlGeneratorFactory : QuerySqlGeneratorFactoryBase
     {
-        public MySqlQuerySqlGeneratorFactory([NotNull] QuerySqlGeneratorDependencies dependencies)
+        private readonly IMySqlOptions _options;
+
+        public MySqlQuerySqlGeneratorFactory([NotNull] QuerySqlGeneratorDependencies dependencies, IMySqlOptions options)
             : base(dependencies)
         {
+            _options = options;
         }
 
         public override IQuerySqlGenerator CreateDefault(SelectExpression selectExpression)
             => new MySqlQuerySqlGenerator(
                 Dependencies,
-                Check.NotNull(selectExpression, nameof(selectExpression)));
+                Check.NotNull(selectExpression, nameof(selectExpression)), _options);
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
@@ -20,6 +20,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         private const int AnsiMax = 8000;
 
         private readonly int _maxSpecificSize;
+        private readonly bool _noBackslashEscapes;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -30,7 +31,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             DbType? dbType,
             bool unicode = false,
             int? size = null,
-            bool fixedLength = false)
+            bool fixedLength = false,
+            bool noBackslashEscapes = false)
             : this(
                 new RelationalTypeMappingParameters(
                     new CoreTypeMappingParameters(typeof(string)),
@@ -41,6 +43,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                     size,
                     fixedLength))
         {
+            _noBackslashEscapes = noBackslashEscapes;
         }
 
         /// <summary>
@@ -105,9 +108,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             => IsUnicode
                 ? $"'{EscapeSqlLiteral((string)value)}'" // Interpolation okay; strings
                 : $"'{EscapeSqlLiteral((string)value)}'";
-        
-		protected override string EscapeSqlLiteral(string literal)
+
+        protected override string EscapeSqlLiteral(string literal)
         {
+            if (_noBackslashEscapes)
+            {
+                return base.EscapeSqlLiteral(literal);
+            }
             return literal.Replace("\\", "\\\\").Replace("'", "\\'");
         }
     }

--- a/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
@@ -111,11 +111,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         protected override string EscapeSqlLiteral(string literal)
         {
-            if (_noBackslashEscapes)
-            {
-                return base.EscapeSqlLiteral(literal);
-            }
-            return literal.Replace("\\", "\\\\").Replace("'", "\\'");
+            return _noBackslashEscapes
+                ? base.EscapeSqlLiteral(literal)
+                : base.EscapeSqlLiteral(literal).Replace("\\", "\\\\");
         }
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
@@ -105,5 +105,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             => IsUnicode
                 ? $"'{EscapeSqlLiteral((string)value)}'" // Interpolation okay; strings
                 : $"'{EscapeSqlLiteral((string)value)}'";
+        
+		protected override string EscapeSqlLiteral(string literal)
+        {
+            return literal.Replace("\\", "\\\\").Replace("'", "\\'");
+        }
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -50,6 +50,19 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         private readonly MySqlStringTypeMapping _nvarcharmax     =
             new MySqlStringTypeMapping("longtext CHARACTER SET ucs2", DbType.String, unicode: true);
 
+        private readonly MySqlStringTypeMapping _char_noBackslashEscapes        =
+            new MySqlStringTypeMapping("char", DbType.AnsiStringFixedLength, fixedLength: true, noBackslashEscapes:true);
+        private readonly MySqlStringTypeMapping _varchar_noBackslashEscapes     =
+            new MySqlStringTypeMapping("varchar", DbType.AnsiString, noBackslashEscapes: true);
+        private readonly MySqlStringTypeMapping _nchar_noBackslashEscapes       =
+            new MySqlStringTypeMapping("nchar", DbType.StringFixedLength, unicode: true, fixedLength: true, noBackslashEscapes: true);
+        private readonly MySqlStringTypeMapping _nvarchar_noBackslashEscapes    =
+            new MySqlStringTypeMapping("nvarchar", DbType.String, unicode: true, noBackslashEscapes: true);
+	    private readonly MySqlStringTypeMapping _varcharmax_noBackslashEscapes  =
+	        new MySqlStringTypeMapping("longtext CHARACTER SET latin1", DbType.AnsiString, noBackslashEscapes: true);
+        private readonly MySqlStringTypeMapping _nvarcharmax_noBackslashEscapes =
+            new MySqlStringTypeMapping("longtext CHARACTER SET ucs2", DbType.String, unicode: true, noBackslashEscapes: true);
+
         // DateTime
         private readonly MySqlDateTypeMapping _date                       = new MySqlDateTypeMapping("date");
         private readonly MySqlDateTimeTypeMapping _dateTime6              = new MySqlDateTimeTypeMapping("datetime(6)", precision: 6);
@@ -133,30 +146,41 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                     { "longblob", _varbinary },
 
                     // string
-                    { "char", _char },
-                    { "varchar", _varchar },
-                    { "nchar", _nchar },
-                    { "nvarchar", _nvarchar },
-                    { "tinytext", _varcharmax },
-                    { "text", _varcharmax },
-                    { "mediumtext", _varcharmax },
-                    { "longtext", _varcharmax },
+                    { "char", options.NoBackslashEscapes ? _char_noBackslashEscapes : _char },
+                    { "varchar", options.NoBackslashEscapes ? _varchar_noBackslashEscapes : _varchar },
+                    { "nchar", options.NoBackslashEscapes ? _nchar_noBackslashEscapes : _nchar },
+                    { "nvarchar", options.NoBackslashEscapes ? _nvarchar_noBackslashEscapes : _nvarchar },
+                    { "tinytext", options.NoBackslashEscapes ? _varcharmax_noBackslashEscapes : _varcharmax },
+                    { "text", options.NoBackslashEscapes ? _varcharmax_noBackslashEscapes : _varcharmax },
+                    { "mediumtext", options.NoBackslashEscapes ? _varcharmax_noBackslashEscapes : _varcharmax },
+                    { "longtext", options.NoBackslashEscapes ? _varcharmax_noBackslashEscapes : _varcharmax },
 
                     // DateTime
                     { "date", _date }
                 };
 
-            _unicodeStoreTypeMappings
-                = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
+            _unicodeStoreTypeMappings = options.NoBackslashEscapes
+                ? new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "char", _nchar },
-                    { "varchar", _nvarchar },
-                    { "nchar", _nchar },
-                    { "nvarchar", _nvarchar },
-                    { "tinytext", _nvarcharmax },
-                    { "text", _nvarcharmax },
-                    { "mediumtext", _nvarcharmax },
-                    { "longtext", _nvarcharmax }
+                    {"char", _nchar_noBackslashEscapes},
+                    {"varchar", _nvarchar_noBackslashEscapes},
+                    {"nchar", _nchar_noBackslashEscapes},
+                    {"nvarchar", _nvarchar_noBackslashEscapes},
+                    {"tinytext", _nvarcharmax_noBackslashEscapes},
+                    {"text", _nvarcharmax_noBackslashEscapes},
+                    {"mediumtext", _nvarcharmax_noBackslashEscapes},
+                    {"longtext", _nvarcharmax_noBackslashEscapes}
+                }
+                : new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
+                {
+                    {"char", _nchar},
+                    {"varchar", _nvarchar},
+                    {"nchar", _nchar},
+                    {"nvarchar", _nvarchar},
+                    {"tinytext", _nvarcharmax},
+                    {"text", _nvarcharmax},
+                    {"mediumtext", _nvarcharmax},
+                    {"longtext", _nvarcharmax}
                 };
 
             _clrTypeMappings

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -366,7 +366,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                         dbType,
                         !isAnsi,
                         size,
-                        isFixedLength);
+                        isFixedLength,
+                        _options.NoBackslashEscapes);
                 }
 
                 if (clrType == typeof(byte[]))

--- a/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlNoBackslashesTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlNoBackslashesTest.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
+{
+    public class EscapesMySqlNoBackslashesTest : EscapesMySqlTestBase<NorthwindQueryMySqlNoBackslashesFixture<NoopModelCustomizer>>
+    {
+        public EscapesMySqlNoBackslashesTest(NorthwindQueryMySqlNoBackslashesFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper) : base(fixture)
+        {
+            SetSqlMode("NO_BACKSLASH_ESCAPES");
+
+            fixture.TestSqlLoggerFactory.Clear();
+            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [ConditionalFact(Skip = "see issue #667")]
+        public override void Input_query_escapes_parameter()
+        {
+
+        }
+
+        [Fact]
+        public override void Where_query_escapes_literal()
+        {
+            base.Where_query_escapes_literal();
+            AssertBaseline(@"SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = 'B''s Beverages'");
+        }
+
+        [Fact]
+        public void Where_query_escapes_parameter()
+        {
+            base.Where_query_escapes_parameter(@"Back\slash's Operation");
+            AssertBaseline(@"SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = 'Back\slash''s Operation'");
+        }
+
+        [Fact]
+        public void Where_contains_query_escapes()
+        {
+            base.Where_contains_query_escapes(@"Back\slash's Operation", "B's Beverages");
+            AssertBaseline(@"SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` IN ('Back\slash''s Operation', 'B''s Beverages')");
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
+{
+    public class EscapesMySqlTest : EscapesMySqlTestBase<NorthwindQueryMySqlFixture<NoopModelCustomizer>>
+    {
+        private readonly ITestOutputHelper _output;
+
+        public EscapesMySqlTest(NorthwindQueryMySqlFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper) : base(fixture)
+        {
+            fixture.TestSqlLoggerFactory.Clear();
+            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+
+            _output = testOutputHelper;
+        }
+
+        [Fact]
+        public override void Input_query_escapes_parameter()
+        {
+            base.Input_query_escapes_parameter();
+            AssertBaseline(@"@p0='ESCAPETEST' (Nullable = false) (Size = 255)
+@p1='' (Size = 4000)
+@p2='' (Size = 4000)
+@p3='Back\slash's Operation' (Size = 4000)
+@p4='' (Size = 4000)
+@p5='' (Size = 4000)
+@p6='' (Size = 4000)
+@p7='' (Size = 4000)
+@p8='' (Size = 4000)
+@p9='' (Size = 4000)
+@p10='' (Size = 4000)
+
+INSERT INTO `Customers` (`CustomerID`, `Address`, `City`, `CompanyName`, `ContactName`, `ContactTitle`, `Country`, `Fax`, `Phone`, `PostalCode`, `Region`)
+VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10);",
+                @"@__companyName_0='Back\slash's Operation' (Size = 4000)
+
+SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = @__companyName_0");
+        }
+
+        [Fact]
+        public override void Where_query_escapes_literal()
+        {
+            base.Where_query_escapes_literal();
+            AssertBaseline(@"SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = 'B''s Beverages'");
+        }
+
+        [Fact]
+        public void Where_query_escapes_parameter()
+        {
+            base.Where_query_escapes_parameter(@"Back\slash's Operation");
+            AssertBaseline(@"@__companyName_0='Back\slash's Operation' (Size = 4000)
+
+SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = @__companyName_0");
+        }
+
+        [Fact]
+        public void Where_contains_query_escapes()
+        {
+            base.Where_contains_query_escapes(@"Back\slash's Operation", "B's Beverages");
+            AssertBaseline(@"SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` IN ('Back\\slash''s Operation', 'B''s Beverages')");
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlTestBase.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlTestBase.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using MySql.Data.MySqlClient;
+using Xunit;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
+{
+    public abstract class EscapesMySqlTestBase<TFixture> : IClassFixture<TFixture>, IDisposable where TFixture : NorthwindQueryMySqlFixture<NoopModelCustomizer>
+    {
+        private readonly NorthwindContext _context;
+        protected EscapesMySqlTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+            _context = CreateContext();
+        }
+
+        protected TFixture Fixture;
+
+        protected NorthwindContext CreateContext() => Fixture.CreateContext();
+
+        protected void PerfomInTransaction(Action<NorthwindContext> action)
+        {
+            using (var transaction = _context.Database.BeginTransaction())
+            {
+                action.Invoke(_context);
+            }
+        }
+
+        public virtual void Input_query_escapes_parameter()
+        {
+            using (var transaction = _context.Database.BeginTransaction())
+            {
+                var companyName = @"Back\slash's Operation";
+                _context.Customers.Add(new Customer
+                {
+                    CustomerID = "ESCAPETEST",
+                    CompanyName = companyName
+                });
+                _context.SaveChanges();
+                var count = _context.Customers.Count(x => x.CompanyName == companyName);
+                Assert.Equal(1, count);
+            }
+        }
+
+        public virtual void Where_query_escapes_literal()
+        {
+            _context.Customers.Count(x => x.CompanyName == "B's Beverages");
+        }
+
+        public virtual void Where_query_escapes_parameter(string companyName)
+        {
+            _context.Customers.Count(x => x.CompanyName == companyName);
+        }
+
+        public virtual void Where_contains_query_escapes(params string[] companyNames)
+        {
+            _context.Customers.Count(x => companyNames.Contains(x.CompanyName));
+        }
+        
+        protected void SetSqlMode(string modes)
+        {
+            _context.Database.ExecuteSqlCommand("SET SESSION sql_mode = @p0", new MySqlParameter("@p0", modes) );
+        }
+
+        protected void AssertBaseline(params string[] expected)
+        {
+            Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+        }
+
+        public void Dispose() => _context.Dispose();
+
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindQueryMySqlNoBackslashesFixture.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindQueryMySqlNoBackslashesFixture.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
+{
+    public class
+        NorthwindQueryMySqlNoBackslashesFixture<TModelCustomizer> : NorthwindQueryMySqlFixture<TModelCustomizer> where TModelCustomizer : IModelCustomizer, new()
+    {
+        protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.NoBackslashEscapesInstance;
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStoreFactory.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStoreFactory.cs
@@ -7,16 +7,20 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
     public class MySqlTestStoreFactory : ITestStoreFactory
     {
         public static MySqlTestStoreFactory Instance { get; } = new MySqlTestStoreFactory();
+        public static MySqlTestStoreFactory NoBackslashEscapesInstance { get; } = new MySqlTestStoreFactory(true);
 
-        protected MySqlTestStoreFactory()
+        private readonly bool _noBackslashEscapes;
+
+        protected MySqlTestStoreFactory(bool noBackslashEscapes = false)
         {
+            _noBackslashEscapes = noBackslashEscapes;
         }
 
         public virtual TestStore Create(string storeName)
-            => MySqlTestStore.Create(storeName);
+            => MySqlTestStore.Create(storeName, noBackslashEscapes:_noBackslashEscapes);
 
         public virtual TestStore GetOrCreate(string storeName)
-            => MySqlTestStore.GetOrCreate(storeName);
+            => MySqlTestStore.GetOrCreate(storeName, noBackslashEscapes: _noBackslashEscapes);
 
         public IServiceCollection AddProviderServices(IServiceCollection serviceCollection)
             => serviceCollection.AddEntityFrameworkMySql()

--- a/test/EFCore.MySql.Tests/MySqlOptionsExtensionTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlOptionsExtensionTest.cs
@@ -15,17 +15,19 @@ namespace Pomelo.EntityFrameworkCore.MySql
             Assert.Equal(new MySqlOptionsExtension().GetServiceProviderHashCode(), new MySqlOptionsExtension().GetServiceProviderHashCode());
 
             Assert.Equal(new MySqlOptionsExtension()
-                .WithAnsiCharSetInfo(new CharSetInfo(CharSet.Latin1))
-                .WithCharSetBehavior(CharSetBehavior.AppendToAllColumns)
-                .WithUnicodeCharSetInfo(new CharSetInfo(CharSet.Utf8mb4))
-                .WithServerVersion(new ServerVersion(new Version(1,2,3,4), ServerType.MySql))
-                .GetServiceProviderHashCode(),
+                    .WithAnsiCharSetInfo(new CharSetInfo(CharSet.Latin1))
+                    .WithCharSetBehavior(CharSetBehavior.AppendToAllColumns)
+                    .WithUnicodeCharSetInfo(new CharSetInfo(CharSet.Utf8mb4))
+                    .WithServerVersion(new ServerVersion(new Version(1, 2, 3, 4), ServerType.MySql))
+                    .DisableBackslashEscaping()
+                    .GetServiceProviderHashCode(),
                 new MySqlOptionsExtension()
-                .WithAnsiCharSetInfo(new CharSetInfo(CharSet.Latin1))
-                .WithCharSetBehavior(CharSetBehavior.AppendToAllColumns)
-                .WithUnicodeCharSetInfo(new CharSetInfo(CharSet.Utf8mb4))
-                .WithServerVersion(new ServerVersion(new Version(1, 2, 3, 4), ServerType.MySql))
-                .GetServiceProviderHashCode());
+                    .WithAnsiCharSetInfo(new CharSetInfo(CharSet.Latin1))
+                    .WithCharSetBehavior(CharSetBehavior.AppendToAllColumns)
+                    .WithUnicodeCharSetInfo(new CharSetInfo(CharSet.Utf8mb4))
+                    .WithServerVersion(new ServerVersion(new Version(1, 2, 3, 4), ServerType.MySql))
+                    .DisableBackslashEscaping()
+                    .GetServiceProviderHashCode());
         }
     }
 }


### PR DESCRIPTION
Fixes #667 

Issue: Constant string values are not escaped (except for occurances of `'` being replaced with `''`). 
Since variable values contained in [`InExpression`](https://github.com/aspnet/EntityFrameworkCore/blob/release/2.2/src/EFCore.Relational/Query/Expressions/InExpression.cs)s will be resolved to constants when those are expanded during query generation, this also affects use cases dealing with input other than hard coded strings.

Solution: Handle constant string values the same way as parameter string values (see escaping in [`MySqlParameter`](https://github.com/mysql-net/MySqlConnector/blob/62690094a865b68ba15136c1e5d9304df878757d/src/MySqlConnector/MySql.Data.MySqlClient/MySqlParameter.cs#L190)).

Parameter values in insert/update operations will still not be escaped correctly with NO_BACKSLASH_ESCAPES, but I think this really is an edge case and it will be obsolete as soon as prepared statements are used - which seems to be in the making already.