### PR TITLE
add statement terminator in RenameColumOperation script generation

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -592,7 +592,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder
                     .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName))
                     .Append(" ")
-                    .Append(type);
+                    .Append(type)
+                    .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
 
                 EndStatement(builder);
                 return;
@@ -639,7 +640,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 operation,
                 model,
                 builder);
-
+            builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
             EndStatement(builder);
         }
 

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
@@ -820,7 +820,7 @@ DROP PROCEDURE IF EXISTS POMELO_AFTER_ADD_PRIMARY_KEY;".Replace("\r", string.Emp
             Generate(migrationBuilder.Operations.ToArray());
 
             Assert.Equal(
-                "ALTER TABLE `Person` CHANGE `Name` `FullName` VARCHAR(4000)",
+                "ALTER TABLE `Person` CHANGE `Name` `FullName` VARCHAR(4000);" + EOL,
                 Sql);
         }
 
@@ -841,7 +841,7 @@ DROP PROCEDURE IF EXISTS POMELO_AFTER_ADD_PRIMARY_KEY;".Replace("\r", string.Emp
                 migrationBuilder.Operations.ToArray());
 
             Assert.Equal(
-                "ALTER TABLE `Person` CHANGE `Name` `FullName` longtext NULL",
+                "ALTER TABLE `Person` CHANGE `Name` `FullName` longtext NULL;" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
This commit fixes the script generation for migrations featuring a `RenameColumnOperation`, currently producing faulty SQL due to missing statement terminators.