### PR TITLE
Make queries non-cacheable when NoBackslashEscaping

### DIFF
--- a/src/EFCore.MySql/Query/Sql/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/Sql/Internal/MySqlQuerySqlGenerator.cs
@@ -126,6 +126,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Sql.Internal
             return base.VisitBinary(binaryExpression);
         }
 
+        private bool _isParameterReplaced = false;
+        public override bool IsCacheable => !_isParameterReplaced && base.IsCacheable;
+
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
         {
             if (_noBackslashEscapes)
@@ -138,6 +141,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Sql.Internal
                 var isRegistered = ParameterValues.TryGetValue(parameterExpression.Name, out value);
                 if (isRegistered && value is string)
                 {
+                    _isParameterReplaced = true;
                     return VisitConstant(Expression.Constant(value));
                 }
             }

--- a/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlNoBackslashesTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlNoBackslashesTest.cs
@@ -47,5 +47,23 @@ WHERE `x`.`CompanyName` = 'Back\slash''s Operation'");
 FROM `Customers` AS `x`
 WHERE `x`.`CompanyName` IN ('Back\slash''s Operation', 'B''s Beverages')");
         }
+
+        [Fact]
+        public void Where_query_multiple_with_different_parameter()
+        {
+            base.Where_query_escapes_parameter(@"Back\slash's Operation");
+            base.Where_query_escapes_parameter(@"Back\slash's 2nd Operation");
+            AssertBaseline(
+                // first operation
+@"SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = 'Back\slash''s Operation'",
+                // second operation
+@"SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = 'Back\slash''s 2nd Operation'"
+                );
+
+        }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlTest.cs
@@ -70,5 +70,25 @@ WHERE `x`.`CompanyName` = @__companyName_0");
 FROM `Customers` AS `x`
 WHERE `x`.`CompanyName` IN ('Back\\slash''s Operation', 'B''s Beverages')");
         }
+
+        [Fact]
+        public void Where_query_multiple_with_different_parameter()
+        {
+            base.Where_query_escapes_parameter(@"Back\slash's Operation");
+            base.Where_query_escapes_parameter(@"Back\slash's 2nd Operation");
+            AssertBaseline(
+            // first operation
+@"@__companyName_0='Back\slash's Operation' (Size = 4000)
+
+SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = @__companyName_0",
+            // second operation
+@"@__companyName_0='Back\slash's 2nd Operation' (Size = 4000)
+
+SELECT COUNT(*)
+FROM `Customers` AS `x`
+WHERE `x`.`CompanyName` = @__companyName_0");
+        }
     }
 }


### PR DESCRIPTION
When NoBackslashEscaping is set, parameters in queries are replaced with their value, which should make them non-cacheable.
This should resolve #702 