### PR TITLE
Add string.PadLeft, string.PadRight Translators

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlCompositeMethodCallTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlCompositeMethodCallTranslator.cs
@@ -31,7 +31,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             new MySqlStringTrimEndTranslator(),
             new MySqlStringTrimStartTranslator(),
             new MySqlStringTrimTranslator(),
-            new MySqlStringIndexOfTranslator()
+            new MySqlStringIndexOfTranslator(),
+            new MySqlStringPadLeftRightTranslator()
         };
 
         /// <summary>

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringPadLeftRightTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringPadLeftRightTranslator.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class MySqlStringPadLeftRightTranslator : IMethodCallTranslator
+    {
+        private static readonly Dictionary<MethodInfo, string> _withOneArgumentMethods = new Dictionary<MethodInfo, string>
+        {
+            { typeof(string).GetRuntimeMethod(nameof(string.PadLeft), new[] { typeof(int) }), "LPAD" },
+            { typeof(string).GetRuntimeMethod(nameof(string.PadRight), new[] { typeof(int) }), "RPAD" }
+        };
+
+        private static readonly Dictionary<MethodInfo, string> _withTwoArgumentsMethods = new Dictionary<MethodInfo, string>
+        {
+            { typeof(string).GetRuntimeMethod(nameof(string.PadLeft), new[] { typeof(int), typeof(char) }), "LPAD" },
+            { typeof(string).GetRuntimeMethod(nameof(string.PadRight), new[] { typeof(int), typeof(char) }), "RPAD" }
+        };
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            Check.NotNull(methodCallExpression, nameof(methodCallExpression));
+
+            ConstantExpression padstr = null;
+            ConstantExpression len = null;
+
+            if(_withOneArgumentMethods.TryGetValue(methodCallExpression.Method, out var sqlFunction)
+                && methodCallExpression.Arguments[0].NodeType == ExpressionType.Constant)
+            {
+                padstr = Expression.Constant(' ');
+                len = methodCallExpression.Arguments[0] as ConstantExpression;
+            }
+            else if (_withTwoArgumentsMethods.TryGetValue(methodCallExpression.Method, out sqlFunction)
+                && methodCallExpression.Arguments[0].NodeType == ExpressionType.Constant
+                && methodCallExpression.Arguments[1].NodeType == ExpressionType.Constant)
+            {
+                len = methodCallExpression.Arguments[0] as ConstantExpression;
+                padstr = methodCallExpression.Arguments[1] as ConstantExpression;
+            }
+            else
+            {
+                return null;
+            }
+
+            return new SqlFunctionExpression(
+                    sqlFunction,
+                    methodCallExpression.Type,
+                    new[] { methodCallExpression.Object, len, padstr });
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
@@ -839,6 +839,70 @@ WHERE `t`.`c` < @__nextYear_0");
             base.Where_multiple_contains_in_subquery_with_or();
         }
 
+        [ConditionalFact]
+        public void PadLeft_without_second_arg()
+        {
+            AssertSingleResult<Customer>(
+                    customer => customer.Where(r => r.CustomerID.PadLeft(2) == "AL").Count(),
+                    asserter: (_, a) =>
+                    {
+                        var len = (int)a;
+                        Assert.Equal(len, 1);
+                        AssertSql(@"SELECT COUNT(*)
+FROM `Customers` AS `r`
+WHERE LPAD(`r`.`CustomerID`, 2, ' ') = 'AL'");
+                    }
+                );
+        }
+
+        [ConditionalFact]
+        public void PadLeft_with_second_arg()
+        {
+            AssertSingleResult<Customer>(
+                    customer => customer.Where(r => r.CustomerID.PadLeft(3, 'x') == "AL").Count(),
+                    asserter: (_, a) =>
+                    {
+                        var len = (int)a;
+                        Assert.Equal(len, 0);
+                        AssertSql(@"SELECT COUNT(*)
+FROM `Customers` AS `r`
+WHERE LPAD(`r`.`CustomerID`, 3, 'x') = 'AL'");
+                    }
+                );
+        }
+
+        [ConditionalFact]
+        public void PadRight_without_second_arg()
+        {
+            AssertSingleResult<Customer>(
+                    customer => customer.Where(r => r.CustomerID.PadRight(3) == "AL").Count(),
+                    asserter: (_, a) =>
+                    {
+                        var len = (int)a;
+                        Assert.Equal(len, 0);
+                        AssertSql(@"SELECT COUNT(*)
+FROM `Customers` AS `r`
+WHERE RPAD(`r`.`CustomerID`, 3, ' ') = 'AL'");
+                    }
+                );
+        }
+
+        [ConditionalFact]
+        public void PadRight_with_second_arg()
+        {
+            AssertSingleResult<Customer>(
+                  customer => customer.Where(r => r.CustomerID.PadRight(4, 'c') == "AL").Count(),
+                  asserter: (_, a) =>
+                  {
+                      var len = (int)a;
+                      Assert.Equal(len, 0);
+                      AssertSql(@"SELECT COUNT(*)
+FROM `Customers` AS `r`
+WHERE RPAD(`r`.`CustomerID`, 4, 'c') = 'AL'");
+                  }
+              );
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
Hi all,

Improvements:
Added Method Call Translator for `string.PadLeft` and `string.PadRight` methods.
Added Unit Tests for `MySqlStringPadLeftRightTranslator`.
