### PR TITLE
Fix scaffold script for integration tests

### DIFF
--- a/test/EFCore.MySql.IntegrationTests/scripts/scaffold.sh
+++ b/test/EFCore.MySql.IntegrationTests/scripts/scaffold.sh
@@ -7,7 +7,7 @@ set -e
 rm -rf Scaffold
 mkdir -p Scaffold
 
-connection_string=$(dotnet run connectionString)
+connection_string=$(dotnet run connectionString ... | tail -1)
 dotnet ef dbcontext scaffold -o "Scaffold" -t "DataTypesSimple" -t "DataTypesVariable" "$connection_string" "Pomelo.EntityFrameworkCore.MySql"
 
 error=false


### PR DESCRIPTION
This merge will solve the scaffold script by simply only using the last returned line.
It did include the dotnet core warning message about a version which resulted in the failed execution.
