### PR TITLE
Update type mapping Clone for 2.2.0

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlBoolTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlBoolTypeMapping.cs
@@ -42,18 +42,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlBoolTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlBoolTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlBoolTypeMapping(parameters);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.MySql/Storage/Internal/MySqlByteArrayTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlByteArrayTypeMapping.cs
@@ -73,18 +73,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlByteArrayTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlByteArrayTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlByteArrayTypeMapping(parameters);
 
         private static int CalculateSize(int? size)
             => size.HasValue && size < MaxSize ? size.Value : MaxSize;

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTimeOffsetTypeMapping.cs
@@ -50,18 +50,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlDateTimeOffsetTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlDateTimeOffsetTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlDateTimeOffsetTypeMapping(parameters);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTimeTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTimeTypeMapping.cs
@@ -52,18 +52,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlDateTimeTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlDateTimeTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlDateTimeTypeMapping(parameters);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTypeMapping.cs
@@ -43,18 +43,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlDateTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlDateTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlDateTypeMapping(parameters);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.MySql/Storage/Internal/MySqlDecimalTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDecimalTypeMapping.cs
@@ -38,18 +38,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlDecimalTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlDecimalTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlDecimalTypeMapping(parameters);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.MySql/Storage/Internal/MySqlDoubleTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDoubleTypeMapping.cs
@@ -37,17 +37,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlDoubleTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlDoubleTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlDoubleTypeMapping(parameters);
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlFloatTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlFloatTypeMapping.cs
@@ -38,18 +38,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlFloatTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlFloatTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlFloatTypeMapping(parameters);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMapping.cs
@@ -66,18 +66,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlJsonTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlJsonTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlJsonTypeMapping(parameters);
 
         /// <summary>
         ///     Generates the escaped SQL representation of a literal value.

--- a/src/EFCore.MySql/Storage/Internal/MySqlOldGuidTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlOldGuidTypeMapping.cs
@@ -37,17 +37,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => ByteArrayFormatter.ToHex(((Guid)value).ToByteArray());
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlOldGuidTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlOldGuidTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlOldGuidTypeMapping(parameters);
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
@@ -62,18 +62,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                 : size.HasValue && size <= AnsiMax ? size.Value : AnsiMax;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlStringTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlStringTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlStringTypeMapping(parameters);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.MySql/Storage/Internal/MySqlTimeSpanTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTimeSpanTypeMapping.cs
@@ -46,18 +46,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
+        ///     Creates a copy of this mapping.
         /// </summary>
-        public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new MySqlTimeSpanTypeMapping(Parameters.WithStoreTypeAndSize(storeType, size));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override CoreTypeMapping Clone(ValueConverter converter)
-            => new MySqlTimeSpanTypeMapping(Parameters.WithComposedConverter(converter));
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new MySqlTimeSpanTypeMapping(parameters);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.


### PR DESCRIPTION
Update `Clone` methods in Type Mappings as per https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/726#issuecomment-452490838