### PR TITLE
Implement MySqlDbFunctionsExtensions, resolves #747

### DIFF
--- a/src/EFCore.MySql/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/MySqlDbFunctionsExtensions.cs
@@ -1,0 +1,454 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
+    ///     The methods on this class are accessed via <see cref="EF.Functions" />.
+    /// </summary>
+    public static class MySqlDbFunctionsExtensions
+    {
+        /// <summary>
+        ///     Counts the number of year boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of year boundaries crossed between the dates.</returns>
+        public static int DateDiffYear(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+            => endDate.Year - startDate.Year;
+
+        /// <summary>
+        ///     Counts the number of year boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of year boundaries crossed between the dates.</returns>
+        public static int? DateDiffYear(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffYear(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of year boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of year boundaries crossed between the dates.</returns>
+        public static int DateDiffYear(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => DateDiffYear(_, startDate.UtcDateTime, endDate.UtcDateTime);
+
+        /// <summary>
+        ///     Counts the number of year boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of year boundaries crossed between the dates.</returns>
+        public static int? DateDiffYear(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffYear(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of month boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of month boundaries crossed between the dates.</returns>
+        public static int DateDiffMonth(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+            => 12 * (endDate.Year - startDate.Year) + endDate.Month - startDate.Month;
+
+        /// <summary>
+        ///     Counts the number of month boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of month boundaries crossed between the dates.</returns>
+        public static int? DateDiffMonth(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffMonth(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of month boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of month boundaries crossed between the dates.</returns>
+        public static int DateDiffMonth(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => DateDiffMonth(_, startDate.UtcDateTime, endDate.UtcDateTime);
+
+        /// <summary>
+        ///     Counts the number of month boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of month boundaries crossed between the dates.</returns>
+        public static int? DateDiffMonth(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffMonth(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of day boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of day boundaries crossed between the dates.</returns>
+        public static int DateDiffDay(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+            => (endDate.Date - startDate.Date).Days;
+
+        /// <summary>
+        ///     Counts the number of day boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of day boundaries crossed between the dates.</returns>
+        public static int? DateDiffDay(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffDay(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of day boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of day boundaries crossed between the dates.</returns>
+        public static int DateDiffDay(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => DateDiffDay(_, startDate.UtcDateTime, endDate.UtcDateTime);
+
+        /// <summary>
+        ///     Counts the number of day boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of day boundaries crossed between the dates.</returns>
+        public static int? DateDiffDay(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffDay(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of hour boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of hour boundaries crossed between the dates.</returns>
+        public static int DateDiffHour(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+        {
+            checked
+            {
+                return DateDiffDay(_, startDate, endDate) * 24 + endDate.Hour - startDate.Hour;
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of hour boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of hour boundaries crossed between the dates.</returns>
+        public static int? DateDiffHour(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffHour(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of hour boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of hour boundaries crossed between the dates.</returns>
+        public static int DateDiffHour(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => DateDiffHour(_, startDate.UtcDateTime, endDate.UtcDateTime);
+
+        /// <summary>
+        ///     Counts the number of hour boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of hour boundaries crossed between the dates.</returns>
+        public static int? DateDiffHour(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffHour(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of minute boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of minute boundaries crossed between the dates.</returns>
+        public static int DateDiffMinute(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+        {
+            checked
+            {
+                return DateDiffHour(_, startDate, endDate) * 60 + endDate.Minute - startDate.Minute;
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of minute boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of minute boundaries crossed between the dates.</returns>
+        public static int? DateDiffMinute(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffMinute(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of minute boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of minute boundaries crossed between the dates.</returns>
+        public static int DateDiffMinute(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => DateDiffMinute(_, startDate.UtcDateTime, endDate.UtcDateTime);
+
+        /// <summary>
+        ///     Counts the number of minute boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of minute boundaries crossed between the dates.</returns>
+        public static int? DateDiffMinute(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffMinute(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of second boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of second boundaries crossed between the dates.</returns>
+        public static int DateDiffSecond(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+        {
+            checked
+            {
+                return DateDiffMinute(_, startDate, endDate) * 60 + endDate.Second - startDate.Second;
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of second boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of second boundaries crossed between the dates.</returns>
+        public static int? DateDiffSecond(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffSecond(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of second boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of second boundaries crossed between the dates.</returns>
+        public static int DateDiffSecond(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => DateDiffSecond(_, startDate.UtcDateTime, endDate.UtcDateTime);
+
+        /// <summary>
+        ///     Counts the number of second boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of second boundaries crossed between the dates.</returns>
+        public static int? DateDiffSecond(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffSecond(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of microsecond boundaries crossed between the dates.</returns>
+        public static int DateDiffMicrosecond(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+        {
+            checked
+            {
+                return (int)((endDate.Ticks - startDate.Ticks) / 10);
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of microsecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffMicrosecond(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffMicrosecond(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of microsecond boundaries crossed between the dates.</returns>
+        public static int DateDiffMicrosecond(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => DateDiffMicrosecond(_, startDate.UtcDateTime, endDate.UtcDateTime);
+
+        /// <summary>
+        ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of microsecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffMicrosecond(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => (startDate.HasValue && endDate.HasValue)
+                ? (int?)DateDiffMicrosecond(_, startDate.Value, endDate.Value)
+                : null;
+    }
+}

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlCompositeMethodCallTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlCompositeMethodCallTranslator.cs
@@ -32,7 +32,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             new MySqlStringTrimStartTranslator(),
             new MySqlStringTrimTranslator(),
             new MySqlStringIndexOfTranslator(),
-            new MySqlStringPadLeftRightTranslator()
+            new MySqlStringPadLeftRightTranslator(),
+            new MySqlDateDiffTranslator()
         };
 
         /// <summary>

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlDateDiffTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlDateDiffTranslator.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class MySqlDateDiffTranslator : IMethodCallTranslator
+    {
+        private readonly Dictionary<MethodInfo, string> _methodInfoDateDiffMapping
+            = new Dictionary<MethodInfo, string>
+            {
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffYear),
+                        new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
+                    "YEAR"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffYear),
+                        new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }),
+                    "YEAR"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffYear),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }),
+                    "YEAR"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffYear),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "YEAR"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMonth),
+                        new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
+                    "MONTH"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMonth),
+                        new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }),
+                    "MONTH"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMonth),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }),
+                    "MONTH"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMonth),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "MONTH"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffDay),
+                        new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
+                    "DAY"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffDay),
+                        new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }),
+                    "DAY"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffDay),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }),
+                    "DAY"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffDay),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "DAY"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffHour),
+                        new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
+                    "HOUR"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffHour),
+                        new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }),
+                    "HOUR"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffHour),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }),
+                    "HOUR"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffHour),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "HOUR"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMinute),
+                        new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
+                    "MINUTE"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMinute),
+                        new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }),
+                    "MINUTE"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMinute),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }),
+                    "MINUTE"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMinute),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "MINUTE"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffSecond),
+                        new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
+                    "SECOND"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffSecond),
+                        new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }),
+                    "SECOND"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffSecond),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }),
+                    "SECOND"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffSecond),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "SECOND"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond),
+                        new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
+                    "MICROSECOND"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond),
+                        new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }),
+                    "MICROSECOND"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }),
+                    "MICROSECOND"
+                },
+                {
+                    typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond),
+                        new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "MICROSECOND"
+                }
+            };
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            Check.NotNull(methodCallExpression, nameof(methodCallExpression));
+
+            return _methodInfoDateDiffMapping.TryGetValue(methodCallExpression.Method, out var unit)
+                ? new SqlFunctionExpression(
+                    functionName: "TIMESTAMPDIFF",
+                    returnType: methodCallExpression.Type,
+                    arguments: new[] { new SqlFragmentExpression(unit), methodCallExpression.Arguments[1], methodCallExpression.Arguments[2] })
+                : null;
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/DbFunctionsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/DbFunctionsMySqlTest.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
@@ -11,5 +16,120 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
         }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Year()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffYear(c.OrderDate, DateTime.Now) == 0);
+
+                Assert.Equal(0, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `c`
+WHERE TIMESTAMPDIFF(YEAR, `c`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Month()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffMonth(c.OrderDate, DateTime.Now) == 0);
+
+                Assert.Equal(0, count);
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `c`
+WHERE TIMESTAMPDIFF(MONTH, `c`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Day()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffDay(c.OrderDate, DateTime.Now) == 0);
+
+                Assert.Equal(0, count);
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `c`
+WHERE TIMESTAMPDIFF(DAY, `c`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Hour()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffHour(c.OrderDate, DateTime.Now) == 0);
+
+                Assert.Equal(0, count);
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `c`
+WHERE TIMESTAMPDIFF(HOUR, `c`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Minute()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffMinute(c.OrderDate, DateTime.Now) == 0);
+
+                Assert.Equal(0, count);
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `c`
+WHERE TIMESTAMPDIFF(MINUTE, `c`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Second()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffSecond(c.OrderDate, DateTime.Now) == 0);
+
+                Assert.Equal(0, count);
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `c`
+WHERE TIMESTAMPDIFF(SECOND, `c`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Microsecond()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffMicrosecond(DateTime.Now, DateTime.Now.AddSeconds(1)) == 0);
+
+                Assert.Equal(0, count);
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `c`
+WHERE TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL 1.0 second)) = 0");
+            }
+        }
+
+        private void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }


### PR DESCRIPTION
Hi, 

MySqlDbFunctionsExtensions has been implemented in this pull request. There is only one difference between this implementation and SqlServerDbFunctionsExtensions, which is:

MySql doesn't support NANOSECOND output in TIMESTAMPDIFF function so i removed `DateDiffNanosecond`.

Resolves the issue #747 