### PR TITLE
Fix datetimeoffset identity column

### DIFF
--- a/src/EFCore.MySql/Metadata/MySqlPropertyAnnotations.cs
+++ b/src/EFCore.MySql/Metadata/MySqlPropertyAnnotations.cs
@@ -344,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             var type = property.ClrType;
 
-            return (type.IsInteger() || type == typeof(decimal) || type == typeof(DateTime)) && !HasConverter(property);
+            return (type.IsInteger() || type == typeof(decimal) || type == typeof(DateTime) || type == typeof(DateTimeOffset)) && !HasConverter(property);
         }
 
         private static bool IsCompatibleComputedColumn(IProperty property)

--- a/src/EFCore.MySql/Properties/MySqlStrings.resx
+++ b/src/EFCore.MySql/Properties/MySqlStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="IdentityBadType" xml:space="preserve">
-    <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer and DateTime properties.</value>
+    <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer, DateTime, and DateTimeOffset properties.</value>
   </data>
   <data name="UnqualifiedDataType" xml:space="preserve">
     <value>Data type '{dataType}' is not supported in this form. Either specify the length explicitly in the type name, for example as '{dataType}(16)', or remove the data type and use APIs such as HasMaxLength to allow EF choose the data type.</value>


### PR DESCRIPTION
Trivial fix for https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/799

This allows the `DateTimeOffset` columns to function with `ValueGeneratedOnAdd()`, `ValueGeneratedOnAddOrUpdate()`, and `[DatabaseGenerated(DatabaseGeneratedOption.Identity)]`, in exactly the same way that `DateTime` does.