### PR TITLE
Potential fix for issue-801

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -912,7 +912,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var autoIncrement = false;
             if ((identity || valueGenerationStrategy == MySqlValueGenerationStrategy.IdentityColumn) &&
-                string.IsNullOrWhiteSpace(defaultValueSql) && defaultValue == null)
+                string.IsNullOrWhiteSpace(defaultValueSql) && defaultValue == clrType.GetDefaultValue())
             {
                 switch (matchType)
                 {


### PR DESCRIPTION
https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/801

Use IdentityColumn value generation if default value is the clrType default, instead of just null (which only works for reference types)

Effectively this allows the `.Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn)` annotation to override the `defaultValue` parameter if that default value is equal to the default value for the CLR type. This means that any column which maps to a struct CLR type can use `MySqlValueGenerationStrategy.IdentityColumn`.

However, this might be a bit of a kludge. Ideally, the migration `migrationBuilder.AddColumn()` generated would have `defaultValue` set to `null` in this case, avoiding the need for this kludge. However I'm unsure of the changes required to make that happen.
