### PR TITLE
Allow mappings from plugins to be used

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -255,8 +255,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
-            => FindRawMapping(mappingInfo)?.Clone(mappingInfo);
+        protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo) =>
+            // first, try any plugins, allowing them to override built-in mappings
+            base.FindMapping(mappingInfo) ??
+            FindRawMapping(mappingInfo)?.Clone(mappingInfo);
 
         private RelationalTypeMapping FindRawMapping(RelationalTypeMappingInfo mappingInfo)
         {


### PR DESCRIPTION
This cherry-picks a fix I made to the `2.2.1` branch that hasn't officially shipped yet.