### PR TITLE
Fix issues from latest Like PR

### DIFF
--- a/src/EFCore.MySql/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/MySqlDbFunctionsExtensions.cs
@@ -504,31 +504,15 @@ namespace Microsoft.EntityFrameworkCore
 
         private static bool LikeCore<T>(T matchExpression, string pattern, string escapeCharacter)
         {
-            if (matchExpression == null)
-            {
-                return false;
-            }
-
             if (matchExpression is IConvertible convertible)
             {
-                return Like(EF.Functions, convertible.ToString(CultureInfo.InvariantCulture), pattern, escapeCharacter);
+                return EF.Functions.Like(convertible.ToString(CultureInfo.InvariantCulture), pattern, escapeCharacter);
             }
 
-            if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
+            if (matchExpression is byte[] byteArray)
             {
-                var genericArgument = typeof(T).GetGenericArguments().First();
-                var value = Convert.ChangeType(matchExpression, genericArgument);
-
-                return LikeCore(value, pattern, escapeCharacter);
-            }
-
-            if (typeof(T) == typeof(byte[]))
-            {
-                var value = (string)BitConverter.ToString((dynamic)matchExpression);
-                if (!string.IsNullOrEmpty(value))
-                {
-                    return EF.Functions.Like(value.Replace("-", ""), pattern, escapeCharacter);
-                }
+                var value = BitConverter.ToString(byteArray);
+                return EF.Functions.Like(value.Replace("-", string.Empty), pattern, escapeCharacter);
             }
 
             return false;


### PR DESCRIPTION
The merge from PR #806 lets the test runner crash, because of an unintended recursion in the client evaluation test code, that leads to a stack overflow.

This fixes that and other problems.

The `Nullable<>` checks can be dropped because `Nullable<>` casts implicitly to its underlying type and will therefore cast to `IConvertible`, if implemented by the underlying type.

All related tests are green.