### PR TITLE
Fix DateTimeOffset handling

### DIFF
--- a/src/EFCore.MySql/Query/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQuerySqlGenerator.cs
@@ -20,6 +20,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
     /// </summary>
     public class MySqlQuerySqlGenerator : QuerySqlGenerator
     {
+        // The order in which the types are specified matters, because types get matched by using StartsWith.
         private static readonly Dictionary<string, string[]> _castMappings = new Dictionary<string, string[]>
         {
             { "signed", new []{ "tinyint", "smallint", "mediumint", "int", "bigint", "bit" }},
@@ -27,8 +28,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             { "double", new []{ "double" } },
             { "float", new []{ "float" } },
             { "binary", new []{ "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob" } },
+            { "datetime(6)", new []{ "datetime(6)" } },
             { "datetime", new []{ "datetime" } },
             { "date", new []{ "date" } },
+            { "timestamp(6)", new []{ "timestamp(6)" } },
+            { "timestamp", new []{ "timestamp" } },
+            { "time(6)", new []{ "time(6)" } },
             { "time", new []{ "time" } },
             { "json", new []{ "json" } },
             { "char", new []{ "char", "varchar", "text", "tinytext", "mediumtext", "longtext" } },
@@ -150,10 +155,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             }
 
             var typeMapping = sqlUnaryExpression.TypeMapping;
-
-            //
-            // TODO: Build better mappings with TypeMappingSource.
-            //
 
             var storeTypeLower = typeMapping.StoreType.ToLower();
             string castMapping = null;

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTimeOffsetTypeMapping.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Globalization;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -18,8 +19,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     /// </summary>
     public class MySqlDateTimeOffsetTypeMapping : DateTimeOffsetTypeMapping
     {
-        private const string DateTimeOffsetFormatConst6 = @"'{0:yyyy-MM-dd HH\:mm\:ss.ffffff}'";
-        private const string DateTimeOffsetFormatConst = @"'{0:yyyy-MM-dd HH\:mm\:ss}'";
+        private const string DateTimeOffsetFormatConst6 = @"yyyy-MM-dd HH\:mm\:ss.ffffff";
+        private const string DateTimeOffsetFormatConst = @"yyyy-MM-dd HH\:mm\:ss";
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -57,11 +58,24 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new MySqlDateTimeOffsetTypeMapping(parameters);
 
+        public override string GenerateProviderValueSqlLiteral([CanBeNull] object value)
+            => value == null
+                ? "NULL"
+                : GenerateNonNullSqlLiteral(
+                    value is DateTimeOffset dateTimeOffset
+                        ? dateTimeOffset.UtcDateTime
+                        : value);
+
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.
         /// </summary>
         protected override string SqlLiteralFormatString
-            => Parameters.Precision == null ? DateTimeOffsetFormatConst : DateTimeOffsetFormatConst6;
+            => "'{0:" + GetFormatString() + "}'";
+
+        public string GetFormatString() =>
+            Parameters.Precision == null
+                ? DateTimeOffsetFormatConst
+                : DateTimeOffsetFormatConst6;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
@@ -1,6 +1,12 @@
+using System;
 using System.Threading.Tasks;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Extensions;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using Xunit;
 using Xunit.Abstractions;
@@ -9,165 +15,362 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 {
     public class GearsOfWarQueryMySqlTest : GearsOfWarQueryTestBase<GearsOfWarQueryMySqlFixture>
     {
+        private readonly MySqlTypeMappingSource _typeMappingSource;
+
         public GearsOfWarQueryMySqlTest(GearsOfWarQueryMySqlFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            using var context = CreateContext();
+            _typeMappingSource = (MySqlTypeMappingSource)context.GetService<IRelationalTypeMappingSource>();
+
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_now(bool isAsync)
         {
-            return base.Where_datetimeoffset_now(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline != DateTimeOffset.Now
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource) != DateTimeOffset.Now
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_utcnow(bool isAsync)
         {
-            return base.Where_datetimeoffset_utcnow(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline != DateTimeOffset.UtcNow
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource) != DateTimeOffset.UtcNow
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_date_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_date_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.Date > new DateTimeOffset().Date
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Date > new DateTimeOffset().SimulateDatabaseRoundtrip(_typeMappingSource).Date
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_year_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_year_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.Year == 2
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Year == 2
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_month_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_month_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.Month == 1
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Month == 1
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_dayofyear_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_dayofyear_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.DayOfYear == 2
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).DayOfYear == 2
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_day_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_day_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.Day == 2
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Day == 2
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_hour_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_hour_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.Hour == 10
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Hour == 10
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_minute_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_minute_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.Minute == 0
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Minute == 0
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_second_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_second_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.Second == 0
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Second == 0
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Where_datetimeoffset_millisecond_component(bool isAsync)
         {
-            return base.Where_datetimeoffset_millisecond_component(isAsync);
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => from m in ms
+                    where m.Timeline.Millisecond == 0
+                    select m,
+                ms => from m in ms
+                    where m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Millisecond == 0
+                    select new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    });
         }
 
-        [ConditionalFact(Skip = "Issue #819")]
-        [MemberData("IsAsyncData")]
+        [ConditionalFact]
         public override void Where_datetimeoffset_milliseconds_parameter_and_constant()
         {
             base.Where_datetimeoffset_milliseconds_parameter_and_constant();
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task DateTimeOffset_DateAdd_AddYears(bool isAsync)
         {
-            return base.DateTimeOffset_DateAdd_AddYears(isAsync);
+            return AssertQueryScalar<Mission>(
+                isAsync,
+                ms => from m in ms
+                    select m.Timeline.AddYears(1));
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task DateTimeOffset_DateAdd_AddMonths(bool isAsync)
         {
-            return base.DateTimeOffset_DateAdd_AddMonths(isAsync);
+            return AssertQueryScalar<Mission>(
+                isAsync,
+                ms => from m in ms
+                    select m.Timeline.AddMonths(1));
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task DateTimeOffset_DateAdd_AddDays(bool isAsync)
         {
-            return base.DateTimeOffset_DateAdd_AddDays(isAsync);
+            return AssertQueryScalar<Mission>(
+                isAsync,
+                ms => from m in ms
+                    select m.Timeline.AddDays(1));
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task DateTimeOffset_DateAdd_AddHours(bool isAsync)
         {
-            return base.DateTimeOffset_DateAdd_AddHours(isAsync);
+            return AssertQueryScalar<Mission>(
+                isAsync,
+                ms => from m in ms
+                    select m.Timeline.AddHours(1));
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task DateTimeOffset_DateAdd_AddMinutes(bool isAsync)
         {
-            return base.DateTimeOffset_DateAdd_AddMinutes(isAsync);
+            return AssertQueryScalar<Mission>(
+                isAsync,
+                ms => from m in ms
+                    select m.Timeline.AddMinutes(1));
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task DateTimeOffset_DateAdd_AddSeconds(bool isAsync)
         {
-            return base.DateTimeOffset_DateAdd_AddSeconds(isAsync);
+            return AssertQueryScalar<Mission>(
+                isAsync,
+                ms => from m in ms
+                    select m.Timeline.AddSeconds(1));
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task DateTimeOffset_DateAdd_AddMilliseconds(bool isAsync)
         {
-            return base.DateTimeOffset_DateAdd_AddMilliseconds(isAsync);
+            return AssertQueryScalar<Mission>(
+                isAsync,
+                ms => from m in ms
+                    select m.Timeline.AddMilliseconds(300));
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task Time_of_day_datetimeoffset(bool isAsync)
         {
-            return base.Time_of_day_datetimeoffset(isAsync);
+            return AssertQueryScalar<Mission, TimeSpan>(
+                isAsync,
+                ms => from m in ms
+                    select m.Timeline.TimeOfDay,
+                ms => from m in ms
+                    select m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).TimeOfDay);
         }
 
-        [ConditionalTheory(Skip = "Issue #819")]
-        [MemberData("IsAsyncData")]
-        public override Task GetValueOrDefault_on_DateTimeOffset(bool isAsync)
-        {
-            return base.GetValueOrDefault_on_DateTimeOffset(isAsync);
-        }
-
-        [ConditionalTheory(Skip = "Issue #819")]
+        [ConditionalTheory]
         [MemberData("IsAsyncData")]
         public override Task DateTimeOffset_Contains_Less_than_Greater_than(bool isAsync)
         {
-            return base.DateTimeOffset_Contains_Less_than_Greater_than(isAsync);
+            var dto = new DateTimeOffset(599898024001234567, new TimeSpan(1, 30, 0));
+            var start = dto.AddDays(-1);
+            var end = dto.AddDays(1);
+            var dates = new DateTimeOffset[] { dto };
+
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => ms.Where(m => start <= m.Timeline.Date &&
+                                    m.Timeline < end &&
+                                    dates.Contains(m.Timeline)),
+                ms => ms.Where(m => start.SimulateDatabaseRoundtrip(_typeMappingSource) <= m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource).Date &&
+                                    m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource) < end.SimulateDatabaseRoundtrip(_typeMappingSource) &&
+                                    dates.Select(d => d.SimulateDatabaseRoundtrip(_typeMappingSource)).Contains(m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource)))
+                    .Select(m => new Mission()
+                    {
+                        Id = m.Id,
+                        CodeName = m.CodeName,
+                        Rating = m.Rating,
+                        Timeline = m.Timeline.SimulateDatabaseRoundtrip(_typeMappingSource),
+                        ParticipatingSquads = m.ParticipatingSquads,
+                    }));
         }
 
         [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString)]
@@ -247,18 +450,28 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             return base.Select_subquery_boolean_with_pushdown(isAsync);
         }
 
-        [ConditionalTheory(Skip = "MySQL does not support LIMIT with a parameterized argument, unless the statement was prepared. The argument needs to be a numeric constant")]
+        [ConditionalTheory(Skip = "MySQL does not support LIMIT with a parameterized argument, unless the statement was prepared. The argument needs to be a numeric constant.")]
         [MemberData(nameof(IsAsyncData))]
         public override Task Take_without_orderby_followed_by_orderBy_is_pushed_down1(bool isAsync)
         {
             return base.Take_without_orderby_followed_by_orderBy_is_pushed_down1(isAsync);
         }
 
-        [ConditionalTheory(Skip = "MySQL does not support LIMIT with a parameterized argument, unless the statement was prepared. The argument needs to be a numeric constant")]
+        [ConditionalTheory(Skip = "MySQL does not support LIMIT with a parameterized argument, unless the statement was prepared. The argument needs to be a numeric constant.")]
         [MemberData(nameof(IsAsyncData))]
         public override Task Take_without_orderby_followed_by_orderBy_is_pushed_down2(bool isAsync)
         {
             return base.Take_without_orderby_followed_by_orderBy_is_pushed_down2(isAsync);
         }
+
+        public Task AssertQueryScalar<TItem>(bool isAsync,
+            Func<IQueryable<TItem>, IQueryable<DateTimeOffset>> query,
+            bool assertOrder = false)
+            where TItem : class
+            => AssertQueryScalar(
+                isAsync,
+                query,
+                ms => query(ms).Select(d => d.SimulateDatabaseRoundtrip(_typeMappingSource)),
+                assertOrder);
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Extensions/MySqlTestDateTimeOffsetExtensions.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Extensions/MySqlTestDateTimeOffsetExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.EntityFrameworkCore.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Extensions
+{
+    public static class MySqlTestDateTimeOffsetExtensions
+    {
+        public static DateTimeOffset SimulateDatabaseRoundtrip(this DateTimeOffset dateTimeOffset, MySqlTypeMappingSource typeMappingSource)
+        {
+            var dateTimeOffsetTypeMapping = (MySqlDateTimeOffsetTypeMapping)typeMappingSource.GetMappingForValue(dateTimeOffset);
+            var value = DateTimeOffset.ParseExact(
+                dateTimeOffsetTypeMapping.GenerateSqlLiteral(dateTimeOffset)
+                    .Trim('\''),
+                dateTimeOffsetTypeMapping.GetFormatString(),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal);
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Fix `DateTimeOffset` handling by calling `DateTimeOffset.UtcDateTime` for literals. Parameters are already handled in the same way by MySqlConnector.

Fixes #819 