### PR TITLE
Update further MySQL 5.7 tests and support matching MariaDB features

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersion.Support.cs
@@ -76,7 +76,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         /// referenced by the provided version strings and/or support keys.
         /// </summary>
         /// <param name="supportKeysOrVersionStrings">A mix of server version strings and/or support keys.</param>
-        /// <returns></returns>
+        /// <returns>Returns the constructed <see cref="ServerVersionSupport"/> object.</returns>
         /// <remarks>Used by test attributes. Provider code should use the `Supports` instance methods instead.</remarks>
         public static ServerVersionSupport GetSupport(params string[] supportKeysOrVersionStrings)
             => new ServerVersionSupport(supportKeysOrVersionStrings

--- a/src/EFCore.MySql/Storage/Internal/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersion.Support.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
+{
+    public partial class ServerVersion
+    {
+        #region Individual version strings for tests
+
+        public const string DateTime6MySqlSupportVersionString = "5.6.0-mysql";
+        public const string DateTime6MariaDbSupportVersionString = "10.1.2-mariadb";
+
+        public const string RenameIndexMySqlSupportVersionString = "5.7.0-mysql";
+        // public const string RenameIndexMariaDbSupportVersionString = "?.?.?-mariadb";
+
+        public const string RenameColumnMySqlSupportVersionString = "8.0.0-mysql";
+        // public const string RenameColumnMariaDbSupportVersionString = "?.?.?-mariadb";
+
+        public const string WindowFunctionsMySqlSupportVersionString = "8.0.0-mysql";
+        public const string WindowFunctionsMariaDbSupportVersionString = "10.2.0-mariadb";
+
+        public const string OuterApplyMySqlSupportVersionString = "8.0.14-mysql";
+        // public const string OuterApplyMariaDbSupportVersionString = "?.?.?-mariadb"; // MDEV-19078, MDEV-6373
+
+        public const string CrossApplyMySqlSupportVersionString = "8.0.14-mysql";
+        // public const string CrossApplyMariaDbSupportVersionString = "?.?.?-mariadb"; // MDEV-19078, MDEV-6373
+
+        public const string FloatCastMySqlSupportVersionString = "8.0.17-mysql";
+        public const string FloatCastMariaDbSupportVersionString = "10.4.5-mariadb";
+
+        public const string DoubleCastMySqlSupportVersionString = "8.0.17-mysql";
+        public const string DoubleCastMariaDbSupportVersionString = "10.4.0-mariadb";
+
+        #endregion
+
+        #region SupportMap keys for test attributes
+
+        public const string DateTime6SupportKey = nameof(DateTime6SupportKey);
+        public const string RenameIndexSupportKey = nameof(RenameIndexSupportKey);
+        public const string RenameColumnSupportKey = nameof(RenameColumnSupportKey);
+        public const string WindowFunctionsSupportKey = nameof(WindowFunctionsSupportKey);
+        public const string OuterApplySupportKey = nameof(OuterApplySupportKey);
+        public const string CrossApplySupportKey = nameof(CrossApplySupportKey);
+        public const string FloatCastSupportKey = nameof(FloatCastSupportKey);
+        public const string DoubleCastSupportKey = nameof(DoubleCastSupportKey);
+
+        #endregion
+
+        protected static readonly Dictionary<string, ServerVersionSupport> SupportMap = new Dictionary<string, ServerVersionSupport>()
+        {
+            { DateTime6SupportKey, new ServerVersionSupport(DateTime6MySqlSupportVersionString, DateTime6MariaDbSupportVersionString) },
+            { RenameIndexSupportKey, new ServerVersionSupport(RenameIndexMySqlSupportVersionString/*, RenameIndexMariaDbSupportVersionString*/) },
+            { RenameColumnSupportKey, new ServerVersionSupport(RenameColumnMySqlSupportVersionString/*, RenameColumnMariaDbSupportVersionString*/) },
+            { WindowFunctionsSupportKey, new ServerVersionSupport(WindowFunctionsMySqlSupportVersionString, WindowFunctionsMariaDbSupportVersionString) },
+            { OuterApplySupportKey, new ServerVersionSupport(OuterApplyMySqlSupportVersionString/*, OuterApplyMariaDbSupportVersionString*/) },
+            { CrossApplySupportKey, new ServerVersionSupport(CrossApplyMySqlSupportVersionString/*, CrossApplyMariaDbSupportVersionString*/) },
+            { FloatCastSupportKey, new ServerVersionSupport(FloatCastMySqlSupportVersionString, FloatCastMariaDbSupportVersionString) },
+            { DoubleCastSupportKey, new ServerVersionSupport(DoubleCastMySqlSupportVersionString, DoubleCastMariaDbSupportVersionString) },
+        };
+
+        #region Support checks for provider code
+
+        public bool SupportsDateTime6 => SupportMap[DateTime6SupportKey].IsSupported(this);
+        public bool SupportsRenameIndex => SupportMap[RenameIndexSupportKey].IsSupported(this);
+        public bool SupportsRenameColumn => SupportMap[RenameColumnSupportKey].IsSupported(this);
+        public bool SupportsWindowFunctions => SupportMap[WindowFunctionsSupportKey].IsSupported(this);
+        public bool SupportsFloatCast => SupportMap[FloatCastSupportKey].IsSupported(this);
+        public bool SupportsDoubleCast => SupportMap[DoubleCastSupportKey].IsSupported(this);
+        public bool SupportsOuterApply => SupportMap[OuterApplySupportKey].IsSupported(this);
+        public bool SupportsCrossApply => SupportMap[CrossApplySupportKey].IsSupported(this);
+
+        #endregion
+
+        /// <summary>
+        /// Constructs a new <see cref="ServerVersionSupport"/> object containing the <see cref="ServerVersion"/> objects
+        /// referenced by the provided version strings and/or support keys.
+        /// </summary>
+        /// <param name="supportKeysOrVersionStrings">A mix of server version strings and/or support keys.</param>
+        /// <returns></returns>
+        /// <remarks>Used by test attributes. Provider code should use the `Supports` instance methods instead.</remarks>
+        public static ServerVersionSupport GetSupport(params string[] supportKeysOrVersionStrings)
+            => new ServerVersionSupport(supportKeysOrVersionStrings
+                .SelectMany(s => SupportMap.ContainsKey(s) ? SupportMap[s].SupportedServerVersions : new[] { new ServerVersion(s) })
+                .ToArray());
+    }
+}

--- a/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
@@ -7,7 +7,7 @@ using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {
-    public class ServerVersion
+    public partial class ServerVersion
     {
         public static Regex ReVersion = new Regex(@"\d+\.\d+\.?(?:\d+)?");
         private static readonly Version _defaultVersion = new Version(8, 0, 0);
@@ -44,34 +44,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         public readonly ServerType Type;
         public readonly Version Version;
-
-        public bool SupportsDateTime6 => DateTime6VersionSupport.IsSupported(this);
-        public bool SupportsRenameIndex => RenameIndexVersionSupport.IsSupported(this);
-        public bool SupportsRenameColumn => RenameColumnVersionSupport.IsSupported(this);
-        public bool SupportsWindowFunctions => WindowFunctionsVersionSupport.IsSupported(this);
-        public bool SupportsFloatCast => FloatCastVersionSupport.IsSupported(this);
-        public bool SupportsDoubleCast => DoubleCastVersionSupport.IsSupported(this);
-        public bool SupportsOuterApply => OuterApplyVersionSupport.IsSupported(this);
-        public bool SupportsCrossApply => CrossApplyVersionSupport.IsSupported(this);
-
-        public static readonly ServerVersionSupport DateTime6VersionSupport = new ServerVersionSupport(new ServerVersion(DateTime6MySqlSupportVersionString), new ServerVersion(DateTime6MariaDbSupportVersionString));
-        public static readonly ServerVersionSupport RenameIndexVersionSupport = new ServerVersionSupport(new ServerVersion(RenameIndexMySqlSupportVersionString));
-        public static readonly ServerVersionSupport RenameColumnVersionSupport = new ServerVersionSupport(new ServerVersion(RenameColumnMySqlSupportVersionString));
-        public static readonly ServerVersionSupport WindowFunctionsVersionSupport = new ServerVersionSupport(new ServerVersion(WindowFunctionsMySqlSupportVersionString));
-        public static readonly ServerVersionSupport OuterApplyVersionSupport = new ServerVersionSupport(new ServerVersion(OuterApplyMySqlSupportVersionString));
-        public static readonly ServerVersionSupport CrossApplyVersionSupport = new ServerVersionSupport(new ServerVersion(CrossApplyMySqlSupportVersionString));
-        public static readonly ServerVersionSupport FloatCastVersionSupport = new ServerVersionSupport(new ServerVersion(FloatCastMySqlSupportVersionString));
-        public static readonly ServerVersionSupport DoubleCastVersionSupport = new ServerVersionSupport(new ServerVersion(DoubleCastMySqlSupportVersionString));
-
-        public const string DateTime6MySqlSupportVersionString = "5.6.0-mysql";
-        public const string DateTime6MariaDbSupportVersionString = "10.1.2-mariadb";
-        public const string RenameIndexMySqlSupportVersionString = "5.7.0-mysql";
-        public const string RenameColumnMySqlSupportVersionString = "8.0.0-mysql";
-        public const string WindowFunctionsMySqlSupportVersionString = "8.0.0-mysql";
-        public const string OuterApplyMySqlSupportVersionString = "8.0.14-mysql";
-        public const string CrossApplyMySqlSupportVersionString = "8.0.14-mysql";
-        public const string FloatCastMySqlSupportVersionString = "8.0.17-mysql";
-        public const string DoubleCastMySqlSupportVersionString = "8.0.17-mysql";
 
         public int IndexMaxBytes =>
             (Type == ServerType.MySql && Version >= new Version(5, 7, 7))

--- a/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
@@ -48,27 +47,31 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         public bool SupportsDateTime6 => DateTime6VersionSupport.IsSupported(this);
         public bool SupportsRenameIndex => RenameIndexVersionSupport.IsSupported(this);
+        public bool SupportsRenameColumn => RenameColumnVersionSupport.IsSupported(this);
+        public bool SupportsWindowFunctions => WindowFunctionsVersionSupport.IsSupported(this);
         public bool SupportsFloatCast => FloatCastVersionSupport.IsSupported(this);
         public bool SupportsDoubleCast => DoubleCastVersionSupport.IsSupported(this);
         public bool SupportsOuterApply => OuterApplyVersionSupport.IsSupported(this);
         public bool SupportsCrossApply => CrossApplyVersionSupport.IsSupported(this);
-        public bool SupportsRenameColumn => RenameColumnVersionSupport.IsSupported(this);
 
-        protected static readonly ServerVersionSupport DateTime6VersionSupport = new ServerVersionSupport(new ServerVersion(DateTime6SupportVersionString));
-        protected static readonly ServerVersionSupport RenameIndexVersionSupport = new ServerVersionSupport(new ServerVersion(RenameIndexSupportVersionString));
-        protected static readonly ServerVersionSupport RenameColumnVersionSupport = new ServerVersionSupport(new ServerVersion(RenameColumnSupportVersionString));
-        protected static readonly ServerVersionSupport OuterApplyVersionSupport = new ServerVersionSupport(new ServerVersion(OuterApplySupportVersionString));
-        protected static readonly ServerVersionSupport CrossApplyVersionSupport = new ServerVersionSupport(new ServerVersion(CrossApplySupportVersionString));
-        protected static readonly ServerVersionSupport FloatCastVersionSupport = new ServerVersionSupport(new ServerVersion(FloatCastSupportVersionString));
-        protected static readonly ServerVersionSupport DoubleCastVersionSupport = new ServerVersionSupport(new ServerVersion(DoubleCastSupportVersionString));
+        public static readonly ServerVersionSupport DateTime6VersionSupport = new ServerVersionSupport(new ServerVersion(DateTime6MySqlSupportVersionString), new ServerVersion(DateTime6MariaDbSupportVersionString));
+        public static readonly ServerVersionSupport RenameIndexVersionSupport = new ServerVersionSupport(new ServerVersion(RenameIndexMySqlSupportVersionString));
+        public static readonly ServerVersionSupport RenameColumnVersionSupport = new ServerVersionSupport(new ServerVersion(RenameColumnMySqlSupportVersionString));
+        public static readonly ServerVersionSupport WindowFunctionsVersionSupport = new ServerVersionSupport(new ServerVersion(WindowFunctionsMySqlSupportVersionString));
+        public static readonly ServerVersionSupport OuterApplyVersionSupport = new ServerVersionSupport(new ServerVersion(OuterApplyMySqlSupportVersionString));
+        public static readonly ServerVersionSupport CrossApplyVersionSupport = new ServerVersionSupport(new ServerVersion(CrossApplyMySqlSupportVersionString));
+        public static readonly ServerVersionSupport FloatCastVersionSupport = new ServerVersionSupport(new ServerVersion(FloatCastMySqlSupportVersionString));
+        public static readonly ServerVersionSupport DoubleCastVersionSupport = new ServerVersionSupport(new ServerVersion(DoubleCastMySqlSupportVersionString));
 
-        public const string DateTime6SupportVersionString = "5.6.0-mysql";
-        public const string RenameIndexSupportVersionString = "5.7.0-mysql";
-        public const string RenameColumnSupportVersionString = "8.0.0-mysql";
-        public const string OuterApplySupportVersionString = "8.0.14-mysql";
-        public const string CrossApplySupportVersionString = "8.0.14-mysql";
-        public const string FloatCastSupportVersionString = "8.0.17-mysql";
-        public const string DoubleCastSupportVersionString = "8.0.17-mysql";
+        public const string DateTime6MySqlSupportVersionString = "5.6.0-mysql";
+        public const string DateTime6MariaDbSupportVersionString = "10.1.2-mariadb";
+        public const string RenameIndexMySqlSupportVersionString = "5.7.0-mysql";
+        public const string RenameColumnMySqlSupportVersionString = "8.0.0-mysql";
+        public const string WindowFunctionsMySqlSupportVersionString = "8.0.0-mysql";
+        public const string OuterApplyMySqlSupportVersionString = "8.0.14-mysql";
+        public const string CrossApplyMySqlSupportVersionString = "8.0.14-mysql";
+        public const string FloatCastMySqlSupportVersionString = "8.0.17-mysql";
+        public const string DoubleCastMySqlSupportVersionString = "8.0.17-mysql";
 
         public int IndexMaxBytes =>
             (Type == ServerType.MySql && Version >= new Version(5, 7, 7))
@@ -87,25 +90,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         public override int GetHashCode()
             => (Version.GetHashCode() * 397) ^ Type.GetHashCode();
-        
-        protected class ServerVersionSupport
-        {
-            public ServerVersion[] SupportedServerVersions { get; }
 
-            public ServerVersionSupport(params ServerVersion[] supportedServerVersions)
-            {
-                SupportedServerVersions = supportedServerVersions;
-            }
-
-            public bool IsSupported(ServerVersion serverVersion)
-            {
-                if (SupportedServerVersions.Length <= 0)
-                {
-                    return false;
-                }
-
-                return SupportedServerVersions.Any(s => serverVersion.Type == s.Type && serverVersion.Version >= s.Version);
-            }
-        }
+        public override string ToString()
+            => Version + "-" + (Type == ServerType.MariaDb ? "mariadb" : "mysql");
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/ServerVersionSupport.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersionSupport.cs
@@ -2,7 +2,7 @@ using System.Linq;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {
-    public class ServerVersionSupport
+    public partial class ServerVersionSupport
     {
         public ServerVersion[] SupportedServerVersions { get; }
 

--- a/src/EFCore.MySql/Storage/Internal/ServerVersionSupport.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersionSupport.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
+{
+    public class ServerVersionSupport
+    {
+        public ServerVersion[] SupportedServerVersions { get; }
+
+        public ServerVersionSupport(params string[] supportedServerVersions)
+            : this(supportedServerVersions.Select(s => new ServerVersion(s)).ToArray())
+        {
+        }
+
+        public ServerVersionSupport(params ServerVersion[] supportedServerVersions)
+        {
+            SupportedServerVersions = supportedServerVersions;
+        }
+
+        public bool IsSupported(ServerVersion serverVersion)
+        {
+            if (SupportedServerVersions.Length <= 0)
+            {
+                return false;
+            }
+
+            return SupportedServerVersions.Any(s => serverVersion.Type == s.Type && serverVersion.Version >= s.Version);
+        }
+
+        public override string ToString()
+            => string.Join(", ", SupportedServerVersions.Select(s => s.ToString()));
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsQueryMySqlTest.cs
@@ -1,5 +1,9 @@
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
@@ -11,6 +15,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsMySqlSupportVersionString)]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(isAsync);
         }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsQueryMySqlTest.cs
@@ -17,7 +17,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsSupportKey)]
         [MemberData(nameof(IsAsyncData))]
         public override Task SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(bool isAsync)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsWeakQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsWeakQueryMySqlTest.cs
@@ -1,5 +1,9 @@
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
@@ -11,6 +15,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsMySqlSupportVersionString)]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(isAsync);
         }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsWeakQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsWeakQueryMySqlTest.cs
@@ -17,7 +17,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsSupportKey)]
         [MemberData(nameof(IsAsyncData))]
         public override Task SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(bool isAsync)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
@@ -373,42 +373,42 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                     }));
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool isAsync)
         {
             return base.Correlated_collections_inner_subquery_predicate_references_outer_qsre(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool isAsync)
         {
             return base.Correlated_collections_inner_subquery_selector_references_outer_qsre(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
         [MemberData("IsAsyncData")]
         public override Task Outer_parameter_in_join_key_inner_and_outer(bool isAsync)
         {
             return base.Outer_parameter_in_join_key_inner_and_outer(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
         [MemberData("IsAsyncData")]
         public override Task Outer_parameter_in_group_join_with_DefaultIfEmpty(bool isAsync)
         {
             return base.Outer_parameter_in_group_join_with_DefaultIfEmpty(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
         [MemberData("IsAsyncData")]
         public override Task Outer_parameter_in_join_key(bool isAsync)
         {
             return base.Outer_parameter_in_join_key(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task Correlated_collections_nested_inner_subquery_references_outer_qsre_two_levels_up(bool isAsync)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
@@ -373,42 +373,42 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                     }));
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public override Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool isAsync)
         {
             return base.Correlated_collections_inner_subquery_predicate_references_outer_qsre(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public override Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool isAsync)
         {
             return base.Correlated_collections_inner_subquery_selector_references_outer_qsre(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
         [MemberData("IsAsyncData")]
         public override Task Outer_parameter_in_join_key_inner_and_outer(bool isAsync)
         {
             return base.Outer_parameter_in_join_key_inner_and_outer(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
         [MemberData("IsAsyncData")]
         public override Task Outer_parameter_in_group_join_with_DefaultIfEmpty(bool isAsync)
         {
             return base.Outer_parameter_in_group_join_with_DefaultIfEmpty(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString, Skip = "https://bugs.mysql.com/bug.php?id=96946")]
         [MemberData("IsAsyncData")]
         public override Task Outer_parameter_in_join_key(bool isAsync)
         {
             return base.Outer_parameter_in_join_key(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public override Task Correlated_collections_nested_inner_subquery_references_outer_qsre_two_levels_up(bool isAsync)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.MySql.cs
@@ -1021,14 +1021,14 @@ WHERE (LOCATE(CONVERT(LCASE('nt') USING utf8mb4) COLLATE utf8mb4_bin, LCASE(`c`.
                 });
         }
 
-        [SupportedServerVersionLessThanTheory(ServerVersion.CrossApplySupportVersionString)]
+        [SupportedServerVersionLessThanTheory(ServerVersion.CrossApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public virtual Task CrossApply_not_supported_throws(bool isAsync)
         {
             return Assert.ThrowsAsync<InvalidOperationException>(() => base.SelectMany_correlated_with_outer_1(isAsync));
         }
 
-        [SupportedServerVersionLessThanTheory(ServerVersion.OuterApplySupportVersionString)]
+        [SupportedServerVersionLessThanTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public virtual Task OuterApply_not_supported_throws(bool isAsync)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.MySql.cs
@@ -1021,14 +1021,14 @@ WHERE (LOCATE(CONVERT(LCASE('nt') USING utf8mb4) COLLATE utf8mb4_bin, LCASE(`c`.
                 });
         }
 
-        [SupportedServerVersionLessThanTheory(ServerVersion.CrossApplyMySqlSupportVersionString)]
+        [SupportedServerVersionLessThanTheory(ServerVersion.CrossApplySupportKey)]
         [MemberData("IsAsyncData")]
         public virtual Task CrossApply_not_supported_throws(bool isAsync)
         {
             return Assert.ThrowsAsync<InvalidOperationException>(() => base.SelectMany_correlated_with_outer_1(isAsync));
         }
 
-        [SupportedServerVersionLessThanTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionLessThanTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public virtual Task OuterApply_not_supported_throws(bool isAsync)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
@@ -786,42 +786,42 @@ WHERE `o`.`OrderDate` IS NOT NULL AND (EXTRACT(year FROM `o`.`OrderDate`) < @__n
             return Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_Except_reference_projection(isAsync));
         }
 
-        [SupportedServerVersionTheory(ServerVersion.CrossApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.CrossApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_correlated_with_outer_1(bool isAsync)
         {
             return base.SelectMany_correlated_with_outer_1(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.CrossApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.CrossApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_correlated_with_outer_2(bool isAsync)
         {
             return base.SelectMany_correlated_with_outer_2(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_correlated_with_outer_3(bool isAsync)
         {
             return base.SelectMany_correlated_with_outer_3(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_correlated_with_outer_4(bool isAsync)
         {
             return base.SelectMany_correlated_with_outer_4(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool isAsync)
         {
             return base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(isAsync);
         }
 
-        [SupportedServerVersionFact(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionFact(ServerVersion.OuterApplySupportKey)]
         public override void Select_nested_collection_multi_level()
         {
             base.Select_nested_collection_multi_level();
@@ -836,21 +836,21 @@ WHERE `o`.`OrderDate` IS NOT NULL AND (EXTRACT(year FROM `o`.`OrderDate`) < @__n
             return base.Union_Take_Union_Take(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsSupportKey)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_Joined_Take(bool isAsync)
         {
             return base.SelectMany_Joined_Take(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(bool isAsync)
         {
             return base.Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportKey)]
         [MemberData("IsAsyncData")]
         public override Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(bool isAsync)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
@@ -786,42 +786,42 @@ WHERE `o`.`OrderDate` IS NOT NULL AND (EXTRACT(year FROM `o`.`OrderDate`) < @__n
             return Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_Except_reference_projection(isAsync));
         }
 
-        [SupportedServerVersionTheory(ServerVersion.CrossApplySupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.CrossApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_correlated_with_outer_1(bool isAsync)
         {
             return base.SelectMany_correlated_with_outer_1(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.CrossApplySupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.CrossApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_correlated_with_outer_2(bool isAsync)
         {
             return base.SelectMany_correlated_with_outer_2(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_correlated_with_outer_3(bool isAsync)
         {
             return base.SelectMany_correlated_with_outer_3(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public override Task SelectMany_correlated_with_outer_4(bool isAsync)
         {
             return base.SelectMany_correlated_with_outer_4(isAsync);
         }
 
-        [SupportedServerVersionTheory(ServerVersion.OuterApplySupportVersionString)]
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
         [MemberData("IsAsyncData")]
         public override Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool isAsync)
         {
             return base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(isAsync);
         }
 
-        [SupportedServerVersionFact(ServerVersion.OuterApplySupportVersionString)]
+        [SupportedServerVersionFact(ServerVersion.OuterApplyMySqlSupportVersionString)]
         public override void Select_nested_collection_multi_level()
         {
             base.Select_nested_collection_multi_level();
@@ -834,6 +834,27 @@ WHERE `o`.`OrderDate` IS NOT NULL AND (EXTRACT(year FROM `o`.`OrderDate`) < @__n
             //       To make this work, the SELECT statement containing the ORDER BY and/or LIMIT clause needs to be wrapped by another
             //       SELECT statement.
             return base.Union_Take_Union_Take(isAsync);
+        }
+
+        [SupportedServerVersionTheory(ServerVersion.WindowFunctionsMySqlSupportVersionString)]
+        [MemberData("IsAsyncData")]
+        public override Task SelectMany_Joined_Take(bool isAsync)
+        {
+            return base.SelectMany_Joined_Take(isAsync);
+        }
+
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [MemberData("IsAsyncData")]
+        public override Task Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(bool isAsync)
+        {
+            return base.Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(isAsync);
+        }
+
+        [SupportedServerVersionTheory(ServerVersion.OuterApplyMySqlSupportVersionString)]
+        [MemberData("IsAsyncData")]
+        public override Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(bool isAsync)
+        {
+            return base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(isAsync);
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionFactAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionFactAttribute.cs
@@ -1,28 +1,22 @@
-﻿using System;
-using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+﻿using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes
 {
     public sealed class SupportedServerVersionFactAttribute : FactAttribute
     {
-        public SupportedServerVersionFactAttribute(string version)
-            : this(new ServerVersion(version))
+        public SupportedServerVersionFactAttribute(params string[] versions)
+            : this(new ServerVersionSupport(versions))
         {
         }
 
-        public SupportedServerVersionFactAttribute(Version version)
-            : this(new ServerVersion(version))
-        {
-        }
-
-        private SupportedServerVersionFactAttribute(ServerVersion supportedVersion)
+        private SupportedServerVersionFactAttribute(ServerVersionSupport serverVersionSupport)
         {
             var currentVersion = new ServerVersion(AppConfig.Config.GetSection("Data")["ServerVersion"]);
 
-            if (currentVersion.Version < supportedVersion.Version && string.IsNullOrEmpty(Skip))
+            if (!serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
             {
-                Skip = $"Test is supported only on {supportedVersion.Version} and higher.";
+                Skip = $"Test is supported on {serverVersionSupport.SupportedServerVersions} and higher.";
             }
         }
     }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionFactAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionFactAttribute.cs
@@ -16,7 +16,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attribu
 
             if (!serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
             {
-                Skip = $"Test is supported on {serverVersionSupport.SupportedServerVersions} and higher.";
+                Skip = $"Test is supported only on {serverVersionSupport.SupportedServerVersions} and higher.";
             }
         }
     }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionFactAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionFactAttribute.cs
@@ -5,8 +5,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attribu
 {
     public sealed class SupportedServerVersionFactAttribute : FactAttribute
     {
-        public SupportedServerVersionFactAttribute(params string[] versions)
-            : this(new ServerVersionSupport(versions))
+        public SupportedServerVersionFactAttribute(params string[] versionsOrKeys)
+            : this(ServerVersion.GetSupport(versionsOrKeys))
         {
         }
 

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanTheoryAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanTheoryAttribute.cs
@@ -15,9 +15,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attribu
         {
             var currentVersion = new ServerVersion(AppConfig.Config.GetSection("Data")["ServerVersion"]);
 
-            if (!serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
+            if (serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
             {
-                Skip = $"Test is supported only on versions lower than {serverVersionSupport}.";
+                Skip = $"Test is supported only on server versions lower than {serverVersionSupport}.";
             }
         }
     }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanTheoryAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanTheoryAttribute.cs
@@ -6,23 +6,18 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attribu
 {
     public sealed class SupportedServerVersionLessThanTheoryAttribute : TheoryAttribute
     {
-        public SupportedServerVersionLessThanTheoryAttribute(string version)
-            : this(new ServerVersion(version))
+        public SupportedServerVersionLessThanTheoryAttribute(params string[] versions)
+            : this(new ServerVersionSupport(versions))
         {
         }
 
-        public SupportedServerVersionLessThanTheoryAttribute(Version version)
-            : this(new ServerVersion(version))
-        {
-        }
-
-        private SupportedServerVersionLessThanTheoryAttribute(ServerVersion supportedVersion)
+        private SupportedServerVersionLessThanTheoryAttribute(ServerVersionSupport serverVersionSupport)
         {
             var currentVersion = new ServerVersion(AppConfig.Config.GetSection("Data")["ServerVersion"]);
 
-            if (currentVersion.Version >= supportedVersion.Version && string.IsNullOrEmpty(Skip))
+            if (!serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
             {
-                Skip = $"Test is supported only on server versions lower than {supportedVersion.Version}.";
+                Skip = $"Test is supported only on versions lower than {serverVersionSupport}.";
             }
         }
     }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanTheoryAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanTheoryAttribute.cs
@@ -6,8 +6,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attribu
 {
     public sealed class SupportedServerVersionLessThanTheoryAttribute : TheoryAttribute
     {
-        public SupportedServerVersionLessThanTheoryAttribute(params string[] versions)
-            : this(new ServerVersionSupport(versions))
+        public SupportedServerVersionLessThanTheoryAttribute(params string[] versionsOrKeys)
+            : this(ServerVersion.GetSupport(versionsOrKeys))
         {
         }
 

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionTheoryAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionTheoryAttribute.cs
@@ -5,11 +5,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attribu
 {
     public sealed class SupportedServerVersionTheoryAttribute : TheoryAttribute
     {
-        public SupportedServerVersionTheoryAttribute(params string[] versions)
-            : this(new ServerVersionSupport(versions))
+        public SupportedServerVersionTheoryAttribute(params string[] versionsOrKeys)
+            : this(ServerVersion.GetSupport(versionsOrKeys))
         {
         }
-        
+
         private SupportedServerVersionTheoryAttribute(ServerVersionSupport serverVersionSupport)
         {
             var currentVersion = new ServerVersion(AppConfig.Config.GetSection("Data")["ServerVersion"]);

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionTheoryAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionTheoryAttribute.cs
@@ -1,28 +1,22 @@
-﻿using System;
-using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+﻿using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes
 {
     public sealed class SupportedServerVersionTheoryAttribute : TheoryAttribute
     {
-        public SupportedServerVersionTheoryAttribute(string version)
-            : this(new ServerVersion(version))
+        public SupportedServerVersionTheoryAttribute(params string[] versions)
+            : this(new ServerVersionSupport(versions))
         {
         }
-
-        public SupportedServerVersionTheoryAttribute(Version version)
-            : this(new ServerVersion(version))
-        {
-        }
-
-        private SupportedServerVersionTheoryAttribute(ServerVersion supportedVersion)
+        
+        private SupportedServerVersionTheoryAttribute(ServerVersionSupport serverVersionSupport)
         {
             var currentVersion = new ServerVersion(AppConfig.Config.GetSection("Data")["ServerVersion"]);
 
-            if (currentVersion.Version < supportedVersion.Version && string.IsNullOrEmpty(Skip))
+            if (!serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
             {
-                Skip = $"Test is supported only on {supportedVersion.Version} and higher.";
+                Skip = $"Test is supported on {serverVersionSupport} and higher.";
             }
         }
     }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionTheoryAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionTheoryAttribute.cs
@@ -16,7 +16,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attribu
 
             if (!serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
             {
-                Skip = $"Test is supported on {serverVersionSupport} and higher.";
+                Skip = $"Test is supported only on {serverVersionSupport} and higher.";
             }
         }
     }


### PR DESCRIPTION
Includes the first batch of fixed tests for MySQL 5.7.
Now supports the following implemented features in MariaDB, that were already supported for MySQL:

- `datetime(6)`, `timestamp(6)` and `time(6)` support
- Window functions (like `OVER(PARTITION BY)`)
- `CAST()` as `float`
- `CAST()` as `double`
