### PR TITLE
Implement ServerVersion auto detection feature

### DIFF
--- a/src/EFCore.MySql/Design/Internal/MySqlDesignTimeServices.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlDesignTimeServices.cs
@@ -25,7 +25,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
                 .AddSingleton<IDatabaseModelFactory, MySqlDatabaseModelFactory>()
                 .AddSingleton<IProviderConfigurationCodeGenerator, MySqlCodeGenerator>()
                 .AddSingleton<IAnnotationCodeGenerator, MySqlAnnotationCodeGenerator>()
-                .TryAddSingleton<IMySqlOptions, MySqlOptions>();
+                .AddSingleton<IMySqlOptions, MySqlOptions>()
+                .AddSingleton<IMySqlConnectionInfo, MySqlConnectionInfo>();
         }
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -56,11 +56,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<ISqlExpressionFactory, MySqlSqlExpressionFactory>()
                 .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, MySqlSqlTranslatingExpressionVisitorFactory>()
                 .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, MySqlQueryableMethodTranslatingExpressionVisitorFactory>()
-                .TryAddProviderSpecificServices(
-                b => b
+                .TryAddProviderSpecificServices(m => m
                     .TryAddSingleton<IMySqlOptions, MySqlOptions>()
-                    .TryAddScoped<IMySqlUpdateSqlGenerator, MySqlUpdateSqlGenerator>()
-                    .TryAddScoped<IMySqlRelationalConnection, MySqlRelationalConnection>());
+                    .TryAddSingleton<IMySqlConnectionInfo, MySqlConnectionInfo>()
+                    .TryAddScoped<IMySqlRelationalConnection, MySqlRelationalConnection>()
+                    .TryAddScoped<IMySqlUpdateSqlGenerator, MySqlUpdateSqlGenerator>());
 
             builder.TryAddCoreServices();
 

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -17,6 +17,7 @@ using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Migrations
 {
@@ -29,26 +30,18 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             RegexOptions.IgnoreCase);
 
         private readonly IMigrationsAnnotationProvider _migrationsAnnotations;
+        private readonly IMySqlConnectionInfo _connectionInfo;
 
         private IReadOnlyList<MigrationOperation> _operations;
-
-        private readonly IMySqlOptions _options;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        /// <param name="dependencies"> Parameter object containing dependencies for this service. </param>
-        /// <param name="migrationsAnnotations"> Provider-specific Migrations annotations to use. </param>
-        /// <param name="options">IMySqlOptions</param>
+        
         public MySqlMigrationsSqlGenerator(
             [NotNull] MigrationsSqlGeneratorDependencies dependencies,
             [NotNull] IMigrationsAnnotationProvider migrationsAnnotations,
-            [NotNull] IMySqlOptions options)
+            [NotNull] IMySqlConnectionInfo connectionInfo)
             : base(dependencies)
         {
             _migrationsAnnotations = migrationsAnnotations;
-            _options = options;
+            _connectionInfo = connectionInfo;
         }
 
         /// <summary>
@@ -154,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (operation.NewName != null)
             {
-                if (_options.ServerVersion.SupportsRenameIndex)
+                if (_connectionInfo.ServerVersion.SupportsRenameIndex)
                 {
                     builder.Append("ALTER TABLE ")
                         .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
@@ -513,7 +506,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             builder.Append("ALTER TABLE ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema));
 
-            if (_options.ServerVersion.SupportsRenameColumn)
+            if (_connectionInfo.ServerVersion.SupportsRenameColumn)
             {
                 builder.Append(" RENAME COLUMN ")
                     .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
@@ -730,7 +723,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         autoIncrement = true;
                         break;
                     case "datetime":
-                        if (!_options.ServerVersion.SupportsDateTime6)
+                        if (!_connectionInfo.ServerVersion.SupportsDateTime6)
                         {
                             throw new InvalidOperationException(
                                 $"Error in {table}.{name}: DATETIME does not support values generated " +
@@ -750,7 +743,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 switch (matchType)
                 {
                     case "datetime":
-                        if (!_options.ServerVersion.SupportsDateTime6)
+                        if (!_connectionInfo.ServerVersion.SupportsDateTime6)
                         {
                             throw new InvalidOperationException(
                                 $"Error in {table}.{name}: DATETIME does not support values generated " +

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -796,7 +796,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     .Append(" AS ")
                     .Append($"({operation.ComputedColumnSql})");
 
-                if (operation.IsNullable && _options.ServerVersion.SupportsNullableGeneratedColumns)
+                if (operation.IsNullable && _connectionInfo.ServerVersion.SupportsNullableGeneratedColumns)
                 {
                     builder.Append(" NULL");
                 }

--- a/src/EFCore.MySql/Query/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQuerySqlGenerator.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -42,7 +43,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 
         private const ulong LimitUpperBound = 18446744073709551610;
 
-        private readonly IMySqlOptions _options;
+        private readonly IMySqlConnectionInfo _connectionInfo;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -50,10 +51,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
         /// </summary>
         public MySqlQuerySqlGenerator(
             [NotNull] QuerySqlGeneratorDependencies dependencies,
-            [CanBeNull] IMySqlOptions options)
+            [CanBeNull] IMySqlConnectionInfo connectionInfo)
             : base(dependencies)
         {
-            _options = options;
+            _connectionInfo = connectionInfo;
         }
 
         /// <summary>
@@ -191,13 +192,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 
             var useDecimalToDoubleFloatWorkaround = false;
 
-            if (castMapping.StartsWith("double") && (!_options?.ServerVersion.SupportsDoubleCast ?? false))
+            if (castMapping.StartsWith("double") && !_connectionInfo.ServerVersion.SupportsDoubleCast)
             {
                 useDecimalToDoubleFloatWorkaround = true;
                 castMapping = "decimal(65,30)";
             }
 
-            if (castMapping.StartsWith("float") && (!_options?.ServerVersion.SupportsFloatCast ?? false))
+            if (castMapping.StartsWith("float") && !_connectionInfo.ServerVersion.SupportsFloatCast)
             {
                 useDecimalToDoubleFloatWorkaround = true;
                 castMapping = "decimal(65,30)";

--- a/src/EFCore.MySql/Query/Internal/MySqlQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQuerySqlGeneratorFactory.cs
@@ -3,23 +3,27 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlQuerySqlGeneratorFactory : IQuerySqlGeneratorFactory
     {
         private readonly QuerySqlGeneratorDependencies _dependencies;
-        private readonly IMySqlOptions _options;
+        private readonly IMySqlConnectionInfo _connectionInfo;
 
-        public MySqlQuerySqlGeneratorFactory([NotNull] QuerySqlGeneratorDependencies dependencies, IMySqlOptions options)
+        public MySqlQuerySqlGeneratorFactory(
+            [NotNull] QuerySqlGeneratorDependencies dependencies,
+            IMySqlConnectionInfo connectionInfo)
         {
             _dependencies = dependencies;
-            _options = options;
+            _connectionInfo = connectionInfo;
         }
 
         public virtual QuerySqlGenerator Create()
-            => new MySqlQuerySqlGenerator(_dependencies, _options);
+            => new MySqlQuerySqlGenerator(_dependencies, _connectionInfo);
     }
 }

--- a/src/EFCore.MySql/Query/Internal/MySqlQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQueryableMethodTranslatingExpressionVisitor.cs
@@ -3,22 +3,24 @@ using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlQueryableMethodTranslatingExpressionVisitor : RelationalQueryableMethodTranslatingExpressionVisitor
     {
-        private readonly IMySqlOptions _options;
+        private readonly IMySqlConnectionInfo _connectionInfo;
 
         public MySqlQueryableMethodTranslatingExpressionVisitor(
             QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
             RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies,
-            IMySqlOptions options,
+            IMySqlConnectionInfo connectionInfo,
             IModel model)
             : base(dependencies, relationalDependencies, model)
         {
-            _options = options;
+            _connectionInfo = connectionInfo;
         }
 
         // There is no native support for EXCEPT in MySQL.
@@ -32,8 +34,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             // Trigger client eval, if there is no LATERAL support.
             // TODO: Check why this does not catch all OuterApply statements.
             if (((SelectExpression)source.QueryExpression).Tables
-                .Any(t => t is CrossApplyExpression && !_options.ServerVersion.SupportsCrossApply
-                          || t is OuterApplyExpression && !_options.ServerVersion.SupportsOuterApply))
+                .Any(t => t is CrossApplyExpression && !_connectionInfo.ServerVersion.SupportsCrossApply
+                          || t is OuterApplyExpression && !_connectionInfo.ServerVersion.SupportsOuterApply))
             {
                 return null;
             }

--- a/src/EFCore.MySql/Query/Internal/MySqlQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -8,23 +10,23 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
     {
         private readonly QueryableMethodTranslatingExpressionVisitorDependencies _dependencies;
         private readonly RelationalQueryableMethodTranslatingExpressionVisitorDependencies _relationalDependencies;
-        private readonly IMySqlOptions _options;
+        private readonly IMySqlConnectionInfo _connectionInfo;
 
         public MySqlQueryableMethodTranslatingExpressionVisitorFactory(
             QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
             RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies,
-            IMySqlOptions options)
+            IMySqlConnectionInfo connectionInfo)
         {
             _dependencies = dependencies;
             _relationalDependencies = relationalDependencies;
-            _options = options;
+            _connectionInfo = connectionInfo;
         }
 
         public virtual QueryableMethodTranslatingExpressionVisitor Create(IModel model)
             => new MySqlQueryableMethodTranslatingExpressionVisitor(
                 _dependencies,
                 _relationalDependencies,
-                _options,
+                _connectionInfo,
                 model);
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/IMySqlConnectionInfo.cs
+++ b/src/EFCore.MySql/Storage/Internal/IMySqlConnectionInfo.cs
@@ -1,0 +1,14 @@
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
+{
+    public interface IMySqlConnectionInfo
+    {
+        /// <summary>
+        /// The actual ServerVersion of the connection or IMySqlOptions.ServerVersion,
+        /// if the latter was set explicitly.
+        /// </summary>
+        /// <remarks>If the property is retrieved before the connection was opened, it
+        /// returns the default ServerVersion of IMySqlOptions with the `IsDefault`
+        /// property set to `true`.</remarks>
+        ServerVersion ServerVersion { get; }
+    }
+}

--- a/src/EFCore.MySql/Storage/Internal/MySqlConnectionInfo.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlConnectionInfo.cs
@@ -1,0 +1,28 @@
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
+{
+    public class MySqlConnectionInfo : IMySqlConnectionInfo
+    {
+        private readonly ServerVersion _optionsServerVersion;
+        private ServerVersion _connectionServerVersion;
+
+        public MySqlConnectionInfo(IMySqlOptions options)
+        {
+            _optionsServerVersion = options.ServerVersion;
+        }
+
+        /// <summary>
+        /// The actual ServerVersion of the connection or IMySqlOptions.ServerVersion,
+        /// if the latter was set explicitly.
+        /// </summary>
+        /// <remarks>If the property is retrieved before the connection was opened, it
+        /// returns the default ServerVersion of IMySqlOptions with the `IsDefault`
+        /// property set to `true`.</remarks>
+        public ServerVersion ServerVersion
+        {
+            get => _connectionServerVersion ?? _optionsServerVersion;
+            internal set => _connectionServerVersion = value;
+        }
+    }
+}

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -359,7 +359,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                     var size = mappingInfo.Size ??
                                (mappingInfo.IsKeyOrIndex
                                    // Allow to use at most half of the max key length, so at least 2 columns can fit
-                                   ? Math.Min(_connectionInfo.ServerVersion.IndexMaxBytes / (bytesPerChar * 2), 255)
+                                   ? Math.Min(_connectionInfo.ServerVersion.MaxKeyLength / (bytesPerChar * 2), 255)
                                    : (int?)null);
                     if (size > maxSize)
                     {
@@ -389,7 +389,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                     }
 
                     var size = mappingInfo.Size ??
-                               (mappingInfo.IsKeyOrIndex ? _connectionInfo.ServerVersion.IndexMaxBytes : (int?)null);
+                               (mappingInfo.IsKeyOrIndex ? _connectionInfo.ServerVersion.MaxKeyLength : (int?)null);
 
                     return new MySqlByteArrayTypeMapping(
                         size: size,

--- a/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/Internal/ServerVersion.cs
@@ -33,6 +33,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             else
             {
                 Version = _defaultVersion;
+                IsDefault = true;
             }
         }
 
@@ -42,8 +43,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             Type = type;
         }
 
-        public readonly ServerType Type;
-        public readonly Version Version;
+        public ServerType Type { get; }
+        public Version Version { get; }
+        public bool IsDefault { get; }
 
         public override bool Equals(object obj)
             => !(obj is null)

--- a/test/EFCore.MySql.FunctionalTests/Query/SpatialQueryMySqlFixture.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SpatialQueryMySqlFixture.cs
@@ -50,8 +50,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             public ReplacementTypeMappingSource(
                 TypeMappingSourceDependencies dependencies,
                 RelationalTypeMappingSourceDependencies relationalDependencies,
-                IMySqlOptions options)
-                : base(dependencies, relationalDependencies, options)
+                IMySqlOptions options,
+                IMySqlConnectionInfo connectionInfo)
+                : base(dependencies, relationalDependencies, options, connectionInfo)
             {
             }
 

--- a/test/EFCore.MySql.Tests/Migrations/ModelSnapshotMySqlTest.cs
+++ b/test/EFCore.MySql.Tests/Migrations/ModelSnapshotMySqlTest.cs
@@ -159,7 +159,8 @@ builder.Entity(""Pomelo.EntityFrameworkCore.MySql.Migrations.ModelSnapshotMySqlT
             var typeMappingSource = new MySqlTypeMappingSource(
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>(),
-                new MySqlOptions());
+                TestServiceFactory.Instance.Create<MySqlOptions>(),
+                TestServiceFactory.Instance.Create<MySqlConnectionInfo>());
 
             var modelValidator = CreateModelValidator(typeMappingSource);
             modelValidator.Validate(


### PR DESCRIPTION
The feature is discussed in #832, #156 and https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/842#issuecomment-537097399

This PR introduces the `MySqlConnectionInfo` class that implements the `IMySqlConnectionInfo` interface and contains the property `ServerVersion`.

If the `ServerVersion` is retrieved before the connection was opened (possible for some tests), it returns the default `ServerVersion` of `IMySqlOptions` with the `IsDefault` property set to `true`.
For the corresponding test cases it still needs to be evaluated, whether this behavior is expected or could potentially lead to tests for mixed server versions.

This *shouldn't* be an issue, as the test suit requires an explicit `ServerVersion` being set anyway, to handle the custom `Fact` and `Theory` attributes that depend on the `ServerVersion` from `AppConfig`.
So the auto detection feature would not be made use of for the test suite.

Fixes #832