### PR TITLE
Remove dependency on Castle.Core

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,6 @@
     <MicrosoftEntityFrameworkCoreRelationalVersion>2.2.6</MicrosoftEntityFrameworkCoreRelationalVersion>
     <MySqlConnectorVersion>0.59.2</MySqlConnectorVersion>
     <PomeloJsonObjectVersion>2.2.0</PomeloJsonObjectVersion>
-    <CastleCoreVersion>4.1.0</CastleCoreVersion>
     <!-- Shared Test Dependencies -->
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>

--- a/src/EFCore.MySql/EFCore.MySql.csproj
+++ b/src/EFCore.MySql/EFCore.MySql.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftEntityFrameworkCoreRelationalVersion)" />
     <PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />
     <PackageReference Include="Pomelo.JsonObject" Version="$(PomeloJsonObjectVersion)" />
-    <PackageReference Include="Castle.Core" Version="$(CastleCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This appears to be unused: https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/commit/74bf3a90728a2c7998a4ff780d0d97e65a7e3be2#r35379779

This removes an extra dependency that has been added between 2.2.1 and 2.2.6.