### PR TITLE
Remove Castle.Core from 3.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,6 @@
     <MicrosoftEntityFrameworkCoreRelationalVersion>3.0.0</MicrosoftEntityFrameworkCoreRelationalVersion>
     <MySqlConnectorVersion>0.59.2</MySqlConnectorVersion>
     <PomeloJsonObjectVersion>2.2.0</PomeloJsonObjectVersion>
-    <CastleCoreVersion>4.4.0</CastleCoreVersion>
     <MicrosoftExtensionsCachingMemoryVersion>3.0.0</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsDependencyInjection>3.0.0</MicrosoftExtensionsDependencyInjection>
     <SystemDiagnosticsDiagnosticSource>4.6.0</SystemDiagnosticsDiagnosticSource>

--- a/src/EFCore.MySql/EFCore.MySql.csproj
+++ b/src/EFCore.MySql/EFCore.MySql.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Pomelo.JsonObject" Version="$(PomeloJsonObjectVersion)" />
-    <PackageReference Include="Castle.Core" Version="$(CastleCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(LocalEFCoreRepository)' == ''">


### PR DESCRIPTION
This is also an unnecessary dependency for the 3.0 release.