### PR TITLE
Fix ValueGeneration for `datetime` and `timestamp` columns in migrations

### DIFF
--- a/src/EFCore.MySql/EFCore.MySql.csproj
+++ b/src/EFCore.MySql/EFCore.MySql.csproj
@@ -10,6 +10,10 @@
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);EF1001</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Pomelo.JsonObject" Version="$(PomeloJsonObjectVersion)" />
   </ItemGroup>

--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<ISqlExpressionFactory, MySqlSqlExpressionFactory>()
                 .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, MySqlSqlTranslatingExpressionVisitorFactory>()
                 .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, MySqlQueryableMethodTranslatingExpressionVisitorFactory>()
+                .TryAdd<IMigrationsModelDiffer, MySqlMigrationsModelDiffer>()
                 .TryAddProviderSpecificServices(m => m
                     .TryAddSingleton<IMySqlOptions, MySqlOptions>()
                     .TryAddSingleton<IMySqlConnectionInfo, MySqlConnectionInfo>()

--- a/src/EFCore.MySql/Internal/MySqlValueGenerationStrategyCompatibility.cs
+++ b/src/EFCore.MySql/Internal/MySqlValueGenerationStrategyCompatibility.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Internal
+{
+    public static class MySqlValueGenerationStrategyCompatibility
+    {
+        public static MySqlValueGenerationStrategy? GetValueGenerationStrategy(IAnnotation[] annotations)
+        {
+            var valueGenerationStrategy = annotations.FirstOrDefault(a => a.Name == MySqlAnnotationNames.ValueGenerationStrategy)?.Value as MySqlValueGenerationStrategy?;
+
+            if (!valueGenerationStrategy.HasValue ||
+                valueGenerationStrategy == MySqlValueGenerationStrategy.None)
+            {
+                var generatedOnAddAnnotation = annotations.FirstOrDefault(a => a.Name == MySqlAnnotationNames.LegacyValueGeneratedOnAdd)?.Value;
+                if (generatedOnAddAnnotation != null && (bool)generatedOnAddAnnotation)
+                {
+                    valueGenerationStrategy = MySqlValueGenerationStrategy.IdentityColumn;
+                }
+
+                var generatedOnAddOrUpdateAnnotation = annotations.FirstOrDefault(a => a.Name == MySqlAnnotationNames.LegacyValueGeneratedOnAddOrUpdate)?.Value;
+                if (generatedOnAddOrUpdateAnnotation != null && (bool)generatedOnAddOrUpdateAnnotation)
+                {
+                    valueGenerationStrategy = MySqlValueGenerationStrategy.ComputedColumn;
+                }
+            }
+
+            return valueGenerationStrategy;
+        }
+    }
+}

--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
@@ -11,8 +11,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
 {

--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.EntityFrameworkCore.Update.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
+{
+    public class MySqlMigrationsModelDiffer : MigrationsModelDiffer
+    {
+        public MySqlMigrationsModelDiffer(
+            [NotNull] IRelationalTypeMappingSource typeMappingSource,
+            [NotNull] IMigrationsAnnotationProvider migrationsAnnotations,
+            [NotNull] IChangeDetector changeDetector,
+            [NotNull] IUpdateAdapterFactory updateAdapterFactory,
+            [NotNull] CommandBatchPreparerDependencies commandBatchPreparerDependencies)
+            : base(
+                typeMappingSource,
+                migrationsAnnotations,
+                changeDetector,
+                updateAdapterFactory,
+                commandBatchPreparerDependencies)
+        {
+        }
+
+        protected override IEnumerable<MigrationOperation> Add(IProperty target, DiffContext diffContext, bool inline = false)
+        {
+            if (target.FindTypeMapping() is RelationalTypeMapping storeType)
+            {
+                var valueGenerationStrategy = MySqlValueGenerationStrategyCompatibility.GetValueGenerationStrategy(MigrationsAnnotations.For(target).ToArray());
+
+                // Ensure that null will be set for the columns default value, if CURRENT_TIMESTAMP has been required.
+                inline = inline ||
+                             (storeType.StoreTypeNameBase == "datetime" ||
+                                storeType.StoreTypeNameBase == "timestamp") &&
+                             (valueGenerationStrategy == MySqlValueGenerationStrategy.IdentityColumn ||
+                                valueGenerationStrategy == MySqlValueGenerationStrategy.ComputedColumn);
+            }
+
+            return base.Add(target, diffContext, inline);
+        }
+    }
+}

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -689,25 +689,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 }
             }
 
-            var annotatable = (IAnnotatable)operation;
-            var valueGenerationStrategy = annotatable[MySqlAnnotationNames.ValueGenerationStrategy] as MySqlValueGenerationStrategy?;
-
-            if (!valueGenerationStrategy.HasValue ||
-                valueGenerationStrategy == MySqlValueGenerationStrategy.None)
-            {
-                var generatedOnAddAnnotation = annotatable[MySqlAnnotationNames.LegacyValueGeneratedOnAdd];
-                if (generatedOnAddAnnotation != null && (bool)generatedOnAddAnnotation)
-                {
-                    valueGenerationStrategy = MySqlValueGenerationStrategy.IdentityColumn;
-                }
-
-                var generatedOnAddOrUpdateAnnotation =
-                    annotatable[MySqlAnnotationNames.LegacyValueGeneratedOnAddOrUpdate];
-                if (generatedOnAddOrUpdateAnnotation != null && (bool)generatedOnAddOrUpdateAnnotation)
-                {
-                    valueGenerationStrategy = MySqlValueGenerationStrategy.ComputedColumn;
-                }
-            }
+            var valueGenerationStrategy = MySqlValueGenerationStrategyCompatibility.GetValueGenerationStrategy(operation.GetAnnotations().OfType<IAnnotation>().ToArray());
 
             var autoIncrement = false;
             if (valueGenerationStrategy == MySqlValueGenerationStrategy.IdentityColumn &&


### PR DESCRIPTION
Creating a migration that adds a `datetime` or `timestamp` column with the value generation option set to `IdentityColumn` or `ComputedColumn` and no explicit default value specified, should leave the default value `null` in it's `MigrationBuilder.AddColumn` call, so that `CURRENT_TIMESTAMP` will be used in the generated `ALTER TABLE` statement.

`MigrationsModelDiffer` is an internal class. The only way I can think of, to do this without the (probably not very problematic) override we do now, is to introduce another specific annotation, that when set ignores the `defaultValue` in favor of using `TIMESTAMP_CURRENT`, or states that if `defaultValue` is set to the CLR default value, it should be considered as `DEFAULT`.

Fixes #801 