### PR TITLE
Fixes #884 - Included null check for clrType when trying to match mappingInfo against Guid store types

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -288,7 +288,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                 if (_options.ConnectionSettings.OldGuids)
                 {
                     if (storeTypeName.Equals(_oldGuid.StoreType, StringComparison.OrdinalIgnoreCase)
-                        && clrType == typeof(Guid))
+                        && (clrType == typeof(Guid) || clrType == null))
                     {
                         return _oldGuid;
                     }
@@ -296,7 +296,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                 else
                 {
                     if (storeTypeName.Equals(_uniqueidentifier.StoreType, StringComparison.OrdinalIgnoreCase)
-                        && clrType == typeof(Guid))
+                        && (clrType == typeof(Guid) || clrType == null))
                     {
                         return _uniqueidentifier;
                     }


### PR DESCRIPTION
BINARY(16) and CHAR(36) were not mapped to Guid when scaffolding from database due to clrType being null.