### PR TITLE
Using line break characters can lead to wrong values in idempotent scripts

### DIFF
--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -14,5 +14,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         CharSetInfo AnsiCharSetInfo { get; }
         CharSetInfo UnicodeCharSetInfo { get; }
         bool NoBackslashEscapes { get; }
+        bool ReplaceLineBreaksWithCharFunction { get; }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -5,7 +5,6 @@ using System.Text;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using System.Globalization;
@@ -18,6 +17,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
 
         public MySqlOptionsExtension()
         {
+            ReplaceLineBreaksWithCharFunction = true;
         }
 
         public MySqlOptionsExtension([NotNull] MySqlOptionsExtension copyFrom)
@@ -29,6 +29,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             UnicodeCharSetInfo = copyFrom.UnicodeCharSetInfo;
             NoBackslashEscapes = copyFrom.NoBackslashEscapes;
             UpdateSqlModeOnOpen = copyFrom.UpdateSqlModeOnOpen;
+            ReplaceLineBreaksWithCharFunction = copyFrom.ReplaceLineBreaksWithCharFunction;
         }
 
         /// <summary>
@@ -79,6 +80,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public bool UpdateSqlModeOnOpen { get; private set; }
+
+        public bool ReplaceLineBreaksWithCharFunction { get; set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -154,6 +157,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             return clone;
         }
 
+        public MySqlOptionsExtension DisableLineBreakToCharSubstition()
+        {
+            var clone = (MySqlOptionsExtension)Clone();
+            clone.ReplaceLineBreaksWithCharFunction = false;
+            return clone;
+        }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -213,6 +223,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.AnsiCharSetInfo?.GetHashCode() ?? 0L);
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.UnicodeCharSetInfo?.GetHashCode() ?? 0L);
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ Extension.NoBackslashEscapes.GetHashCode();
+                    _serviceProviderHash = (_serviceProviderHash * 397) ^ Extension.ReplaceLineBreaksWithCharFunction.GetHashCode();
                 }
 
                 return _serviceProviderHash.Value;
@@ -230,6 +241,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                     = (Extension.UnicodeCharSetInfo?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
                 debugInfo["MySql:" + nameof(MySqlDbContextOptionsBuilder.DisableBackslashEscaping)]
                     = Extension.NoBackslashEscapes.GetHashCode().ToString(CultureInfo.InvariantCulture);
+                debugInfo["MySql:" + nameof(MySqlDbContextOptionsBuilder.DisableLineBreakToCharSubstition)]
+                    = Extension.ReplaceLineBreaksWithCharFunction.GetHashCode().ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -92,6 +92,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => WithOption(e => e.SetSqlModeOnOpen());
 
         /// <summary>
+        ///     Skip replacing `\r` and `\n` with `CHAR()` calls in strings inside queries.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder DisableLineBreakToCharSubstition()
+            => WithOption(e => e.DisableLineBreakToCharSubstition());
+
+        /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
         /// </summary>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>

--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -20,6 +20,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             CharSetBehavior = CharSetBehavior.AppendToAllAnsiColumns;
             AnsiCharSetInfo = new CharSetInfo(CharSet.Latin1);
             UnicodeCharSetInfo = new CharSetInfo(CharSet.Utf8mb4);
+            ReplaceLineBreaksWithCharFunction = true;
         }
 
         public virtual void Initialize(IDbContextOptions options)
@@ -32,6 +33,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             AnsiCharSetInfo = mySqlOptions.AnsiCharSetInfo ?? AnsiCharSetInfo;
             UnicodeCharSetInfo = mySqlOptions.UnicodeCharSetInfo ?? UnicodeCharSetInfo;
             NoBackslashEscapes = mySqlOptions.NoBackslashEscapes;
+            ReplaceLineBreaksWithCharFunction = mySqlOptions.ReplaceLineBreaksWithCharFunction;
         }
 
         public virtual void Validate(IDbContextOptions options)
@@ -79,5 +81,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
         public virtual CharSetInfo AnsiCharSetInfo { get; private set; }
         public virtual CharSetInfo UnicodeCharSetInfo { get; private set; }
         public virtual bool NoBackslashEscapes { get; private set; }
+        public virtual bool ReplaceLineBreaksWithCharFunction { get; private set; }
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -112,13 +112,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         protected void Initialize()
         {
             // String mappings depend on the MySqlOptions.NoBackslashEscapes setting.
-            _char = new MySqlStringTypeMapping("char", DbType.AnsiStringFixedLength, fixedLength: true, noBackslashEscapes: _options.NoBackslashEscapes);
-            _varchar = new MySqlStringTypeMapping("varchar", DbType.AnsiString, noBackslashEscapes: _options.NoBackslashEscapes);
-            _nchar = new MySqlStringTypeMapping("nchar", DbType.StringFixedLength, unicode: true, fixedLength: true, noBackslashEscapes: _options.NoBackslashEscapes);
-            _nvarchar = new MySqlStringTypeMapping("nvarchar", DbType.String, unicode: true, noBackslashEscapes: _options.NoBackslashEscapes);
-            _varcharmax = new MySqlStringTypeMapping("longtext", DbType.AnsiString, noBackslashEscapes: _options.NoBackslashEscapes);
-            _nvarcharmax = new MySqlStringTypeMapping("longtext", DbType.String, unicode: true, noBackslashEscapes: _options.NoBackslashEscapes);
-            _enum = new MySqlStringTypeMapping("enum", DbType.String, unicode: true, noBackslashEscapes: _options.NoBackslashEscapes);
+            _char = new MySqlStringTypeMapping("char", DbType.AnsiStringFixedLength, _options, fixedLength: true);
+            _varchar = new MySqlStringTypeMapping("varchar", DbType.AnsiString, _options);
+            _nchar = new MySqlStringTypeMapping("nchar", DbType.StringFixedLength, _options, unicode: true, fixedLength: true);
+            _nvarchar = new MySqlStringTypeMapping("nvarchar", DbType.String, _options, unicode: true);
+            _varcharmax = new MySqlStringTypeMapping("longtext", DbType.AnsiString, _options);
+            _nvarcharmax = new MySqlStringTypeMapping("longtext", DbType.String, _options, unicode: true);
+            _enum = new MySqlStringTypeMapping("enum", DbType.String, _options, unicode: true);
             
             _storeTypeMappings
                 = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
@@ -416,10 +416,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                             ? "longtext" + charSetSuffix
                             : (isFixedLength ? "char(" : "varchar(") + size + ")" + charSetSuffix,
                         dbType,
+                        _options,
                         !isAnsi,
                         size,
-                        isFixedLength,
-                        _options.NoBackslashEscapes);
+                        isFixedLength);
                 }
 
                 if (clrType == typeof(byte[]))

--- a/test/EFCore.MySql.Tests/MySqlOptionsExtensionTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlOptionsExtensionTest.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;


### PR DESCRIPTION
Implements @bricelam's workaround from https://github.com/aspnet/EntityFrameworkCore/issues/15256#issuecomment-480434175.

I added an option to disable the replacement of `\r` with `CHAR(13)` and `\n` with `CHAR(10)`.
If a line break appears at the beginning or end of the string, we could optimize the result further in the future by not emitting an empty string.

Fixes #888

