### PR TITLE
Improve database reverse engineering

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -561,11 +561,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                        ? Array.CreateInstance(clrType.GetElementType(), 0)
                                        : clrType.GetDefaultValue());
 
-            var isRowVersion = property.ClrType == typeof(byte[])
+            var isRowVersion = (property.ClrType == typeof(DateTime) || property.ClrType == typeof(byte[]))
                                && property.IsConcurrencyToken
                                && property.ValueGenerated == ValueGenerated.OnAddOrUpdate;
-
-
+            
             var addColumnOperation = new AddColumnOperation
             {
                 Schema = operation.Schema,

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -227,14 +227,14 @@ AND
                             }
 
                             defaultValue = FilterClrDefaults(dataType, nullable, defaultValue);
-                            
+
                             var column = new DatabaseColumn
                             {
                                 Table = table,
                                 Name = name,
                                 StoreType = columType,
                                 IsNullable = nullable,
-                                DefaultValueSql = CreateDefaultValueString(defaultValue),
+                                DefaultValueSql = CreateDefaultValueString(defaultValue, dataType),
                                 ValueGenerated = valueGenerated,
                                 Comment = string.IsNullOrEmpty(comment) ? null : comment,
                             };
@@ -293,12 +293,22 @@ AND
             return defaultValue;
         }
 
-        private string CreateDefaultValueString(string str)
+        private string CreateDefaultValueString(string defaultValue, string dataType)
         {
             // Pending the MySqlConnector implement MySqlCommandBuilder class
-            return str != null
-                ? "'" + str.Replace(@"\", @"\\").Replace("'", "''") + "'"
-                : null;
+            if (string.Equals(dataType, "timestamp", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(defaultValue, "CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase))
+            {
+                return defaultValue;
+            }
+            else if (defaultValue != null)
+            {
+                return "'" + defaultValue.Replace(@"\", @"\\").Replace("'", "''") + "'";
+            }
+            else
+            {
+                return null;
+            }
         }
 
         private const string GetPrimaryQuery = @"SELECT `INDEX_NAME`,

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -142,7 +142,7 @@ AND
                         var type = reader.GetString("TABLE_TYPE");
                         var comment = reader.GetString("TABLE_COMMENT");
 
-                        var table = string.Equals(type, "table", StringComparison.OrdinalIgnoreCase)
+                        var table = string.Equals(type, "base table", StringComparison.OrdinalIgnoreCase)
                             ? new DatabaseTable()
                             : new DatabaseView();
 

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -407,9 +407,7 @@ AND
                                 {
                                     Table = table,
                                     Name = reader.GetString(0),
-                                    IsUnique = reader.GetFieldType(1) == typeof(string)
-                                        ? reader.GetString(1) == "1"
-                                        : !reader.GetBoolean(1)
+                                    IsUnique = !reader.GetBoolean(1)
                                 };
 
                                 foreach (var column in reader.GetString(2).Split(','))

--- a/src/EFCore.MySql/Scaffolding/Internal/SqlDataReaderExtension.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/SqlDataReaderExtension.cs
@@ -1,0 +1,42 @@
+﻿using System.Data.Common;
+using JetBrains.Annotations;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static class SqlDataReaderExtension
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static T GetValueOrDefault<T>([NotNull] this DbDataReader reader, [NotNull] string name)
+        {
+            var idx = reader.GetOrdinal(name);
+            return reader.IsDBNull(idx)
+                ? default
+                : reader.GetFieldValue<T>(idx);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static T GetValueOrDefault<T>([NotNull] this DbDataRecord record, [NotNull] string name)
+        {
+            var idx = record.GetOrdinal(name);
+            return record.IsDBNull(idx)
+                ? default
+                : (T)record.GetValue(idx);
+        }
+    }
+}

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTimeTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTimeTypeMapping.cs
@@ -30,12 +30,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         /// </summary>
         public MySqlDateTimeTypeMapping(
             [NotNull] string storeType,
+            Type clrType,
             ValueConverter converter = null,
             ValueComparer comparer = null,
             int? precision = null)
             : this(
                 new RelationalTypeMappingParameters(
-                    new CoreTypeMappingParameters(typeof(DateTime), converter, comparer),
+                    new CoreTypeMappingParameters(clrType, converter, comparer),
                     storeType,
                     precision == null ? StoreTypePostfix.None : StoreTypePostfix.Precision,
                     System.Data.DbType.DateTime,

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -440,5 +440,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
             return null;
         }
+
+        protected override string ParseStoreTypeName(string storeTypeName, out bool? unicode, out int? size, out int? precision, out int? scale)
+        {
+            var storeTypeBaseName = base.ParseStoreTypeName(storeTypeName, out unicode, out size, out precision, out scale);
+
+            if (storeTypeName?.Contains("unsigned", StringComparison.OrdinalIgnoreCase) ?? false)
+            {
+                return storeTypeBaseName + " unsigned";
+            }
+
+            return storeTypeBaseName;
+        }
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -53,9 +53,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         // DateTime
         private readonly MySqlDateTypeMapping _date = new MySqlDateTypeMapping("date", DbType.Date);
-        private readonly MySqlDateTimeTypeMapping _dateTime6 = new MySqlDateTimeTypeMapping("datetime", precision: 6);
-        private readonly MySqlDateTimeTypeMapping _dateTime = new MySqlDateTimeTypeMapping("datetime");
-        private readonly MySqlDateTimeTypeMapping _timeStamp6 = new MySqlDateTimeTypeMapping("timestamp", precision: 6);
+        private readonly MySqlDateTimeTypeMapping _dateTime6 = new MySqlDateTimeTypeMapping("datetime", typeof(DateTime), precision: 6);
+        private readonly MySqlDateTimeTypeMapping _dateTime = new MySqlDateTimeTypeMapping("datetime", typeof(DateTime));
+        private readonly MySqlDateTimeTypeMapping _timeStamp6 = new MySqlDateTimeTypeMapping("timestamp", typeof(DateTime), precision: 6);
         private readonly MySqlDateTimeOffsetTypeMapping _dateTimeOffset6 = new MySqlDateTimeOffsetTypeMapping("datetime", precision: 6);
         private readonly MySqlDateTimeOffsetTypeMapping _dateTimeOffset = new MySqlDateTimeOffsetTypeMapping("datetime");
         private readonly MySqlDateTimeOffsetTypeMapping _timeStampOffset6 = new MySqlDateTimeOffsetTypeMapping("timestamp", precision: 6);
@@ -65,11 +65,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         private readonly RelationalTypeMapping _binaryRowVersion
             = new MySqlDateTimeTypeMapping(
                 "timestamp",
+                typeof(byte[]),
                 new BytesToDateTimeConverter(),
                 new ByteArrayComparer());
         private readonly RelationalTypeMapping _binaryRowVersion6
             = new MySqlDateTimeTypeMapping(
                 "timestamp",
+                typeof(byte[]),
                 new BytesToDateTimeConverter(),
                 new ByteArrayComparer(),
                 precision: 6);
@@ -426,7 +428,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                 {
                     if (mappingInfo.IsRowVersion == true)
                     {
-                        return _connectionInfo.ServerVersion.SupportsDateTime6 ? _binaryRowVersion6 : _binaryRowVersion;
+                        return _connectionInfo.ServerVersion.SupportsDateTime6
+                            ? _binaryRowVersion6
+                            : _binaryRowVersion;
                     }
 
                     var size = mappingInfo.Size ??

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseCleaner.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseCleaner.cs
@@ -34,5 +34,19 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
                 _options);
 
         protected override bool AcceptIndex(DatabaseIndex index) => false;
+        protected override bool AcceptTable(DatabaseTable table) => !(table is DatabaseView);
+
+        protected override string BuildCustomSql(DatabaseModel databaseModel)
+            => @"SET @views = NULL;
+
+SELECT GROUP_CONCAT(CONCAT('`', `TABLE_SCHEMA`, '.', `TABLE_NAME`, '`')) INTO @views
+FROM `INFORMATION_SCHEMA`.`VIEWS` 
+WHERE `TABLE_SCHEMA` = SCHEMA();
+
+SET @views = IFNULL(CONCAT('DROP VIEW IF EXISTS ', @views), 'SELECT 0');
+
+PREPARE stmt FROM @views;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;";
     }
 }


### PR DESCRIPTION
Add support to reverse engineer views.
Add comments for tables and columns.
Improve handling of default values.
Handle the `CURRENT_TIMESTAMP` default value for `timestamp` columns correctly.
Correctly implement `CURRENT_TIMESTAMP` with `ON UPDATE` clauses.
Introduce a workaround for the missing EF Core handling of `ValueGenerated.OnUpdate`.

Fixes #877
Fixes #867 
Fixes #703
Fixes parts of #792 (others are blocked by an EF Core issue)