### PR TITLE
Reuse the `MySqlStringComparisonMethodTranslator` implementations and replace `BINARY` usage

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
@@ -97,7 +94,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             return null;
         }
 
-        private SqlExpression MakeStringEqualsExpression(
+        public SqlExpression MakeStringEqualsExpression(
             [NotNull] SqlExpression leftValue,
             [NotNull] SqlExpression rightValue,
             [NotNull] SqlExpression stringComparison)
@@ -155,7 +152,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             }
         }
 
-        private SqlExpression MakeStartsWithExpression(
+        public SqlExpression MakeStartsWithExpression(
             [NotNull] SqlExpression target,
             [NotNull] SqlExpression prefix,
             [NotNull] SqlExpression stringComparison)
@@ -232,7 +229,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                 ));
         }
 
-        private SqlExpression MakeEndsWithExpression(
+        public SqlExpression MakeEndsWithExpression(
             [NotNull] SqlExpression target,
             [NotNull] SqlExpression suffix,
             [NotNull] SqlExpression stringComparison)
@@ -312,7 +309,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             }
         }
 
-        private SqlExpression MakeContainsExpression(
+        public SqlExpression MakeContainsExpression(
             [NotNull] SqlExpression target,
             [NotNull] SqlExpression search,
             [NotNull] SqlExpression stringComparison)
@@ -385,7 +382,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             }
         }
 
-        private SqlExpression MakeIndexOfExpression(
+        public SqlExpression MakeIndexOfExpression(
             [NotNull] SqlExpression target,
             [NotNull] SqlExpression search,
             [NotNull] SqlExpression stringComparison)

--- a/test/EFCore.MySql.FunctionalTests/Query/FiltersMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/FiltersMySqlTest.cs
@@ -21,7 +21,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 
 SELECT COUNT(*)
 FROM `Customers` AS `c`
-WHERE ((@__ef_filter__TenantPrefix_0 = '') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR (`c`.`CompanyName` IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND ((`c`.`CompanyName` LIKE CONCAT(`c`.`CompanyName`, '%')) AND (((LEFT(`c`.`CompanyName`, CHAR_LENGTH(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT(`c`.`CompanyName`, CHAR_LENGTH(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT(`c`.`CompanyName`, CHAR_LENGTH(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
+WHERE ((@__ef_filter__TenantPrefix_0 = '') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR (`c`.`CompanyName` IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND ((`c`.`CompanyName` LIKE CONCAT(@__ef_filter__TenantPrefix_0, '%')) AND (((LEFT(`c`.`CompanyName`, CHAR_LENGTH(CONVERT(@__ef_filter__TenantPrefix_0 USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT(@__ef_filter__TenantPrefix_0 USING utf8mb4) COLLATE utf8mb4_bin) AND (LEFT(`c`.`CompanyName`, CHAR_LENGTH(CONVERT(@__ef_filter__TenantPrefix_0 USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL AND CONVERT(@__ef_filter__TenantPrefix_0 USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL)) OR (LEFT(`c`.`CompanyName`, CHAR_LENGTH(CONVERT(@__ef_filter__TenantPrefix_0 USING utf8mb4) COLLATE utf8mb4_bin)) IS NULL AND CONVERT(@__ef_filter__TenantPrefix_0 USING utf8mb4) COLLATE utf8mb4_bin IS NULL)))))");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
@@ -178,7 +178,7 @@ WHERE (EXTRACT(microsecond FROM `o`.`OrderDate`)) DIV (1000) = 88");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE `c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` LIKE 'M%')");
+WHERE `c`.`ContactName` IS NOT NULL AND ((`c`.`ContactName` LIKE CONCAT('M', '%')) AND ((LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT('M' USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT('M' USING utf8mb4) COLLATE utf8mb4_bin) AND LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT('M' USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL))");
         }
 
         public override async Task String_StartsWith_Identity(bool isAsync)
@@ -188,7 +188,7 @@ WHERE `c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` LIKE 'M%')");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` IS NOT NULL AND ((`c`.`ContactName` LIKE CONCAT(`c`.`ContactName`, '%')) AND (((LEFT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) = `c`.`ContactName`) AND (LEFT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) IS NOT NULL AND `c`.`ContactName` IS NOT NULL)) OR (LEFT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) IS NULL AND `c`.`ContactName` IS NULL)))))");
+WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` IS NOT NULL AND ((`c`.`ContactName` LIKE CONCAT(`c`.`ContactName`, '%')) AND (((LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin) AND (LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL AND CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL)) OR (LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) IS NULL AND CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin IS NULL)))))");
         }
 
         public override async Task String_StartsWith_Column(bool isAsync)
@@ -198,7 +198,7 @@ WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`Cont
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` IS NOT NULL AND ((`c`.`ContactName` LIKE CONCAT(`c`.`ContactName`, '%')) AND (((LEFT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) = `c`.`ContactName`) AND (LEFT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) IS NOT NULL AND `c`.`ContactName` IS NOT NULL)) OR (LEFT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) IS NULL AND `c`.`ContactName` IS NULL)))))");
+WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` IS NOT NULL AND ((`c`.`ContactName` LIKE CONCAT(`c`.`ContactName`, '%')) AND (((LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin) AND (LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL AND CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL)) OR (LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) IS NULL AND CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin IS NULL)))))");
         }
 
         public override async Task String_StartsWith_MethodCall(bool isAsync)
@@ -208,7 +208,7 @@ WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`Cont
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE `c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` LIKE 'M%')");
+WHERE `c`.`ContactName` IS NOT NULL AND ((`c`.`ContactName` LIKE CONCAT('M', '%')) AND ((LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT('M' USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT('M' USING utf8mb4) COLLATE utf8mb4_bin) AND LEFT(`c`.`ContactName`, CHAR_LENGTH(CONVERT('M' USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL))");
         }
 
         public override async Task String_EndsWith_Literal(bool isAsync)
@@ -218,7 +218,7 @@ WHERE `c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` LIKE 'M%')");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE `c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` LIKE '%b')");
+WHERE `c`.`ContactName` IS NOT NULL AND ((RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT('b' USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT('b' USING utf8mb4) COLLATE utf8mb4_bin) AND RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT('b' USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL)");
         }
 
         public override async Task String_EndsWith_Identity(bool isAsync)
@@ -228,7 +228,7 @@ WHERE `c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` LIKE '%b')");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` IS NOT NULL AND (((RIGHT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) = `c`.`ContactName`) AND (RIGHT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) IS NOT NULL AND `c`.`ContactName` IS NOT NULL)) OR (RIGHT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) IS NULL AND `c`.`ContactName` IS NULL))))");
+WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` IS NOT NULL AND ((((RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin) AND (RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL AND CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL)) OR (RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) IS NULL AND CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin IS NULL)) OR ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL))))");
         }
 
         public override async Task String_EndsWith_Column(bool isAsync)
@@ -238,7 +238,7 @@ WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`Cont
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` IS NOT NULL AND (((RIGHT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) = `c`.`ContactName`) AND (RIGHT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) IS NOT NULL AND `c`.`ContactName` IS NOT NULL)) OR (RIGHT(`c`.`ContactName`, CHAR_LENGTH(`c`.`ContactName`)) IS NULL AND `c`.`ContactName` IS NULL))))");
+WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` IS NOT NULL AND ((((RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin) AND (RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL AND CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL)) OR (RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin)) IS NULL AND CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin IS NULL)) OR ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL))))");
         }
 
         public override async Task String_EndsWith_MethodCall(bool isAsync)
@@ -248,7 +248,7 @@ WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (`c`.`Cont
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE `c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` LIKE '%m')");
+WHERE `c`.`ContactName` IS NOT NULL AND ((RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT('m' USING utf8mb4) COLLATE utf8mb4_bin)) = CONVERT('m' USING utf8mb4) COLLATE utf8mb4_bin) AND RIGHT(`c`.`ContactName`, CHAR_LENGTH(CONVERT('m' USING utf8mb4) COLLATE utf8mb4_bin)) IS NOT NULL)");
         }
 
         public override async Task String_Contains_Literal(bool isAsync)
@@ -258,7 +258,7 @@ WHERE `c`.`ContactName` IS NOT NULL AND (`c`.`ContactName` LIKE '%m')");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE LOCATE(BINARY 'M', `c`.`ContactName`) > 0");
+WHERE LOCATE(CONVERT('M' USING utf8mb4) COLLATE utf8mb4_bin, `c`.`ContactName`) > 0");
         }
 
         public override async Task String_Contains_Identity(bool isAsync)
@@ -268,7 +268,7 @@ WHERE LOCATE(BINARY 'M', `c`.`ContactName`) > 0");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (LOCATE(BINARY `c`.`ContactName`, `c`.`ContactName`) > 0)");
+WHERE (LOCATE(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin, `c`.`ContactName`) > 0) OR ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL)");
         }
 
         public override async Task String_Contains_Column(bool isAsync)
@@ -278,7 +278,7 @@ WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (LOCATE(BI
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (LOCATE(BINARY `c`.`ContactName`, `c`.`ContactName`) > 0)");
+WHERE (LOCATE(CONVERT(`c`.`ContactName` USING utf8mb4) COLLATE utf8mb4_bin, `c`.`ContactName`) > 0) OR ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL)");
         }
 
         public override async Task String_Contains_MethodCall(bool isAsync)
@@ -288,7 +288,7 @@ WHERE ((`c`.`ContactName` = '') AND `c`.`ContactName` IS NOT NULL) OR (LOCATE(BI
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE LOCATE(BINARY 'M', `c`.`ContactName`) > 0");
+WHERE LOCATE(CONVERT('M' USING utf8mb4) COLLATE utf8mb4_bin, `c`.`ContactName`) > 0");
         }
 
         public override async Task IsNullOrWhiteSpace_in_predicate(bool isAsync)
@@ -317,7 +317,7 @@ WHERE (CHAR_LENGTH(`c`.`City`) = 6) AND CHAR_LENGTH(`c`.`City`) IS NOT NULL");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE ((LOCATE('Sea', `c`.`City`) - 1) <> -1) OR LOCATE('Sea', `c`.`City`) - 1 IS NULL");
+WHERE ((LOCATE(CONVERT('Sea' USING utf8mb4) COLLATE utf8mb4_bin, `c`.`City`) - 1) <> -1) OR LOCATE(CONVERT('Sea' USING utf8mb4) COLLATE utf8mb4_bin, `c`.`City`) - 1 IS NULL");
         }
 
         public override async Task Indexof_with_emptystring(bool isAsync)
@@ -325,7 +325,7 @@ WHERE ((LOCATE('Sea', `c`.`City`) - 1) <> -1) OR LOCATE('Sea', `c`.`City`) - 1 I
             await base.Indexof_with_emptystring(isAsync);
 
             AssertSql(
-                @"SELECT LOCATE('', `c`.`ContactName`) - 1
+                @"SELECT LOCATE(CONVERT('' USING utf8mb4) COLLATE utf8mb4_bin, `c`.`ContactName`) - 1
 FROM `Customers` AS `c`
 WHERE `c`.`CustomerID` = 'ALFKI'");
         }


### PR DESCRIPTION
Make use of the `MySqlStringComparisonMethodTranslator` implementations in `MySqlStringMethodTranslator` instead of keeping its own implementation, to fix issues where the defined `CharSet` and the charset of the column differ, and to simplify the code base.

In the future, the two classes should be combined (probably into separate partial class files for better management).

Related to #885 in regards to `3.0.0`.
Fixes #890 