### PR TITLE
Default data type mappings customization

### DIFF
--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -3,6 +3,7 @@
 
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
 {
@@ -15,5 +16,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         CharSet NationalCharSet { get; }
         bool NoBackslashEscapes { get; }
         bool ReplaceLineBreaksWithCharFunction { get; }
+        MySqlDefaultDataTypeMappings DefaultDataTypeMappings { get; }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using System.Globalization;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
 {
@@ -29,6 +30,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             NoBackslashEscapes = copyFrom.NoBackslashEscapes;
             UpdateSqlModeOnOpen = copyFrom.UpdateSqlModeOnOpen;
             ReplaceLineBreaksWithCharFunction = copyFrom.ReplaceLineBreaksWithCharFunction;
+            DefaultDataTypeMappings = copyFrom.DefaultDataTypeMappings;
         }
 
         /// <summary>
@@ -38,7 +40,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override DbContextOptionsExtensionInfo Info
-            => _info = _info ?? new ExtensionInfo(this);
+            => _info ??= new ExtensionInfo(this);
 
         protected override RelationalOptionsExtension Clone()
             => new MySqlOptionsExtension(this);
@@ -73,7 +75,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         /// </summary>
         public bool UpdateSqlModeOnOpen { get; private set; }
 
-        public bool ReplaceLineBreaksWithCharFunction { get; set; }
+        public bool ReplaceLineBreaksWithCharFunction { get; private set; }
+
+        public MySqlDefaultDataTypeMappings DefaultDataTypeMappings { get; private set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -118,7 +122,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public MySqlOptionsExtension DisableBackslashEscaping()
+        public MySqlOptionsExtension WithDisabledBackslashEscaping()
         {
             var clone = (MySqlOptionsExtension)Clone();
             clone.NoBackslashEscapes = true;
@@ -129,20 +133,27 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public MySqlOptionsExtension SetSqlModeOnOpen()
+        public MySqlOptionsExtension WithSettingSqlModeOnOpen()
         {
             var clone = (MySqlOptionsExtension)Clone();
             clone.UpdateSqlModeOnOpen = true;
             return clone;
         }
 
-        public MySqlOptionsExtension DisableLineBreakToCharSubstition()
+        public MySqlOptionsExtension WithDisabledLineBreakToCharSubstition()
         {
             var clone = (MySqlOptionsExtension)Clone();
             clone.ReplaceLineBreaksWithCharFunction = false;
             return clone;
         }
 
+        public MySqlOptionsExtension WithDefaultDataTypeMappings(MySqlDefaultDataTypeMappings defaultDataTypeMappings)
+        {
+            var clone = (MySqlOptionsExtension)Clone();
+            clone.DefaultDataTypeMappings = defaultDataTypeMappings;
+            return clone;
+        }
+        
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -201,7 +212,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.NullableCharSetBehavior?.GetHashCode() ?? 0L);
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.CharSet?.GetHashCode() ?? 0L);
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ Extension.NoBackslashEscapes.GetHashCode();
+                    _serviceProviderHash = (_serviceProviderHash * 397) ^ Extension.UpdateSqlModeOnOpen.GetHashCode();
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ Extension.ReplaceLineBreaksWithCharFunction.GetHashCode();
+                    _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.DefaultDataTypeMappings?.GetHashCode() ?? 0L);
                 }
 
                 return _serviceProviderHash.Value;
@@ -217,8 +230,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                     = (Extension.CharSet?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
                 debugInfo["MySql:" + nameof(MySqlDbContextOptionsBuilder.DisableBackslashEscaping)]
                     = Extension.NoBackslashEscapes.GetHashCode().ToString(CultureInfo.InvariantCulture);
+                debugInfo["MySql:" + nameof(MySqlDbContextOptionsBuilder.SetSqlModeOnOpen)]
+                    = Extension.UpdateSqlModeOnOpen.GetHashCode().ToString(CultureInfo.InvariantCulture);
                 debugInfo["MySql:" + nameof(MySqlDbContextOptionsBuilder.DisableLineBreakToCharSubstition)]
                     = Extension.ReplaceLineBreaksWithCharFunction.GetHashCode().ToString(CultureInfo.InvariantCulture);
+                debugInfo["MySql:" + nameof(MySqlDbContextOptionsBuilder.DefaultDataTypeMappings)]
+                    = (Extension.DefaultDataTypeMappings?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -8,6 +8,7 @@ using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -66,11 +67,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// When `false`, does not change the <see cref="SetSqlModeOnOpen" /> option, when calling this method.</param>
         public virtual MySqlDbContextOptionsBuilder DisableBackslashEscaping(bool setSqlModeOnOpen = true)
         {
-            var builder = WithOption(e => e.DisableBackslashEscaping());
+            var builder = WithOption(e => e.WithDisabledBackslashEscaping());
 
             if (setSqlModeOnOpen)
             {
-                builder = builder.WithOption(e => e.SetSqlModeOnOpen());
+                builder = builder.WithOption(e => e.WithSettingSqlModeOnOpen());
             }
 
             return builder;
@@ -83,13 +84,19 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     handled by the caller, to synchronize it with other options that have been set.
         /// </summary>
         public virtual MySqlDbContextOptionsBuilder SetSqlModeOnOpen()
-            => WithOption(e => e.SetSqlModeOnOpen());
+            => WithOption(e => e.WithSettingSqlModeOnOpen());
 
         /// <summary>
         ///     Skip replacing `\r` and `\n` with `CHAR()` calls in strings inside queries.
         /// </summary>
         public virtual MySqlDbContextOptionsBuilder DisableLineBreakToCharSubstition()
-            => WithOption(e => e.DisableLineBreakToCharSubstition());
+            => WithOption(e => e.WithDisabledLineBreakToCharSubstition());
+
+        /// <summary>
+        ///     Configures default mappings between specific CLR and MySQL types.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder DefaultDataTypeMappings(Func<MySqlDefaultDataTypeMappings, MySqlDefaultDataTypeMappings> defaultDataTypeMappings)
+            => WithOption(e => e.WithDefaultDataTypeMappings(defaultDataTypeMappings(new MySqlDefaultDataTypeMappings())));
 
         /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.

--- a/src/EFCore.MySql/Internal/MySqlDefaultDataTypeMappings.cs
+++ b/src/EFCore.MySql/Internal/MySqlDefaultDataTypeMappings.cs
@@ -1,0 +1,115 @@
+namespace Pomelo.EntityFrameworkCore.MySql.Internal
+{
+    public class MySqlDefaultDataTypeMappings
+    {
+        public MySqlDefaultDataTypeMappings()
+        {
+        }
+
+        protected MySqlDefaultDataTypeMappings(MySqlDefaultDataTypeMappings copyFrom)
+        {
+            ClrBoolean = copyFrom.ClrBoolean;
+            ClrDateTime = copyFrom.ClrDateTime;
+            ClrDateTimeOffset = copyFrom.ClrDateTimeOffset;
+            ClrTimeSpan = copyFrom.ClrTimeSpan;
+        }
+
+        public MySqlBooleanType ClrBoolean { get; private set; }
+        public MySqlDateTimeType ClrDateTime { get; private set; }
+        public MySqlDateTimeType ClrDateTimeOffset { get; private set; }
+        public MySqlTimeSpanType ClrTimeSpan { get; private set; }
+
+        public MySqlDefaultDataTypeMappings WithClrBoolean(MySqlBooleanType mysqlBooleanType)
+        {
+            var clone = Clone();
+            clone.ClrBoolean = mysqlBooleanType;
+            return clone;
+        }
+
+        public MySqlDefaultDataTypeMappings WithClrDateTime(MySqlDateTimeType mysqlDateTimeType)
+        {
+            var clone = Clone();
+            clone.ClrDateTime = mysqlDateTimeType;
+            return clone;
+        }
+
+        public MySqlDefaultDataTypeMappings WithClrDateTimeOffset(MySqlDateTimeType mysqlDateTimeType)
+        {
+            var clone = Clone();
+            clone.ClrDateTimeOffset = mysqlDateTimeType;
+            return clone;
+        }
+
+        public MySqlDefaultDataTypeMappings WithClrTimeSpan(MySqlTimeSpanType mysqlTimeSpanType)
+        {
+            var clone = Clone();
+            clone.ClrTimeSpan = mysqlTimeSpanType;
+            return clone;
+        }
+
+        protected virtual MySqlDefaultDataTypeMappings Clone() => new MySqlDefaultDataTypeMappings(this);
+
+        protected bool Equals(MySqlDefaultDataTypeMappings other)
+        {
+            return ClrBoolean == other.ClrBoolean &&
+                   ClrDateTime == other.ClrDateTime &&
+                   ClrDateTimeOffset == other.ClrDateTimeOffset &&
+                   ClrTimeSpan == other.ClrTimeSpan;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return Equals((MySqlDefaultDataTypeMappings)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int)ClrBoolean;
+                hashCode = (hashCode * 397) ^ (int)ClrDateTime;
+                hashCode = (hashCode * 397) ^ (int)ClrDateTimeOffset;
+                hashCode = (hashCode * 397) ^ (int)ClrTimeSpan;
+                return hashCode;
+            }
+        }
+    }
+
+    public enum MySqlBooleanType
+    {
+        None = -1,
+        Default = 0,
+        TinyInt1 = 1,
+        Bit1 = 2
+    }
+
+    public enum MySqlDateTimeType
+    {
+        Default = 0,
+        DateTime = 1,
+        DateTime6 = 2,
+        Timestamp6 = 3
+    }
+
+    public enum MySqlTimeSpanType
+    {
+        Default = 0,
+        Time = 1,
+        Time6 = 2,
+    }
+}

--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -8,12 +8,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.Extensions.DependencyInjection;
 using MySql.Data.MySqlClient;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {
@@ -72,6 +70,27 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             if (_mySqlOptionsExtension.NoBackslashEscapes)
             {
                 builder.NoBackslashEscapes = true;
+            }
+
+            var boolHandling = _mySqlOptionsExtension.DefaultDataTypeMappings?.ClrBoolean;
+            switch (boolHandling)
+            {
+                case null:
+                    // Just keep using whatever is already defined in the connection string.
+                    break;
+
+                case MySqlBooleanType.Default:
+                case MySqlBooleanType.TinyInt1:
+                    builder.TreatTinyAsBoolean = true;
+                    break;
+
+                case MySqlBooleanType.None:
+                case MySqlBooleanType.Bit1:
+                    builder.TreatTinyAsBoolean = false;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
 
             return builder;

--- a/test/EFCore.MySql.Tests/MySqlOptionsExtensionTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlOptionsExtensionTest.cs
@@ -17,14 +17,14 @@ namespace Pomelo.EntityFrameworkCore.MySql
                     .WithCharSet(CharSet.Latin1)
                     .WithCharSetBehavior(CharSetBehavior.AppendToAllColumns)
                     .WithServerVersion(new ServerVersion(new Version(1, 2, 3, 4), ServerType.MySql))
-                    .DisableBackslashEscaping()
+                    .WithDisabledBackslashEscaping()
                     .Info
                     .GetServiceProviderHashCode(),
                 new MySqlOptionsExtension()
                     .WithCharSet(CharSet.Latin1)
                     .WithCharSetBehavior(CharSetBehavior.AppendToAllColumns)
                     .WithServerVersion(new ServerVersion(new Version(1, 2, 3, 4), ServerType.MySql))
-                    .DisableBackslashEscaping()
+                    .WithDisabledBackslashEscaping()
                     .Info
                     .GetServiceProviderHashCode());
         }


### PR DESCRIPTION
Allow users to specify the default type mappings for the CLR types `System.Boolean`, `System.DateTime`, `System.DateTimeOffset` and `System.TimeSpan` and consolidate some inconsistent names.

The following example explicitly specifies the usage of `tinyint(1)` for `System.Boolean` (this can still be done as a connection string setting like before with `TreatTinyAsBoolean`) and `datetime` for `System.DateTime` (which would then be used even if the database server supports `datetime(6)`):

```c#
options.UseMySql(myConnectionString, b => b.DefaultDataTypeMappings(m => m
    .WithClrBoolean(MySqlBooleanType.TinyInt1)
    .WithClrDateTime(MySqlDateTimeType.DateTime)));
```

This concludes the feature implementations for `3.0.0`.

Fixes #811 