### PR TITLE
Empty string default value can lead to unexpectedly failing insert statement

### DIFF
--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -284,15 +284,6 @@ AND
                 return defaultValue;
             }
 
-            if (defaultValue == string.Empty)
-            {
-                if (dataTypeName.Contains("char")
-                    || dataTypeName.Contains("text"))
-                {
-                    return null;
-                }
-            }
-
             if (defaultValue == "0")
             {
                 if (dataTypeName == "bit"


### PR DESCRIPTION
Fix an issue, where non-nullable string columns with a default value of an empty string, will be scaffolded without an explicit empty string default value. This can lead to unexpectedly failing insert statements, when the string property has not been set (is `null`).

Fixes #912 
