### PR TITLE
Fix issue related to stripped security information from an internally used connection string

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,7 @@
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.0.0</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <!-- EFCore.MySql Dependencies -->
     <MicrosoftEntityFrameworkCoreRelationalVersion>3.0.0</MicrosoftEntityFrameworkCoreRelationalVersion>
-    <MySqlConnectorVersion>0.60.3</MySqlConnectorVersion>
+    <MySqlConnectorVersion>0.61.0</MySqlConnectorVersion>
     <PomeloJsonObjectVersion>2.2.0</PomeloJsonObjectVersion>
     <MicrosoftExtensionsCachingMemoryVersion>3.0.0</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsDependencyInjection>3.0.0</MicrosoftExtensionsDependencyInjection>

--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -56,7 +56,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             // Apply modified connection string.
             relationalOptions = connection is null
                 ? relationalOptions.WithConnectionString(csb.ConnectionString)
-                : relationalOptions.WithConnection(connection.CloneWith(connectionString));
+                : relationalOptions.WithConnection(connection.CloneWith(csb.ConnectionString));
 
             var optionsBuilder = new DbContextOptionsBuilder();
             var optionsBuilderInfrastructure = (IDbContextOptionsBuilderInfrastructure)optionsBuilder;


### PR DESCRIPTION
Reuse connection string with sensitive information for master connections that are instantiated from relational connections, which have been based on a `DbConnection` object instead of a connection string.

Fixes #908