### PR TITLE
Correct the `datetime(6)` support version

### DIFF
--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -8,7 +8,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
     {
         #region Individual version strings for tests
 
-        public const string DateTime6MySqlSupportVersionString = "5.6.0-mysql";
+        public const string DateTime6MySqlSupportVersionString = "5.6.4-mysql";
         public const string DateTime6MariaDbSupportVersionString = "10.1.2-mariadb";
 
         public const string LargerKeyLengthMySqlSupportVersionString = "5.7.7-mysql";


### PR DESCRIPTION
According to the MySQL docs, support for [fractional seconds in time values](https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html) was added in version 5.6.4:

>MySQL 5.6.4 and up expands fractional seconds support for `TIME`, `DATETIME`, and `TIMESTAMP` values, with up to microseconds (6 digits) precision.