### PR TITLE
Throw on schema use

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,16 +110,16 @@ jobs:
     displayName: Integration Tests legacy migrations
     continueOnError: true
     condition: eq(variables['INTEGRATION_TESTS'],'true')
-  - bash: export EF_SCHEMA="pomelo_test2" && ./dotnet-env.sh dotnet build ./test/EFCore.MySql.IntegrationTests -c Release
+  - bash: export EF_DATABASE="pomelo_test2" && ./dotnet-env.sh dotnet build ./test/EFCore.MySql.IntegrationTests -c Release
     displayName: Integration Tests Building migrations with EF_DATABASE=pomelo_test2
     continueOnError: true
     condition: eq(variables['INTEGRATION_TESTS'],'true')
-  - bash: export EF_SCHEMA="pomelo_test2" && ./dotnet-env.sh ./test/EFCore.MySql.IntegrationTests/scripts/rebuild.sh
+  - bash: export EF_DATABASE="pomelo_test2" && ./dotnet-env.sh ./test/EFCore.MySql.IntegrationTests/scripts/rebuild.sh
     displayName: Integration Tests Setup migrations with EF_DATABASE=pomelo_test2
     continueOnError: true
     condition: eq(variables['INTEGRATION_TESTS'],'true')
-  - bash: export EF_SCHEMA="pomelo_test2" && ./dotnet-env.sh dotnet test -c Release --logger trx test/EFCore.MySql.IntegrationTests
-    displayName: Integration Tests with EF_SCHEMA=pomelo_test2
+  - bash: export EF_DATABASE="pomelo_test2" && ./dotnet-env.sh dotnet test -c Release --logger trx test/EFCore.MySql.IntegrationTests
+    displayName: Integration Tests with EF_DATABASE=pomelo_test2
     continueOnError: true
     condition: eq(variables['INTEGRATION_TESTS'],'true')
   - task: PublishTestResults@2
@@ -191,14 +191,14 @@ jobs:
   - pwsh: $env:EF_RETRY_ON_FAILURE="3"; .\dotnet-env.ps1 dotnet test -c Release --logger trx test\EFCore.MySql.IntegrationTests
     displayName: Integration Tests with EF_RETRY_ON_FAILURE=3
     continueOnError: true
-  - pwsh: $env:EF_SCHEMA="pomelo_test2"; .\dotnet-env.ps1 dotnet build .\test\EFCore.MySql.IntegrationTests -c Release
+  - pwsh: $env:EF_DATABASE="pomelo_test2"; .\dotnet-env.ps1 dotnet build .\test\EFCore.MySql.IntegrationTests -c Release
     displayName: Integration Tests Building migrations with EF_DATABASE=pomelo_test2
     continueOnError: true
-  - pwsh: $env:EF_SCHEMA="pomelo_test2"; .\dotnet-env.ps1 .\test\EFCore.MySql.IntegrationTests\scripts\rebuild.ps1
+  - pwsh: $env:EF_DATABASE="pomelo_test2"; .\dotnet-env.ps1 .\test\EFCore.MySql.IntegrationTests\scripts\rebuild.ps1
     displayName: Integration Tests Setup migrations with EF_DATABASE=pomelo_test2
     continueOnError: true
-  - pwsh: $env:EF_SCHEMA="pomelo_test2"; .\dotnet-env.ps1 dotnet test -c Release --logger trx test\EFCore.MySql.IntegrationTests
-    displayName: Integration Tests with EF_SCHEMA=pomelo_test2
+  - pwsh: $env:EF_DATABASE="pomelo_test2"; .\dotnet-env.ps1 dotnet test -c Release --logger trx test\EFCore.MySql.IntegrationTests
+    displayName: Integration Tests with EF_DATABASE=pomelo_test2
     continueOnError: true
   - task: PublishTestResults@2
     displayName: Publish Test Results

--- a/src/EFCore.MySql/Design/Internal/MySqlDesignTimeServices.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlDesignTimeServices.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pomelo.EntityFrameworkCore.MySql.Migrations.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
 {

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -74,7 +74,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
                 databaseModel.DatabaseName = connection.Database;
                 databaseModel.DefaultSchema = GetDefaultSchema(connection);
 
-                var schemaList = options.Schemas.ToList();
+                var schemaList = Enumerable.Empty<string>().ToList();
                 var tableList = options.Tables.ToList();
                 var tableFilter = GenerateTableFilter(tableList, schemaList);
 

--- a/test/EFCore.MySql.FunctionalTests/AppConfig.cs
+++ b/test/EFCore.MySql.FunctionalTests/AppConfig.cs
@@ -18,9 +18,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 ? Convert.ToInt32(Environment.GetEnvironmentVariable("EF_RETRY_ON_FAILURE"))
                 : 0;
 
-        public static readonly string EfSchema =
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EF_SCHEMA"))
-                ? Environment.GetEnvironmentVariable("EF_SCHEMA")
+        public static readonly string EfDatabase =
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EF_DATABASE"))
+                ? Environment.GetEnvironmentVariable("EF_DATABASE")
                 : null;
 
         public static ServerVersion ServerVersion => _lazyServerVersion.Value;

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySql55Test.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySql55Test.cs
@@ -127,14 +127,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 Sql);
         }
 
-        protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operation)
+        protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operations)
         {
             var services = MySqlTestHelpers.Instance.CreateContextServices(new Version(5, 5, 2), ServerType.MySql);
             var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
             buildAction(modelBuilder);
 
             var batch = services.GetRequiredService<IMigrationsSqlGenerator>()
-                .Generate(operation, modelBuilder.Model);
+                .Generate(ResetSchema(operations), modelBuilder.Model);
 
             Sql = string.Join(
                 EOL,

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
@@ -37,8 +38,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 {
                     Table = "Pie",
                     PrincipalTable = "Flavor",
-                    Columns = new[] {"FlavorId"},
-                    PrincipalColumns = new[] {"Id"}
+                    Columns = new[] { "FlavorId" },
+                    PrincipalColumns = new[] { "Id" }
                 });
 
             Assert.Equal(
@@ -81,23 +82,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         }
 
         [Fact]
-        public void EnsureSchemaOperation()
-        {
-            Generate(new EnsureSchemaOperation
-            {
-                Name = "mySchema"
-            });
-
-            Assert.Equal(
-                @"CREATE DATABASE IF NOT EXISTS `mySchema`;" + EOL,
-                Sql,
-                ignoreLineEndingDifferences: true);
-        }
-
-        [Fact]
         public virtual void CreateDatabaseOperation()
         {
-            Generate(new MySqlCreateDatabaseOperation {Name = "Northwind"});
+            Generate(new MySqlCreateDatabaseOperation { Name = "Northwind" });
 
             Assert.Equal(
                 @"CREATE DATABASE `Northwind`;" + EOL,
@@ -110,7 +97,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.CreateTableOperation();
 
             Assert.Equal(
-                @"CREATE TABLE `dbo`.`People` (
+                @"CREATE TABLE `People` (
     `Id` int NOT NULL,
     `EmployerId` int NULL,
     `SSN` char(11) NULL,
@@ -129,7 +116,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 new CreateTableOperation
                 {
                     Name = "TestUlongAutoIncrement",
-                    Schema = "dbo",
                     Columns =
                     {
                         new AddColumnOperation
@@ -144,12 +130,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                     },
                     PrimaryKey = new AddPrimaryKeyOperation
                     {
-                        Columns = new[] {"Id"}
+                        Columns = new[] { "Id" }
                     }
                 });
 
             Assert.Equal(
-                "CREATE TABLE `dbo`.`TestUlongAutoIncrement` (" + EOL +
+                "CREATE TABLE `TestUlongAutoIncrement` (" + EOL +
                 "    `Id` bigint unsigned NOT NULL AUTO_INCREMENT," + EOL +
                 "    PRIMARY KEY (`Id`)" + EOL +
                 ");" + EOL,
@@ -248,7 +234,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.AddColumnOperation_with_defaultValue();
 
             Assert.Equal(
-                @"ALTER TABLE `dbo`.`People` ADD `Name` varchar(30) NOT NULL DEFAULT 'John Doe';" + EOL,
+                @"ALTER TABLE `People` ADD `Name` varchar(30) NOT NULL DEFAULT 'John Doe';" + EOL,
                 Sql);
         }
 
@@ -565,7 +551,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.AddForeignKeyOperation_with_name();
 
             Assert.Equal(
-                "ALTER TABLE `dbo`.`People` ADD CONSTRAINT `FK_People_Companies` FOREIGN KEY (`EmployerId1`, `EmployerId2`) REFERENCES `hr`.`Companies` (`Id1`, `Id2`) ON DELETE CASCADE;" +
+                "ALTER TABLE `People` ADD CONSTRAINT `FK_People_Companies` FOREIGN KEY (`EmployerId1`, `EmployerId2`) REFERENCES `Companies` (`Id1`, `Id2`) ON DELETE CASCADE;" +
                 EOL,
                 Sql);
         }
@@ -577,17 +563,15 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 new AddForeignKeyOperation
                 {
                     Table = "People",
-                    Schema = "dbo",
                     Name = "FK_ASuperLongForeignKeyNameThatIsDefinetelyNotGoingToFitInThe64CharactersLimit",
-                    Columns = new[] {"EmployerId1", "EmployerId2"},
+                    Columns = new[] { "EmployerId1", "EmployerId2" },
                     PrincipalTable = "Companies",
-                    PrincipalSchema = "hr",
-                    PrincipalColumns = new[] {"Id1", "Id2"},
+                    PrincipalColumns = new[] { "Id1", "Id2" },
                     OnDelete = ReferentialAction.Cascade
                 });
 
             Assert.Equal(
-                "ALTER TABLE `dbo`.`People` ADD CONSTRAINT `FK_ASuperLongForeignKeyNameThatIsDefinetelyNotGoingToFitInThe64C` FOREIGN KEY (`EmployerId1`, `EmployerId2`) REFERENCES `hr`.`Companies` (`Id1`, `Id2`) ON DELETE CASCADE;" +
+                "ALTER TABLE `People` ADD CONSTRAINT `FK_ASuperLongForeignKeyNameThatIsDefinetelyNotGoingToFitInThe64C` FOREIGN KEY (`EmployerId1`, `EmployerId2`) REFERENCES `Companies` (`Id1`, `Id2`) ON DELETE CASCADE;" +
                 EOL,
                 Sql);
         }
@@ -607,7 +591,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.AddPrimaryKeyOperation_with_name();
 
             Assert.Equal(
-                "ALTER TABLE `dbo`.`People` ADD CONSTRAINT `PK_People` PRIMARY KEY (`Id1`, `Id2`);" + EOL,
+                "ALTER TABLE `People` ADD CONSTRAINT `PK_People` PRIMARY KEY (`Id1`, `Id2`);" + EOL,
                 Sql);
         }
 
@@ -630,7 +614,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.AddUniqueConstraintOperation_with_name();
 
             Assert.Equal(
-                "ALTER TABLE `dbo`.`People` ADD CONSTRAINT `AK_People_DriverLicense` UNIQUE (`DriverLicense_State`, `DriverLicense_Number`);" +
+                "ALTER TABLE `People` ADD CONSTRAINT `AK_People_DriverLicense` UNIQUE (`DriverLicense_State`, `DriverLicense_Number`);" +
                 EOL,
                 Sql);
         }
@@ -646,25 +630,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         }
 
         [Fact]
-        public void DropSchemaOperation()
-        {
-            Generate(new DropSchemaOperation
-            {
-                Name = "mySchema"
-            });
-
-            Assert.Equal(
-                @"DROP SCHEMA `mySchema`;" + EOL,
-                Sql);
-        }
-
-        [Fact]
         public override void CreateIndexOperation_unique()
         {
             base.CreateIndexOperation_unique();
 
             Assert.Equal(
-                "CREATE UNIQUE INDEX `IX_People_Name` ON `dbo`.`People` (`FirstName`, `LastName`);" + EOL,
+                "CREATE UNIQUE INDEX `IX_People_Name` ON `People` (`FirstName`, `LastName`);" + EOL,
                 Sql);
         }
 
@@ -676,13 +647,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 {
                     Name = "IX_People_Name",
                     Table = "People",
-                    Schema = "dbo",
-                    Columns = new[] {"FirstName", "LastName"},
+                    Columns = new[] { "FirstName", "LastName" },
                     [MySqlAnnotationNames.FullTextIndex] = true
                 });
 
             Assert.Equal(
-                "CREATE FULLTEXT INDEX `IX_People_Name` ON `dbo`.`People` (`FirstName`, `LastName`);" + EOL,
+                "CREATE FULLTEXT INDEX `IX_People_Name` ON `People` (`FirstName`, `LastName`);" + EOL,
                 Sql);
         }
 
@@ -694,13 +664,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 {
                     Name = "IX_People_Name",
                     Table = "People",
-                    Schema = "dbo",
-                    Columns = new[] {"FirstName", "LastName"},
+                    Columns = new[] { "FirstName", "LastName" },
                     [MySqlAnnotationNames.SpatialIndex] = true
                 });
 
             Assert.Equal(
-                "CREATE SPATIAL INDEX `IX_People_Name` ON `dbo`.`People` (`FirstName`, `LastName`);" + EOL,
+                "CREATE SPATIAL INDEX `IX_People_Name` ON `People` (`FirstName`, `LastName`);" + EOL,
                 Sql);
         }
 
@@ -722,7 +691,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 {
                     Name = "IX_ASuperLongForeignKeyNameThatIsDefinetelyNotGoingToFitInThe64CharactersLimit",
                     Table = "People",
-                    Columns = new[] {"Name"},
+                    Columns = new[] { "Name" },
                     IsUnique = false
                 });
 
@@ -815,7 +784,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.DropColumnOperation();
 
             Assert.Equal(
-                "ALTER TABLE `dbo`.`People` DROP COLUMN `LuckyNumber`;" + EOL,
+                "ALTER TABLE `People` DROP COLUMN `LuckyNumber`;" + EOL,
                 Sql);
         }
 
@@ -825,7 +794,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.DropForeignKeyOperation();
 
             Assert.Equal(
-                "ALTER TABLE `dbo`.`People` DROP FOREIGN KEY `FK_People_Companies`;" + EOL,
+                "ALTER TABLE `People` DROP FOREIGN KEY `FK_People_Companies`;" + EOL,
                 Sql);
         }
 
@@ -835,8 +804,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.DropPrimaryKeyOperation();
 
             Assert.Equal(
-                @"CALL POMELO_BEFORE_DROP_PRIMARY_KEY('dbo', 'People');
-ALTER TABLE `dbo`.`People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replace("\n", EOL) + EOL,
+                @"CALL POMELO_BEFORE_DROP_PRIMARY_KEY(NULL, 'People');
+ALTER TABLE `People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replace("\n", EOL) + EOL,
                 Sql);
         }
 
@@ -846,7 +815,7 @@ ALTER TABLE `dbo`.`People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replac
             base.DropTableOperation();
 
             Assert.Equal(
-                "DROP TABLE `dbo`.`People`;" + EOL,
+                "DROP TABLE `People`;" + EOL,
                 Sql);
         }
 
@@ -856,7 +825,7 @@ ALTER TABLE `dbo`.`People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replac
             base.DropUniqueConstraintOperation();
 
             Assert.Equal(
-                "ALTER TABLE `dbo`.`People` DROP KEY `AK_People_SSN`;" + EOL,
+                "ALTER TABLE `People` DROP KEY `AK_People_SSN`;" + EOL,
                 Sql);
         }
 
@@ -865,7 +834,7 @@ ALTER TABLE `dbo`.`People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replac
             base.DropIndexOperation();
 
             Assert.Equal(
-                @"ALTER TABLE `dbo`.`People` DROP INDEX `IX_People_Name`;" + EOL,
+                @"ALTER TABLE `People` DROP INDEX `IX_People_Name`;" + EOL,
                 Sql);
         }
 
@@ -929,32 +898,57 @@ ALTER TABLE `dbo`.`People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replac
         {
         }
 
-        protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operation)
+        protected override void Generate(params MigrationOperation[] operations)
+            => base.Generate(ResetSchema(operations));
+
+        protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operations)
         {
             var services = MySqlTestHelpers.Instance.CreateContextServices();
             var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
             buildAction(modelBuilder);
 
             var batch = services.GetRequiredService<IMigrationsSqlGenerator>()
-                .Generate(operation, modelBuilder.Model);
+                .Generate(ResetSchema(operations), modelBuilder.Model);
 
             Sql = string.Join(
                 EOL,
                 batch.Select(b => b.CommandText));
         }
 
-        protected virtual void Generate(Action<ModelBuilder> buildAction, CharSetBehavior charSetBehavior, CharSet charSet, params MigrationOperation[] operation)
+        protected virtual void Generate(Action<ModelBuilder> buildAction, CharSetBehavior charSetBehavior, CharSet charSet, params MigrationOperation[] operations)
         {
             var services = MySqlTestHelpers.Instance.CreateContextServices(charSetBehavior, charSet);
             var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
             buildAction(modelBuilder);
 
             var batch = services.GetRequiredService<IMigrationsSqlGenerator>()
-                .Generate(operation, modelBuilder.Model);
+                .Generate(ResetSchema(operations), modelBuilder.Model);
 
             Sql = string.Join(
                 EOL,
                 batch.Select(b => b.CommandText));
+        }
+
+        /// <summary>
+        /// The base class does set schema values, while MySQL does not support
+        /// the EF Core concept of schemas.
+        /// </summary>
+        protected virtual MigrationOperation[] ResetSchema(params MigrationOperation[] operations)
+        {
+            foreach (var operation in operations)
+            {
+                var schemaPropertyInfos = operation
+                    .GetType()
+                    .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty)
+                    .Where(p => p.Name.Contains(nameof(AddForeignKeyOperation.Schema), StringComparison.Ordinal));
+
+                foreach (var schemaPropertyInfo in schemaPropertyInfos)
+                {
+                    schemaPropertyInfo.SetValue(operation, null);
+                }
+            }
+
+            return operations;
         }
     }
 }

--- a/test/EFCore.MySql.IntegrationTests/AppConfig.cs
+++ b/test/EFCore.MySql.IntegrationTests/AppConfig.cs
@@ -18,9 +18,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests
                 ? Convert.ToInt32(Environment.GetEnvironmentVariable("EF_RETRY_ON_FAILURE"))
                 : 0;
 
-        public static readonly string EfSchema =
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EF_SCHEMA"))
-                ? Environment.GetEnvironmentVariable("EF_SCHEMA")
+        public static readonly string EfDatabase =
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EF_DATABASE"))
+                ? Environment.GetEnvironmentVariable("EF_DATABASE")
                 : null;
 
         public static ServerVersion ServerVersion => _lazyServerVersion.Value;

--- a/test/EFCore.MySql.IntegrationTests/AppDb.cs
+++ b/test/EFCore.MySql.IntegrationTests/AppDb.cs
@@ -6,106 +6,101 @@ using Microsoft.EntityFrameworkCore;
 namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests
 {
     public class AppDb : IdentityDbContext<AppIdentityUser>
-	{
-		// blog
-		public DbSet<Blog> Blogs { get; set; }
+    {
+        // blog
+        public DbSet<Blog> Blogs { get; set; }
 
-		// crm
-		public DbSet<CrmAdmin> CrmAdmins { get; set; }
-		public DbSet<CrmRole> CrmRoles { get; set; }
-		public DbSet<CrmMenu> CrmMenus { get; set; }
+        // crm
+        public DbSet<CrmAdmin> CrmAdmins { get; set; }
+        public DbSet<CrmRole> CrmRoles { get; set; }
+        public DbSet<CrmMenu> CrmMenus { get; set; }
 
-		// data types
-		public DbSet<DataTypesSimple> DataTypesSimple { get; set; }
-		public DbSet<DataTypesVariable> DataTypesVariable { get; set; }
+        // data types
+        public DbSet<DataTypesSimple> DataTypesSimple { get; set; }
+        public DbSet<DataTypesVariable> DataTypesVariable { get; set; }
 
-		// generated data types
-		public DbSet<GeneratedContact> GeneratedContacts { get; set; }
-		public DbSet<GeneratedTime> GeneratedTime { get; set; }
-		public DbSet<GeneratedConcurrencyCheck> GeneratedConcurrencyCheck { get; set; }
-	    public DbSet<GeneratedRowVersion> GeneratedRowVersion { get; set; }
+        // generated data types
+        public DbSet<GeneratedContact> GeneratedContacts { get; set; }
+        public DbSet<GeneratedTime> GeneratedTime { get; set; }
+        public DbSet<GeneratedConcurrencyCheck> GeneratedConcurrencyCheck { get; set; }
+        public DbSet<GeneratedRowVersion> GeneratedRowVersion { get; set; }
 
-		// people
-		public DbSet<Person> People { get; set; }
-		public DbSet<PersonTeacher> PeopleTeachers { get; set; }
-		public DbSet<PersonKid> PeopleKids { get; set; }
-		public DbSet<PersonParent> PeopleParents { get; set; }
-		public DbSet<PersonFamily> PeopleFamilies { get; set; }
+        // people
+        public DbSet<Person> People { get; set; }
+        public DbSet<PersonTeacher> PeopleTeachers { get; set; }
+        public DbSet<PersonKid> PeopleKids { get; set; }
+        public DbSet<PersonParent> PeopleParents { get; set; }
+        public DbSet<PersonFamily> PeopleFamilies { get; set; }
 
         // batch
         public DbSet<Product> Products { get; set; }
         public DbSet<ProductCategory> ProductCategory { get; set; }
         public DbSet<Category> Categories { get; set; }
 
-		// sequence
-		public DbSet<Sequence> Sequence { get; set; }
+        // sequence
+        public DbSet<Sequence> Sequence { get; set; }
 
         public AppDb(DbContextOptions options) : base(options)
-		{
-		}
+        {
+        }
 
-		protected override void OnModelCreating(ModelBuilder modelBuilder)
-		{
-			base.OnModelCreating(modelBuilder);
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
 
-			// Shorten key length for Identity
-			modelBuilder.Entity<AppIdentityUser>(entity => {
-				entity.Property(m => m.Email).HasMaxLength(127);
-				entity.Property(m => m.NormalizedEmail).HasMaxLength(127);
-				entity.Property(m => m.NormalizedUserName).HasMaxLength(127);
-				entity.Property(m => m.UserName).HasMaxLength(127);
-			});
-			modelBuilder.Entity<IdentityRole>(entity => {
-				entity.Property(m => m.Name).HasMaxLength(127);
-				entity.Property(m => m.NormalizedName).HasMaxLength(127);
-			});
-			modelBuilder.Entity<IdentityUserLogin<string>>(entity =>
-			{
-				entity.Property(m => m.LoginProvider).HasMaxLength(127);
-				entity.Property(m => m.ProviderKey).HasMaxLength(127);
-			});
-			modelBuilder.Entity<IdentityUserRole<string>>(entity =>
-			{
-				entity.Property(m => m.UserId).HasMaxLength(127);
-				entity.Property(m => m.RoleId).HasMaxLength(127);
-			});
-			modelBuilder.Entity<IdentityUserToken<string>>(entity =>
-			{
-				entity.Property(m => m.UserId).HasMaxLength(127);
-				entity.Property(m => m.LoginProvider).HasMaxLength(127);
-				entity.Property(m => m.Name).HasMaxLength(127);
+            // Shorten key length for Identity
+            modelBuilder.Entity<AppIdentityUser>(entity =>
+            {
+                entity.Property(m => m.Email).HasMaxLength(127);
+                entity.Property(m => m.NormalizedEmail).HasMaxLength(127);
+                entity.Property(m => m.NormalizedUserName).HasMaxLength(127);
+                entity.Property(m => m.UserName).HasMaxLength(127);
+            });
+            modelBuilder.Entity<IdentityRole>(entity =>
+            {
+                entity.Property(m => m.Name).HasMaxLength(127);
+                entity.Property(m => m.NormalizedName).HasMaxLength(127);
+            });
+            modelBuilder.Entity<IdentityUserLogin<string>>(entity =>
+            {
+                entity.Property(m => m.LoginProvider).HasMaxLength(127);
+                entity.Property(m => m.ProviderKey).HasMaxLength(127);
+            });
+            modelBuilder.Entity<IdentityUserRole<string>>(entity =>
+            {
+                entity.Property(m => m.UserId).HasMaxLength(127);
+                entity.Property(m => m.RoleId).HasMaxLength(127);
+            });
+            modelBuilder.Entity<IdentityUserToken<string>>(entity =>
+            {
+                entity.Property(m => m.UserId).HasMaxLength(127);
+                entity.Property(m => m.LoginProvider).HasMaxLength(127);
+                entity.Property(m => m.Name).HasMaxLength(127);
 
-			});
+            });
             modelBuilder.Entity<ProductCategory>()
                 .HasKey(x => new { x.ProductId, x.CategoryId });
 
-		    modelBuilder.Entity<DataTypesVariable>(eb =>
-		    {
-		        // Need to specify the type until EF#12212 is fixed
-		        eb.Property(e => e.TypeJsonArray).HasColumnType("json");
-		        eb.Property(e => e.TypeJsonArrayN).HasColumnType("json");
-		        eb.Property(e => e.TypeJsonObject).HasColumnType("json");
-		        eb.Property(e => e.TypeJsonObjectN).HasColumnType("json");
-		    });
+            modelBuilder.Entity<DataTypesVariable>(eb =>
+            {
+            // Need to specify the type until EF#12212 is fixed
+            eb.Property(e => e.TypeJsonArray).HasColumnType("json");
+                eb.Property(e => e.TypeJsonArrayN).HasColumnType("json");
+                eb.Property(e => e.TypeJsonObject).HasColumnType("json");
+                eb.Property(e => e.TypeJsonObjectN).HasColumnType("json");
+            });
 
-		    modelBuilder.Entity<GeneratedContact>(eb =>
-		    {
-		        // Need to specify the type until EF#12212 is fixed
-		        eb.Property(e => e.Names).HasColumnType("json");
-		        eb.Property(e => e.ContactInfo).HasColumnType("json");
-		    });
+            modelBuilder.Entity<GeneratedContact>(eb =>
+            {
+            // Need to specify the type until EF#12212 is fixed
+            eb.Property(e => e.Names).HasColumnType("json");
+                eb.Property(e => e.ContactInfo).HasColumnType("json");
+            });
 
             // Add our models fluent APIs
             CrmMeta.OnModelCreating(modelBuilder);
-			GeneratedContactMeta.OnModelCreating(modelBuilder);
-			PeopleMeta.OnModelCreating(modelBuilder);
-
-		    if (AppConfig.EfSchema != null)
-		    {
-                // Generates all models in a different schema
-		        modelBuilder.HasDefaultSchema(AppConfig.EfSchema);
-		    }
-
-		}
-	}
+            GeneratedContactMeta.OnModelCreating(modelBuilder);
+            PeopleMeta.OnModelCreating(modelBuilder);
+        }
+    }
 }


### PR DESCRIPTION
Throw if a non-empty schema has been set, as MySQL does not support the EF Core concept of schemas.

This might be a breaking change for anybody who used that loophole in previous versions.

Addresses #922, #897, #892 and possibly others.