### PR TITLE
Use type `string` for all `MySql:CharSet` annotation values

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,6 +37,9 @@
     <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>2.2.4</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
     <MicrosoftExtensionsConfigurationFileExtensionsVersion>2.2.0</MicrosoftExtensionsConfigurationFileExtensionsVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>2.2.0</MicrosoftExtensionsConfigurationJsonVersion>
+    <SystemComponentModelTypeConverterVersion>4.3.0</SystemComponentModelTypeConverterVersion>
+    <CastleCoreVersion>4.0.0</CastleCoreVersion>
+    <NetTopologySuiteVersion>2.0.0</NetTopologySuiteVersion>
      <!-- EFCoreMySqlIntegrationTests Dependencies -->
     <MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion>3.0.0</MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion>
     <MicrosoftAspNetCoreMvcNewtonsoftJsonVersion>3.0.0</MicrosoftAspNetCoreMvcNewtonsoftJsonVersion>

--- a/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
@@ -29,18 +29,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
             Check.NotNull(property, nameof(property));
             Check.NotNull(annotation, nameof(annotation));
 
-            if (annotation.Name == MySqlAnnotationNames.CharSet &&
-                annotation.Value is string charSetName &&
-                charSetName.Length > 0)
-            {
-                var charSetFieldInfo = CharSet.GetFieldInfoFromName(charSetName);
-
-                return charSetFieldInfo != null
-                    ? new MethodCallCodeFragment("HasCharSet", new MySqlCodeGenerationMemberAccess(charSetFieldInfo))
-                    : null;
-            }
-
-            return null;
+            return annotation.Name == MySqlAnnotationNames.CharSet &&
+                   annotation.Value is string charSetName &&
+                   charSetName.Length > 0
+                ? new MethodCallCodeFragment("HasCharSet", charSetName)
+                : null;
         }
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
@@ -76,6 +76,24 @@ namespace Microsoft.EntityFrameworkCore
         /// Configures the <see cref="CharSet"/> for the property's column.
         /// </summary>
         /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="charSetName">The name of the charset to configure for the property's column.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static PropertyBuilder HasCharSet(
+            [NotNull] this PropertyBuilder propertyBuilder,
+            string charSetName)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            var property = propertyBuilder.Metadata;
+            property.SetCharSet(charSetName);
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="CharSet"/> for the property's column.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
         /// <param name="charSet">The <see cref="CharSet"/> to configure for the property's column.</param>
         /// <returns>The same builder instance so that multiple calls can be chained.</returns>
         public static PropertyBuilder HasCharSet(
@@ -85,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
             var property = propertyBuilder.Metadata;
-            property.SetCharSet(charSet);
+            property.SetCharSet(charSet?.Name);
 
             return propertyBuilder;
         }

--- a/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
@@ -140,57 +140,19 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
             => property.FindTypeMapping()?.Converter ?? property.GetValueConverter();
 
         /// <summary>
-        /// Returns the <see cref="CharSet"/> used by the property's column.
+        /// Returns the name of the charset used by the column of the property.
         /// </summary>
-        /// <param name="property">The property of which get its column's <see cref="CharSet"/> from.</param>
-        /// <returns>The <see cref="CharSet"/> or null, if no explicit <see cref="CharSet"/> was set.</returns>
-        public static CharSet GetCharSet([NotNull] this IProperty property)
-        {
-            var charSetName = property[MySqlAnnotationNames.CharSet] as string;
-
-            if (string.IsNullOrEmpty(charSetName))
-            {
-                return null;
-            }
-
-            return CharSet.GetCharSetFromName(charSetName);
-        }
+        /// <param name="property">The property of which to get the columns charset from.</param>
+        /// <returns>The name of the charset or null, if no explicit charset was set.</returns>
+        public static string GetCharSet([NotNull] this IProperty property)
+            => property[MySqlAnnotationNames.CharSet] as string;
 
         /// <summary>
-        /// Sets the <see cref="CharSet"/> in use by the property's column.
+        /// Sets the name of the charset in use by the column of the property.
         /// </summary>
-        /// <param name="property">The property to set the <see cref="CharSet"/> for.</param>
-        /// <param name="charSet">The <see cref="CharSet"/> used by the property's column.</param>
-        public static void SetCharSet([NotNull] this IMutableProperty property, CharSet charSet)
-        {
-            if (charSet != null &&
-                !property.IsUnicode().HasValue)
-            {
-                property.SetIsUnicode(charSet.IsUnicode);
-            }
-
-            property.SetOrRemoveAnnotation(MySqlAnnotationNames.CharSet, charSet);
-        }
-
-        /// <summary>
-        /// Sets a predefined <see cref="CharSet"/> by its name, that is in use by the property's column.
-        /// </summary>
-        /// <param name="property">The property to set the <see cref="CharSet"/> for.</param>
-        /// <param name="predefinedCharSetName">The charset name used by the property's column, that is
-        /// being resolved into a <see cref="CharSet"/> object.</param>
-        public static void SetCharSet([NotNull] this IMutableProperty property, string predefinedCharSetName)
-        {
-            Check.NotNull(property, nameof(property));
-            Check.NotEmpty(predefinedCharSetName, nameof(predefinedCharSetName));
-
-            var charSet = CharSet.GetCharSetFromName(predefinedCharSetName);
-
-            if (charSet == null)
-            {
-                throw new ArgumentOutOfRangeException($"Cannot find a predefined charset with the name of \"{predefinedCharSetName}\".");
-            }
-
-            property.SetCharSet(charSet);
-        }
+        /// <param name="property">The property to set the columns charset for.</param>
+        /// <param name="charSetName">The name of the charset used for the column of the property.</param>
+        public static void SetCharSet([NotNull] this IMutableProperty property, string charSetName)
+            => property.SetOrRemoveAnnotation(MySqlAnnotationNames.CharSet, charSetName);
     }
 }

--- a/src/EFCore.MySql/MySqlRetryingExecutionStrategy.cs
+++ b/src/EFCore.MySql/MySqlRetryingExecutionStrategy.cs
@@ -113,16 +113,5 @@ namespace Microsoft.EntityFrameworkCore
 
             return MySqlTransientExceptionDetector.ShouldRetryOn(exception);
         }
-
-        protected override TimeSpan? GetNextDelay(Exception lastException)
-        {
-            var baseDelay = base.GetNextDelay(lastException);
-            if (baseDelay == null)
-            {
-                return null;
-            }
-
-            return baseDelay;
-        }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/EFCore.MySql.FunctionalTests.csproj
+++ b/test/EFCore.MySql.FunctionalTests/EFCore.MySql.FunctionalTests.csproj
@@ -43,6 +43,10 @@
     <Reference Include="Microsoft.EntityFrameworkCore.Specification.Tests">
       <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Specification.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Specification.Tests.dll</HintPath>
     </Reference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryVersion)" />
+    <PackageReference Include="NetTopologySuite" Version="$(NetTopologySuiteVersion)" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="$(SystemComponentModelTypeConverterVersion)" />
+    <PackageReference Include="Castle.Core" Version="$(CastleCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(LocalMySqlConnectorRepository)' != ''">


### PR DESCRIPTION
Use type `string` for all `MySql:CharSet` annotation values.
Fixes #926 

Add missing references for `EFCore.MySql.FunctionalTests`. Addresses the issue that lead to adding a reference to `Castle.Core` for the `EFCore.MySql` project, which was removed in #859 and #861.

As suspected, the reference is needed only for the `EFCore.MySql.FunctionalTests` project. It is usually just part of the referenced packages, but in case local EF Core assemblies are used, a couple of explicit references were missing.