### PR TITLE
Implement collation support similar to the charset implementation

### DIFF
--- a/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
@@ -29,11 +29,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
             Check.NotNull(property, nameof(property));
             Check.NotNull(annotation, nameof(annotation));
 
-            return annotation.Name == MySqlAnnotationNames.CharSet &&
-                   annotation.Value is string charSetName &&
-                   charSetName.Length > 0
-                ? new MethodCallCodeFragment("HasCharSet", charSetName)
-                : null;
+            switch (annotation.Name)
+            {
+                case MySqlAnnotationNames.CharSet when annotation.Value is string charSet && charSet.Length > 0:
+                    return new MethodCallCodeFragment("HasCharSet", charSet);
+
+                case MySqlAnnotationNames.Collation when annotation.Value is string collation && collation.Length > 0:
+                    return new MethodCallCodeFragment("HasCollation", collation);
+
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
@@ -73,25 +73,25 @@ namespace Microsoft.EntityFrameworkCore
             => (PropertyBuilder<TProperty>)UseMySqlComputedColumn((PropertyBuilder)propertyBuilder);
 
         /// <summary>
-        /// Configures the <see cref="CharSet"/> for the property's column.
+        /// Configures the charset for the property's column.
         /// </summary>
         /// <param name="propertyBuilder">The builder for the property being configured.</param>
-        /// <param name="charSetName">The name of the charset to configure for the property's column.</param>
+        /// <param name="charSet">The name of the charset to configure for the property's column.</param>
         /// <returns>The same builder instance so that multiple calls can be chained.</returns>
         public static PropertyBuilder HasCharSet(
             [NotNull] this PropertyBuilder propertyBuilder,
-            string charSetName)
+            string charSet)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
             var property = propertyBuilder.Metadata;
-            property.SetCharSet(charSetName);
+            property.SetCharSet(charSet);
 
             return propertyBuilder;
         }
 
         /// <summary>
-        /// Configures the <see cref="CharSet"/> for the property's column.
+        /// Configures the charset for the property's column.
         /// </summary>
         /// <param name="propertyBuilder">The builder for the property being configured.</param>
         /// <param name="charSet">The <see cref="CharSet"/> to configure for the property's column.</param>
@@ -104,6 +104,24 @@ namespace Microsoft.EntityFrameworkCore
 
             var property = propertyBuilder.Metadata;
             property.SetCharSet(charSet?.Name);
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        /// Configures the collation for the property's column.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="collation">The name of the collation to configure for the property's column.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static PropertyBuilder HasCollation(
+            [NotNull] this PropertyBuilder propertyBuilder,
+            string collation)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            var property = propertyBuilder.Metadata;
+            property.SetCollation(collation);
 
             return propertyBuilder;
         }

--- a/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
@@ -151,8 +151,24 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// Sets the name of the charset in use by the column of the property.
         /// </summary>
         /// <param name="property">The property to set the columns charset for.</param>
-        /// <param name="charSetName">The name of the charset used for the column of the property.</param>
-        public static void SetCharSet([NotNull] this IMutableProperty property, string charSetName)
-            => property.SetOrRemoveAnnotation(MySqlAnnotationNames.CharSet, charSetName);
+        /// <param name="charSet">The name of the charset used for the column of the property.</param>
+        public static void SetCharSet([NotNull] this IMutableProperty property, string charSet)
+            => property.SetOrRemoveAnnotation(MySqlAnnotationNames.CharSet, charSet);
+
+        /// <summary>
+        /// Returns the name of the collation used by the column of the property.
+        /// </summary>
+        /// <param name="property">The property of which to get the columns collation from.</param>
+        /// <returns>The name of the collation or null, if no explicit collation was set.</returns>
+        public static string GetCollation([NotNull] this IProperty property)
+            => property[MySqlAnnotationNames.Collation] as string;
+
+        /// <summary>
+        /// Sets the name of the collation in use by the column of the property.
+        /// </summary>
+        /// <param name="property">The property to set the columns collation for.</param>
+        /// <param name="collation">The name of the collation used for the column of the property.</param>
+        public static void SetCollation([NotNull] this IMutableProperty property, string collation)
+            => property.SetOrRemoveAnnotation(MySqlAnnotationNames.Collation, collation);
     }
 }

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
@@ -30,5 +30,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
         public const string SpatialIndex = Prefix + "SpatialIndex";
 
         public const string CharSet = Prefix + "CharSet";
+
+        public const string Collation = Prefix + "Collation";
     }
 }

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -785,7 +785,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             }
 
             var columnType = operation.ColumnType != null
-                ? GetColumnTypeWithCharSet(operation, operation.ColumnType)
+                ? GetColumnTypeWithCharSetAndCollation(operation, operation.ColumnType)
                 : GetColumnType(schema, table, name, operation, model);
             
             builder
@@ -799,11 +799,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         protected override string GetColumnType(string schema, string table, string name, ColumnOperation operation, IModel model)
-            => GetColumnTypeWithCharSet(
+            => GetColumnTypeWithCharSetAndCollation(
                 operation,
                 base.GetColumnType(schema, table, name, operation, model));
 
-        private static string GetColumnTypeWithCharSet(ColumnOperation operation, string columnType)
+        private static string GetColumnTypeWithCharSetAndCollation(ColumnOperation operation, string columnType)
         {
             var charSet = operation[MySqlAnnotationNames.CharSet];
             if (charSet != null)
@@ -814,6 +814,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 columnType = Regex.IsMatch(columnType, characterSetClausePattern, RegexOptions.IgnoreCase)
                     ? Regex.Replace(columnType, characterSetClausePattern, characterSetClause)
                     : columnType.TrimEnd() + " " + characterSetClause;
+            }
+
+            var collation = operation[MySqlAnnotationNames.Collation];
+            if (collation != null)
+            {
+                const string collationClausePattern = @"COLLATION \w+";
+                var collationClause = $@"COLLATION {collation}";
+
+                columnType = Regex.IsMatch(columnType, collationClausePattern, RegexOptions.IgnoreCase)
+                    ? Regex.Replace(columnType, collationClausePattern, collationClause)
+                    : columnType.TrimEnd() + " " + collationClause;
             }
 
             return columnType;

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -179,6 +179,7 @@ AND
     IF(`IS_NULLABLE` = 'YES', 1, 0) AS `IS_NULLABLE`,
     `DATA_TYPE`,
     `CHARACTER_SET_NAME`,
+    `COLLATION_NAME`,
     `COLUMN_TYPE`,
     `COLUMN_COMMENT`,
     `EXTRA`
@@ -208,6 +209,7 @@ AND
                             var nullable = reader.GetBoolean("IS_NULLABLE");
                             var dataType = reader.GetValueOrDefault<string>("DATA_TYPE");
                             var charset = reader.GetValueOrDefault<string>("CHARACTER_SET_NAME");
+                            var collation = reader.GetValueOrDefault<string>("COLLATION_NAME");
                             var columType = reader.GetValueOrDefault<string>("COLUMN_TYPE");
                             var extra = reader.GetValueOrDefault<string>("EXTRA");
                             var comment = reader.GetValueOrDefault<string>("COLUMN_COMMENT");
@@ -263,6 +265,7 @@ AND
                                 ValueGenerated = valueGenerated,
                                 Comment = string.IsNullOrEmpty(comment) ? null : comment,
                                 [MySqlAnnotationNames.CharSet] = charset,
+                                [MySqlAnnotationNames.Collation] = collation,
                             };
 
                             table.Columns.Add(column);


### PR DESCRIPTION
Fixes #929 

Let's assume the following table definition:

```sql
CREATE TABLE `Issue929`.`TestTable` (
  `Id` INT NOT NULL AUTO_INCREMENT,
  `varcharCharsetCollation` VARCHAR(45) CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin' NULL,
  `varcharCharset` VARCHAR(45) CHARACTER SET 'utf8mb4' NULL,
  `varcharCollation` VARCHAR(45) NULL COLLATE 'latin2_general_ci',
  `varchar` VARCHAR(45) NULL,
  PRIMARY KEY (`Id`)
) DEFAULT CHARACTER SET = latin1 COLLATE = latin1_general_cs;
```

It will be scaffolded like this:

```c#
modelBuilder.Entity<TestTable>(entity =>
{
    entity.Property(e => e.Id).HasColumnType("int(11)");

    entity.Property(e => e.Varchar)
        .HasColumnName("varchar")
        .HasColumnType("varchar(45)")
        .HasCharSet("latin1")
        .HasCollation("latin1_general_cs");

    entity.Property(e => e.VarcharCharset)
        .HasColumnName("varcharCharset")
        .HasColumnType("varchar(45)")
        .HasCharSet("utf8mb4")
        .HasCollation("utf8mb4_0900_ai_ci");

    entity.Property(e => e.VarcharCharsetCollation)
        .HasColumnName("varcharCharsetCollation")
        .HasColumnType("varchar(45)")
        .HasCharSet("utf8mb4")
        .HasCollation("utf8mb4_bin");

    entity.Property(e => e.VarcharCollation)
        .HasColumnName("varcharCollation")
        .HasColumnType("varchar(45)")
        .HasCharSet("latin2")
        .HasCollation("latin2_general_ci");
});
```