### PR TITLE
Introduce scaffolding specific connection string options

### DIFF
--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrator.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrator.cs
@@ -52,6 +52,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
             bool idempotent = false)
         {
             IEnumerable<string> appliedMigrations;
+
             if (string.IsNullOrEmpty(fromMigration)
                 || fromMigration == Migration.InitialDatabase)
             {
@@ -76,11 +77,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
             var dropPrimaryKeyExists = operations.Any(x => x is DropPrimaryKeyOperation);
             var addPrimaryKeyExists = operations.Any(x => x is AddPrimaryKeyOperation);
 
-            List<string> parts = new List<string>();
+            var parts = new List<string>();
+
             if (dropPrimaryKeyExists)
             {
                 parts.Add(PrepareString(BeforeDropPrimaryKeyHeader));
             }
+
             if (addPrimaryKeyExists)
             {
                 parts.Add(PrepareString(AfterAddPrimaryKeyHeader));
@@ -92,10 +95,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
             {
                 parts.Add(PrepareString(BeforeDropPrimaryKeyFooter));
             }
+
             if (addPrimaryKeyExists)
             {
                 parts.Add(PrepareString(AfterAddPrimaryKeyFooter));
             }
+
             return string.Join("", parts);
         }
 

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -825,8 +825,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var collation = operation[MySqlAnnotationNames.Collation];
             if (collation != null)
             {
-                const string collationClausePattern = @"COLLATION \w+";
-                var collationClause = $@"COLLATION {collation}";
+                const string collationClausePattern = @"COLLATE \w+";
+                var collationClause = $@"COLLATE {collation}";
 
                 columnType = Regex.IsMatch(columnType, collationClausePattern, RegexOptions.IgnoreCase)
                     ? Regex.Replace(columnType, collationClausePattern, collationClause)

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlCodeGenerator.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlCodeGenerator.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Scaffolding;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
 {
@@ -30,11 +31,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
         public override MethodCallCodeFragment GenerateUseProvider(
             string connectionString,
             MethodCallCodeFragment providerOptions)
-            => new MethodCallCodeFragment(
+        {
+            // Strip scaffolding specific connection string options first.
+            connectionString = new MySqlScaffoldingConnectionSettings(connectionString).GetProviderCompatibleConnectionString();
+
+            return new MethodCallCodeFragment(
                 nameof(MySqlDbContextOptionsExtensions.UseMySql),
                 providerOptions == null
-                ? new object[] { connectionString }
-                : new object[] { connectionString, new NestedClosureCodeFragment("x", providerOptions) });
+                    ? new object[] {connectionString}
+                    : new object[] {connectionString, new NestedClosureCodeFragment("x", providerOptions)});
+        }
     }
 }
 

--- a/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
@@ -35,6 +35,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             TreatTinyAsBoolean = csb.TreatTinyAsBoolean;
         }
 
+        public MySqlGuidFormat GuidFormat { get; }
+        public bool TreatTinyAsBoolean { get; }
+
         protected bool Equals(MySqlConnectionSettings other)
         {
             return GuidFormat == other.GuidFormat &&
@@ -65,13 +68,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         {
             unchecked
             {
-                var hashCode = (int)GuidFormat;
-                hashCode = (hashCode * 397) ^ TreatTinyAsBoolean.GetHashCode();
-                return hashCode;
+                return ((int)GuidFormat * 397) ^ TreatTinyAsBoolean.GetHashCode();
             }
         }
-
-        public MySqlGuidFormat GuidFormat { get; }
-        public bool TreatTinyAsBoolean { get; }
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlScaffoldingConnectionSettings.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlScaffoldingConnectionSettings.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Data.Common;
+using MySql.Data.MySqlClient;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
+{
+    // ReSharper disable VirtualMemberCallInConstructor
+    // ReSharper disable NonReadonlyMemberInGetHashCode
+    public class MySqlScaffoldingConnectionSettings
+    {
+        public const string ScaffoldPrefix = "Scaffold:";
+        public const string CharSetKey = ScaffoldPrefix + "CharSet";
+        public const string CollationKey = ScaffoldPrefix + "Collation";
+
+        private readonly DbConnectionStringBuilder _csb;
+
+        public MySqlScaffoldingConnectionSettings(string connectionString)
+        {
+            _csb = new DbConnectionStringBuilder { ConnectionString = connectionString };
+
+            CharSet = GetBoolean(CharSetKey, true);
+            Collation = GetBoolean(CollationKey, true);
+        }
+
+        public bool CharSet { get; set; }
+        public bool Collation { get; set; }
+
+        public string GetProviderCompatibleConnectionString()
+        {
+            var csb = new DbConnectionStringBuilder { ConnectionString = _csb.ConnectionString };
+
+            csb.Remove(CharSetKey);
+            csb.Remove(CollationKey);
+
+            return csb.ConnectionString;
+        }
+
+        protected virtual bool GetBoolean(string key, bool defaultValue = default)
+        {
+            if (_csb.TryGetValue(key, out var value))
+            {
+                if (value is string stringValue)
+                {
+                    if (int.TryParse(stringValue, out var intValue))
+                    {
+                        return intValue != 0;
+                    }
+
+                    if (bool.TryParse(stringValue, out var boolValue))
+                    {
+                        return boolValue;
+                    }
+
+                    if (stringValue.Equals("on", StringComparison.OrdinalIgnoreCase) ||
+                        stringValue.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+                        stringValue.Equals("enable", StringComparison.OrdinalIgnoreCase) ||
+                        stringValue.Equals("enabled", StringComparison.OrdinalIgnoreCase))
+                        return true;
+
+                    if (stringValue.Equals("off", StringComparison.OrdinalIgnoreCase) ||
+                        stringValue.Equals("no", StringComparison.OrdinalIgnoreCase) ||
+                        stringValue.Equals("disable", StringComparison.OrdinalIgnoreCase) ||
+                        stringValue.Equals("disabled", StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+
+                return Convert.ToBoolean(value);
+            }
+
+            return defaultValue;
+        }
+
+        protected bool Equals(MySqlScaffoldingConnectionSettings other)
+        {
+            return CharSet == other.CharSet && Collation == other.Collation;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return Equals((MySqlScaffoldingConnectionSettings)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (CharSet.GetHashCode() * 397) ^ Collation.GetHashCode();
+            }
+        }
+    }
+}


### PR DESCRIPTION
These settings can be used to control what the scaffolder generates.
Currently the following options are supported:
- `Scaffold:CharSet` (default is `true`) that generates `.HasCharSet()` calls for character based columns if `true`
- `Scaffold:Collation` (default is `true`) that generates `.HasCollation()` calls for character based columns if `true`

I wasn't sure if singular or plural option names are more intuitive, so I just went with singular ones.

A scaffolding command could look like this:

`dotnet ef dbcontext scaffold "server=127.0.0.1; uid=root; pwd=; port=3306; database=MyDatabase; Scaffold:CharSet=False; Scaffold:Collation=True"`

Addresses https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/913#issuecomment-550557616