### PR TITLE
Support server version specific models and migrations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
   - bash: ./dotnet-env.sh dotnet test --logger trx test/EFCore.MySql.Tests
     displayName: Tests
     continueOnError: true
-  - bash: ./dotnet-env.sh dotnet test test/EFCore.MySql.FunctionalTests -c Release --logger trx --verbosity detailed
+  - bash: ./dotnet-env.sh dotnet test test/EFCore.MySql.FunctionalTests -c Release --logger trx
     displayName: Functional Tests
     continueOnError: true
   - bash: ./dotnet-env.sh dotnet run --project test/EFCore.MySql.IntegrationTests -c Release testMigrate
@@ -176,7 +176,7 @@ jobs:
   - pwsh: .\dotnet-env.ps1 dotnet test --logger trx test\EFCore.MySql.Tests
     displayName: Tests
     continueOnError: true
-  - pwsh: .\dotnet-env.ps1 dotnet test test\EFCore.MySql.FunctionalTests -c Release --logger trx --verbosity detailed
+  - pwsh: .\dotnet-env.ps1 dotnet test test\EFCore.MySql.FunctionalTests -c Release --logger trx
     displayName: Functional Tests
     continueOnError: true
   - pwsh: .\dotnet-env.ps1 dotnet run --project test\EFCore.MySql.IntegrationTests -c Release testMigrate

--- a/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Storage;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
 {
@@ -22,6 +20,21 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
         public override bool IsHandledByConvention(IModel model, IAnnotation annotation)
         {
             return true;
+        }
+
+        public override MethodCallCodeFragment GenerateFluentApi(IModel model, IAnnotation annotation)
+        {
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(annotation, nameof(annotation));
+
+            switch (annotation.Name)
+            {
+                case MySqlAnnotationNames.ServerVersion when annotation.Value is string serverVersion && serverVersion.Length > 0:
+                    return new MethodCallCodeFragment("ForServerVersion", serverVersion);
+
+                default:
+                    return null;
+            }
         }
 
         public override MethodCallCodeFragment GenerateFluentApi(IProperty property, IAnnotation annotation)

--- a/src/EFCore.MySql/Extensions/MySqlModelBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlModelBuilderExtensions.cs
@@ -1,0 +1,47 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.Extensions;
+using Pomelo.EntityFrameworkCore.MySql.Storage;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     MySQL specific extension methods for <see cref="ModelBuilder" />.
+    /// </summary>
+    public static class MySqlModelBuilderExtensions
+    {
+        /// <summary>
+        /// Configures the server version the model is intended for.
+        /// </summary>
+        /// <param name="modelBuilder">The builder for the model being configured.</param>
+        /// <param name="serverVersion">The server version as a string that the model is intended for.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static ModelBuilder ForServerVersion(
+            [NotNull] this ModelBuilder modelBuilder,
+            string serverVersion)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+
+            modelBuilder.Model.SetServerVersion(serverVersion);
+
+            return modelBuilder;
+        }
+
+        /// <summary>
+        /// Configures the server version the model is intended for.
+        /// </summary>
+        /// <param name="modelBuilder">The builder for the model being configured.</param>
+        /// <param name="serverVersion">The <see cref="ServerVersion"/> that the model is intended for.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static ModelBuilder ForServerVersion(
+            [NotNull] this ModelBuilder modelBuilder,
+            ServerVersion serverVersion)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+
+            modelBuilder.Model.SetServerVersion(serverVersion.ToString());
+
+            return modelBuilder;
+        }
+    }
+}

--- a/src/EFCore.MySql/Extensions/MySqlModelExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlModelExtensions.cs
@@ -46,5 +46,21 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// <returns> The <see cref="ConfigurationSource" /> for the default <see cref="SqlServerValueGenerationStrategy" />. </returns>
         public static ConfigurationSource? GetValueGenerationStrategyConfigurationSource([NotNull] this IConventionModel model)
             => model.FindAnnotation(MySqlAnnotationNames.ValueGenerationStrategy)?.GetConfigurationSource();
+
+        /// <summary>
+        /// Returns the server version the model is intended for as a string.
+        /// </summary>
+        /// <param name="model">The model of which to get the intended server version from.</param>
+        /// <returns>The intended server version string or null, if no explicit server version was set.</returns>
+        public static string GetServerVersion([NotNull] this IModel model)
+            => model[MySqlAnnotationNames.ServerVersion] as string;
+
+        /// <summary>
+        /// Sets the intended server version for the model.
+        /// </summary>
+        /// <param name="model">The model to set the intended server version for.</param>
+        /// <param name="serverVersion">The server version as a string that the model is intended for.</param>
+        public static void SetServerVersion([NotNull] this IMutableModel model, string serverVersion)
+            => model.SetOrRemoveAnnotation(MySqlAnnotationNames.ServerVersion, serverVersion);
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
@@ -4,10 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Extensions

--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Pomelo.EntityFrameworkCore.MySql.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Pomelo.EntityFrameworkCore.MySql.Migrations;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -33,6 +33,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => WithOption(e => e.WithServerVersion(new ServerVersion(serverVersion)));
 
         /// <summary>
+        ///     Configures the target <see cref="ServerVersion"/>.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder ServerVersion(ServerVersion serverVersion)
+            => WithOption(e => e.WithServerVersion(serverVersion));
+
+        /// <summary>
         ///     Configures the Default CharSet Behavior
         /// </summary>
         public virtual MySqlDbContextOptionsBuilder CharSetBehavior(CharSetBehavior charSetBehavior)

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
@@ -15,6 +15,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
         /// </summary>
         public const string Prefix = "MySql:";
 
+        public const string ServerVersion = Prefix + "ServerVersion";
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -16,6 +16,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MySql.Data.MySqlClient;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
@@ -73,6 +74,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
 
                 databaseModel.DatabaseName = connection.Database;
                 databaseModel.DefaultSchema = GetDefaultSchema(connection);
+
+                databaseModel.SetAnnotation(
+                    MySqlAnnotationNames.ServerVersion,
+                    _serviceProvider.GetRequiredService<IMySqlConnectionInfo>().ServerVersion.ToString());
 
                 var schemaList = Enumerable.Empty<string>().ToList();
                 var tableList = options.Tables.ToList();

--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -86,24 +86,24 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
 
         #region Support checks for provider code
 
-        public bool SupportsDateTime6 => SupportMap[DateTime6SupportKey].IsSupported(this);
-        public bool SupportsLargerKeyLength => SupportMap[LargerKeyLengthSupportKey].IsSupported(this);
-        public bool SupportsRenameIndex => SupportMap[RenameIndexSupportKey].IsSupported(this);
-        public bool SupportsRenameColumn => SupportMap[RenameColumnSupportKey].IsSupported(this);
-        public bool SupportsWindowFunctions => SupportMap[WindowFunctionsSupportKey].IsSupported(this);
-        public bool SupportsFloatCast => SupportMap[FloatCastSupportKey].IsSupported(this);
-        public bool SupportsDoubleCast => SupportMap[DoubleCastSupportKey].IsSupported(this);
-        public bool SupportsOuterApply => SupportMap[OuterApplySupportKey].IsSupported(this);
-        public bool SupportsCrossApply => SupportMap[CrossApplySupportKey].IsSupported(this);
-        public bool SupportsJson => SupportMap[JsonSupportKey].IsSupported(this);
-        public bool SupportsGeneratedColumns => SupportMap[GeneratedColumnsSupportKey].IsSupported(this);
-        public bool SupportsNullableGeneratedColumns => SupportMap[NullableGeneratedColumnsSupportKey].IsSupported(this);
-        public bool SupportsDefaultCharSetUtf8Mb4 => SupportMap[DefaultCharSetUtf8Mb4SupportKey].IsSupported(this);
+        public virtual bool SupportsDateTime6 => SupportMap[DateTime6SupportKey].IsSupported(this);
+        public virtual bool SupportsLargerKeyLength => SupportMap[LargerKeyLengthSupportKey].IsSupported(this);
+        public virtual bool SupportsRenameIndex => SupportMap[RenameIndexSupportKey].IsSupported(this);
+        public virtual bool SupportsRenameColumn => SupportMap[RenameColumnSupportKey].IsSupported(this);
+        public virtual bool SupportsWindowFunctions => SupportMap[WindowFunctionsSupportKey].IsSupported(this);
+        public virtual bool SupportsFloatCast => SupportMap[FloatCastSupportKey].IsSupported(this);
+        public virtual bool SupportsDoubleCast => SupportMap[DoubleCastSupportKey].IsSupported(this);
+        public virtual bool SupportsOuterApply => SupportMap[OuterApplySupportKey].IsSupported(this);
+        public virtual bool SupportsCrossApply => SupportMap[CrossApplySupportKey].IsSupported(this);
+        public virtual bool SupportsJson => SupportMap[JsonSupportKey].IsSupported(this);
+        public virtual bool SupportsGeneratedColumns => SupportMap[GeneratedColumnsSupportKey].IsSupported(this);
+        public virtual bool SupportsNullableGeneratedColumns => SupportMap[NullableGeneratedColumnsSupportKey].IsSupported(this);
+        public virtual bool SupportsDefaultCharSetUtf8Mb4 => SupportMap[DefaultCharSetUtf8Mb4SupportKey].IsSupported(this);
 
         #endregion
 
-        public int MaxKeyLength => SupportsLargerKeyLength ? 3072 : 767;
-        public CharSet DefaultCharSet => SupportsDefaultCharSetUtf8Mb4 ? CharSet.Utf8Mb4 : CharSet.Latin1;
+        public virtual int MaxKeyLength => SupportsLargerKeyLength ? 3072 : 767;
+        public virtual CharSet DefaultCharSet => SupportsDefaultCharSetUtf8Mb4 ? CharSet.Utf8Mb4 : CharSet.Latin1;
         
         /// <summary>
         /// Constructs a new <see cref="ServerVersionSupport"/> object containing the <see cref="ServerVersion"/> objects

--- a/src/EFCore.MySql/Storage/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.cs
@@ -10,7 +10,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
     public partial class ServerVersion
     {
         private static readonly Regex _versionRegex = new Regex(@"\d+\.\d+\.?(?:\d+)?");
-        private static readonly ServerVersion _defaultVersion = new ServerVersion(new Version(8, 0, 0), ServerType.MySql);
+
+        public static ServerVersion Default = new ServerVersion(new Version(8, 0, 0), ServerType.MySql);
 
         public ServerVersion()
             : this(null)
@@ -37,8 +38,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             }
             else
             {
-                Version = _defaultVersion.Version;
-                Type = _defaultVersion.Type;
+                Version = Default.Version;
+                Type = Default.Type;
                 IsDefault = true;
             }
         }
@@ -49,9 +50,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             Type = type;
         }
 
-        public Version Version { get; }
-        public ServerType Type { get; }
-        public bool IsDefault { get; }
+        public virtual Version Version { get; }
+        public virtual ServerType Type { get; }
+        public virtual bool IsDefault { get; }
 
         public override bool Equals(object obj)
             => !(obj is null)

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySql55Test.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySql55Test.cs
@@ -93,7 +93,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         public override void RenameColumnOperation()
         {
             var migrationBuilder = new MigrationBuilder("MySql");
-
+            
             migrationBuilder.RenameColumn(
                     table: "Person",
                     name: "Name",
@@ -130,8 +130,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 
         protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operations)
         {
-            var services = MySqlTestHelpers.Instance.CreateContextServices(new ServerVersion("5.5.2-mysql"));
-            var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
+            var serverVersion = new ServerVersion("5.5.2-mysql");
+            var services = MySqlTestHelpers.Instance.CreateContextServices(serverVersion);
+            var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services)
+                .ForServerVersion(serverVersion);
+
             buildAction(modelBuilder);
 
             var batch = services.GetRequiredService<IMigrationsSqlGenerator>()

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySql55Test.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySql55Test.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.Extensions.DependencyInjection;
+using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
@@ -129,7 +130,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 
         protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operations)
         {
-            var services = MySqlTestHelpers.Instance.CreateContextServices(new Version(5, 5, 2), ServerType.MySql);
+            var services = MySqlTestHelpers.Instance.CreateContextServices(new ServerVersion("5.5.2-mysql"));
             var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
             buildAction(modelBuilder);
 

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.Extensions.DependencyInjection;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Xunit;
@@ -903,7 +904,7 @@ ALTER TABLE `People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replace("\n"
 
         protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operations)
         {
-            var services = MySqlTestHelpers.Instance.CreateContextServices();
+            var services = MySqlTestHelpers.Instance.CreateContextServices(new ServerVersion("8.0.0-mysql"));
             var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
             buildAction(modelBuilder);
 

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanFactAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanFactAttribute.cs
@@ -1,0 +1,24 @@
+﻿using Pomelo.EntityFrameworkCore.MySql.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+using Xunit;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes
+{
+    public sealed class SupportedServerVersionLessThanFactAttribute : FactAttribute
+    {
+        public SupportedServerVersionLessThanFactAttribute(params string[] versionsOrKeys)
+            : this(ServerVersion.GetSupport(versionsOrKeys))
+        {
+        }
+
+        private SupportedServerVersionLessThanFactAttribute(ServerVersionSupport serverVersionSupport)
+        {
+            var currentVersion = AppConfig.ServerVersion;
+
+            if (serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
+            {
+                Skip = $"Test is supported only on server versions lower than {serverVersionSupport}.";
+            }
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestHelpers.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestHelpers.cs
@@ -25,8 +25,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
         protected override void UseProviderOptions(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseMySql("Database=DummyDatabase");
 
-        public IServiceProvider CreateContextServices(Version version, ServerType type)
-            => ((IInfrastructure<IServiceProvider>)new DbContext(CreateOptions(version, type))).Instance;
+        public IServiceProvider CreateContextServices(ServerVersion serverVersion)
+            => ((IInfrastructure<IServiceProvider>)new DbContext(CreateOptions(serverVersion))).Instance;
 
         public IServiceProvider CreateContextServices(CharSetBehavior charSetBehavior, CharSet charSet)
             => ((IInfrastructure<IServiceProvider>)new DbContext(CreateOptions(charSetBehavior, charSet))).Instance;
@@ -39,10 +39,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
             return new ModelBuilder(conventionSet);
         }
 
-        public DbContextOptions CreateOptions(Version version, ServerType type)
+        public DbContextOptions CreateOptions(ServerVersion serverVersion)
         {
             var optionsBuilder = new DbContextOptionsBuilder();
-            optionsBuilder.UseMySql("Database=DummyDatabase", b => b.ServerVersion(version, type));
+            optionsBuilder.UseMySql("Database=DummyDatabase", b => b.ServerVersion(serverVersion));
 
             return optionsBuilder.Options;
         }


### PR DESCRIPTION
Introduces the annotation `MySql:ServerVersion` and the `ModelBuilder` extension method `ForServerVersion()`.

The annotation is automatically been generated when scaffolding and will be part of migrations if specified in the model definition the migrations are generated from.

The server version that a model is intended for can be specified like in the following code (it can also be specified as a `ServerVersion` object instead of a string):

```c#
protected override void OnModelCreating(ModelBuilder modelBuilder)
{
    modelBuilder.ForServerVersion("5.7.27-mysql");

    // ...
}
```

Migrations will generate SQL scripts based on this server version, e.g. regarding a `RenameColumn` operation an `ALTER TABLE RENAME COLUMN` statement will be generated for a server version of `8.0.0-mysql` or higher, while an `ALTER TABLE CHANGE COLUMN` statement will be generated for versions below that.