### PR TITLE
Improve `ServerVersion` support

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
@@ -4,10 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Extensions

--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Pomelo.EntityFrameworkCore.MySql.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Pomelo.EntityFrameworkCore.MySql.Migrations;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -33,6 +33,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => WithOption(e => e.WithServerVersion(new ServerVersion(serverVersion)));
 
         /// <summary>
+        ///     Configures the target <see cref="ServerVersion"/>.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder ServerVersion(ServerVersion serverVersion)
+            => WithOption(e => e.WithServerVersion(serverVersion));
+
+        /// <summary>
         ///     Configures the Default CharSet Behavior
         /// </summary>
         public virtual MySqlDbContextOptionsBuilder CharSetBehavior(CharSetBehavior charSetBehavior)

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -856,7 +856,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             else if (defaultValue != null)
             {
                 var typeMapping = Dependencies.TypeMappingSource.GetMappingForValue(defaultValue);
-
                 builder
                     .Append(" DEFAULT ")
                     .Append(typeMapping.GenerateSqlLiteral(defaultValue));

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -2,24 +2,24 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
-using Pomelo.EntityFrameworkCore.MySql.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Migrations
+namespace Pomelo.EntityFrameworkCore.MySql.Migrations
 {
     /// <summary>
     ///     MySql-specific implementation of <see cref="MigrationsSqlGenerator" />.
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         private readonly IMySqlConnectionInfo _connectionInfo;
         private readonly RelationalTypeMapping _stringTypeMapping;
 
-        private IReadOnlyList<MigrationOperation> _operations;
+        protected virtual ServerVersion ServerVersion => _connectionInfo.ServerVersion;
 
         public MySqlMigrationsSqlGenerator(
             [NotNull] MigrationsSqlGeneratorDependencies dependencies,
@@ -44,26 +44,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             _migrationsAnnotations = migrationsAnnotations;
             _connectionInfo = connectionInfo;
             _stringTypeMapping = dependencies.TypeMappingSource.GetMapping(typeof(string));
-        }
-
-        /// <summary>
-        ///     Generates commands from a list of operations.
-        /// </summary>
-        /// <param name="operations"> The operations. </param>
-        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
-        /// <returns> The list of commands to be executed or scripted. </returns>
-        public override IReadOnlyList<MigrationCommand> Generate(IReadOnlyList<MigrationOperation> operations,
-            IModel model = null)
-        {
-            _operations = operations;
-            try
-            {
-                return base.Generate(operations, model);
-            }
-            finally
-            {
-                _operations = null;
-            }
         }
 
         /// <summary>

--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -47,6 +47,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public const string DefaultCharSetUtf8Mb4MySqlSupportVersionString = "8.0.0-mysql";
         // public const string DefaultCharSetUtf8Mb4MariaDbSupportVersionString = "?.?.?-mariadb";
 
+        public const string DefaultExpressionMySqlSupportVersionString = "8.0.13-mysql";
+        // public const string DefaultExpressionMariaDbSupportVersionString = "?.?.?-mariadb";
+
         #endregion
 
         #region SupportMap keys for test attributes
@@ -64,6 +67,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public const string GeneratedColumnsSupportKey = nameof(GeneratedColumnsSupportKey);
         public const string NullableGeneratedColumnsSupportKey = nameof(NullableGeneratedColumnsSupportKey);
         public const string DefaultCharSetUtf8Mb4SupportKey = nameof(DefaultCharSetUtf8Mb4SupportKey);
+        public const string DefaultExpressionSupportKey = nameof(DefaultExpressionSupportKey);
 
         #endregion
 
@@ -82,28 +86,30 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             { GeneratedColumnsSupportKey, new ServerVersionSupport(GeneratedColumnsMySqlSupportVersionString, GeneratedColumnsMariaDbSupportVersionString) },
             { NullableGeneratedColumnsSupportKey, new ServerVersionSupport(NullableGeneratedColumnsMySqlSupportVersionString/*, NullableGeneratedColumnsMariaDbSupportVersionString*/) },
             { DefaultCharSetUtf8Mb4SupportKey, new ServerVersionSupport(DefaultCharSetUtf8Mb4MySqlSupportVersionString/*, DefaultCharSetUtf8Mb4MariaDbSupportVersionString*/) },
+            { DefaultExpressionSupportKey, new ServerVersionSupport(DefaultExpressionMySqlSupportVersionString/*, DefaultExpressionMariaDbSupportVersionString*/) },
         };
 
         #region Support checks for provider code
 
-        public bool SupportsDateTime6 => SupportMap[DateTime6SupportKey].IsSupported(this);
-        public bool SupportsLargerKeyLength => SupportMap[LargerKeyLengthSupportKey].IsSupported(this);
-        public bool SupportsRenameIndex => SupportMap[RenameIndexSupportKey].IsSupported(this);
-        public bool SupportsRenameColumn => SupportMap[RenameColumnSupportKey].IsSupported(this);
-        public bool SupportsWindowFunctions => SupportMap[WindowFunctionsSupportKey].IsSupported(this);
-        public bool SupportsFloatCast => SupportMap[FloatCastSupportKey].IsSupported(this);
-        public bool SupportsDoubleCast => SupportMap[DoubleCastSupportKey].IsSupported(this);
-        public bool SupportsOuterApply => SupportMap[OuterApplySupportKey].IsSupported(this);
-        public bool SupportsCrossApply => SupportMap[CrossApplySupportKey].IsSupported(this);
-        public bool SupportsJson => SupportMap[JsonSupportKey].IsSupported(this);
-        public bool SupportsGeneratedColumns => SupportMap[GeneratedColumnsSupportKey].IsSupported(this);
-        public bool SupportsNullableGeneratedColumns => SupportMap[NullableGeneratedColumnsSupportKey].IsSupported(this);
-        public bool SupportsDefaultCharSetUtf8Mb4 => SupportMap[DefaultCharSetUtf8Mb4SupportKey].IsSupported(this);
+        public virtual bool SupportsDateTime6 => SupportMap[DateTime6SupportKey].IsSupported(this);
+        public virtual bool SupportsLargerKeyLength => SupportMap[LargerKeyLengthSupportKey].IsSupported(this);
+        public virtual bool SupportsRenameIndex => SupportMap[RenameIndexSupportKey].IsSupported(this);
+        public virtual bool SupportsRenameColumn => SupportMap[RenameColumnSupportKey].IsSupported(this);
+        public virtual bool SupportsWindowFunctions => SupportMap[WindowFunctionsSupportKey].IsSupported(this);
+        public virtual bool SupportsFloatCast => SupportMap[FloatCastSupportKey].IsSupported(this);
+        public virtual bool SupportsDoubleCast => SupportMap[DoubleCastSupportKey].IsSupported(this);
+        public virtual bool SupportsOuterApply => SupportMap[OuterApplySupportKey].IsSupported(this);
+        public virtual bool SupportsCrossApply => SupportMap[CrossApplySupportKey].IsSupported(this);
+        public virtual bool SupportsJson => SupportMap[JsonSupportKey].IsSupported(this);
+        public virtual bool SupportsGeneratedColumns => SupportMap[GeneratedColumnsSupportKey].IsSupported(this);
+        public virtual bool SupportsNullableGeneratedColumns => SupportMap[NullableGeneratedColumnsSupportKey].IsSupported(this);
+        public virtual bool SupportsDefaultCharSetUtf8Mb4 => SupportMap[DefaultCharSetUtf8Mb4SupportKey].IsSupported(this);
+        public virtual bool SupportsDefaultExpression => SupportMap[DefaultExpressionSupportKey].IsSupported(this);
 
         #endregion
 
-        public int MaxKeyLength => SupportsLargerKeyLength ? 3072 : 767;
-        public CharSet DefaultCharSet => SupportsDefaultCharSetUtf8Mb4 ? CharSet.Utf8Mb4 : CharSet.Latin1;
+        public virtual int MaxKeyLength => SupportsLargerKeyLength ? 3072 : 767;
+        public virtual CharSet DefaultCharSet => SupportsDefaultCharSetUtf8Mb4 ? CharSet.Utf8Mb4 : CharSet.Latin1;
         
         /// <summary>
         /// Constructs a new <see cref="ServerVersionSupport"/> object containing the <see cref="ServerVersion"/> objects

--- a/src/EFCore.MySql/Storage/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.cs
@@ -11,7 +11,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
     {
         private static readonly Regex _versionRegex = new Regex(@"\d+\.\d+\.?(?:\d+)?");
 
-        public static ServerVersion Default = new ServerVersion(new Version(8, 0, 0), ServerType.MySql);
+        public static ServerVersion Default = new ServerVersion(new Version(8, 0, 17), ServerType.MySql);
 
         public ServerVersion()
             : this(null)

--- a/src/EFCore.MySql/Storage/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.cs
@@ -10,7 +10,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
     public partial class ServerVersion
     {
         private static readonly Regex _versionRegex = new Regex(@"\d+\.\d+\.?(?:\d+)?");
-        private static readonly ServerVersion _defaultVersion = new ServerVersion(new Version(8, 0, 0), ServerType.MySql);
+
+        public static ServerVersion Default = new ServerVersion(new Version(8, 0, 0), ServerType.MySql);
 
         public ServerVersion()
             : this(null)
@@ -37,8 +38,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             }
             else
             {
-                Version = _defaultVersion.Version;
-                Type = _defaultVersion.Type;
+                Version = Default.Version;
+                Type = Default.Type;
                 IsDefault = true;
             }
         }
@@ -49,9 +50,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             Type = type;
         }
 
-        public Version Version { get; }
-        public ServerType Type { get; }
-        public bool IsDefault { get; }
+        public virtual Version Version { get; }
+        public virtual ServerType Type { get; }
+        public virtual bool IsDefault { get; }
 
         public override bool Equals(object obj)
             => !(obj is null)

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySql55Test.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySql55Test.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.Extensions.DependencyInjection;
+using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
@@ -129,7 +130,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 
         protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operations)
         {
-            var services = MySqlTestHelpers.Instance.CreateContextServices(new Version(5, 5, 2), ServerType.MySql);
+            var services = MySqlTestHelpers.Instance.CreateContextServices(new ServerVersion("5.5.2-mysql"));
             var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
             buildAction(modelBuilder);
 

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.Extensions.DependencyInjection;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Xunit;
@@ -903,7 +904,7 @@ ALTER TABLE `People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replace("\n"
 
         protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operations)
         {
-            var services = MySqlTestHelpers.Instance.CreateContextServices();
+            var services = MySqlTestHelpers.Instance.CreateContextServices(new ServerVersion("8.0.0-mysql"));
             var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
             buildAction(modelBuilder);
 

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
@@ -904,7 +904,7 @@ ALTER TABLE `People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replace("\n"
 
         protected override void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operations)
         {
-            var services = MySqlTestHelpers.Instance.CreateContextServices(new ServerVersion("8.0.0-mysql"));
+            var services = MySqlTestHelpers.Instance.CreateContextServices(ServerVersion.Default);
             var modelBuilder = MySqlTestHelpers.Instance.CreateConventionBuilder(services);
             buildAction(modelBuilder);
 

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanFactAttribute.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Attributes/SupportedServerVersionLessThanFactAttribute.cs
@@ -1,0 +1,24 @@
+﻿using Pomelo.EntityFrameworkCore.MySql.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+using Xunit;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes
+{
+    public sealed class SupportedServerVersionLessThanFactAttribute : FactAttribute
+    {
+        public SupportedServerVersionLessThanFactAttribute(params string[] versionsOrKeys)
+            : this(ServerVersion.GetSupport(versionsOrKeys))
+        {
+        }
+
+        private SupportedServerVersionLessThanFactAttribute(ServerVersionSupport serverVersionSupport)
+        {
+            var currentVersion = AppConfig.ServerVersion;
+
+            if (serverVersionSupport.IsSupported(currentVersion) && string.IsNullOrEmpty(Skip))
+            {
+                Skip = $"Test is supported only on server versions lower than {serverVersionSupport}.";
+            }
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestHelpers.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestHelpers.cs
@@ -25,8 +25,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
         protected override void UseProviderOptions(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseMySql("Database=DummyDatabase");
 
-        public IServiceProvider CreateContextServices(Version version, ServerType type)
-            => ((IInfrastructure<IServiceProvider>)new DbContext(CreateOptions(version, type))).Instance;
+        public IServiceProvider CreateContextServices(ServerVersion serverVersion)
+            => ((IInfrastructure<IServiceProvider>)new DbContext(CreateOptions(serverVersion))).Instance;
 
         public IServiceProvider CreateContextServices(CharSetBehavior charSetBehavior, CharSet charSet)
             => ((IInfrastructure<IServiceProvider>)new DbContext(CreateOptions(charSetBehavior, charSet))).Instance;
@@ -39,10 +39,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
             return new ModelBuilder(conventionSet);
         }
 
-        public DbContextOptions CreateOptions(Version version, ServerType type)
+        public DbContextOptions CreateOptions(ServerVersion serverVersion)
         {
             var optionsBuilder = new DbContextOptionsBuilder();
-            optionsBuilder.UseMySql("Database=DummyDatabase", b => b.ServerVersion(version, type));
+            optionsBuilder.UseMySql("Database=DummyDatabase", b => b.ServerVersion(serverVersion));
 
             return optionsBuilder.Options;
         }


### PR DESCRIPTION
Make it easier to override `ServerVersion` members, add another overload for `MySqlDbContextOptionsBuilder.ServerVersion()` that takes a `ServerVersion` object as a parameter and prepare support for MySQL default expressions.

If no explicit server version has been specified and auto detection is not being used (e.g. when generating scripts), the default version to fall back on will be the latest official release of MySQL (currently 8.0.17).