### PR TITLE
Fix `TreatTinyAsBoolean` connection string support when scaffolding

### DIFF
--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -17,6 +17,8 @@ using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 using MySql.Data.MySqlClient;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
@@ -26,13 +28,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
     {
         private readonly IDiagnosticsLogger<DbLoggerCategory.Scaffolding> _logger;
         private MySqlScaffoldingConnectionSettings _settings;
+        private readonly IMySqlOptions _options;
 
         public MySqlDatabaseModelFactory(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
+            IMySqlOptions options)
         {
             Check.NotNull(logger, nameof(logger));
 
             _logger = logger;
+            _options = options;
             _settings = new MySqlScaffoldingConnectionSettings(string.Empty);
         }
 
@@ -62,6 +67,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
 
             try
             {
+                SetupMySqlOptions(connection);
+
                 databaseModel.DatabaseName = connection.Database;
                 databaseModel.DefaultSchema = GetDefaultSchema(connection);
 
@@ -84,6 +91,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
                 {
                     connection.Close();
                 }
+            }
+        }
+
+        private void SetupMySqlOptions(DbConnection connection)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseMySql(connection);
+
+            if (Equals(_options, new MySqlOptions()))
+            {
+                _options.Initialize(optionsBuilder.Options);
             }
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -42,7 +42,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Scaffolding
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"),
                         new MySqlLoggingDefinitions());
-                var databaseModelFactory = new MySqlDatabaseModelFactory(logger);
+                var databaseModelFactory = new MySqlDatabaseModelFactory(logger, Fixture.ServiceProvider.GetService<IMySqlOptions>());
 
                 var databaseModel = databaseModelFactory.Create(Fixture.TestStore.ConnectionString,
                     new DatabaseModelFactoryOptions(tables, schemas));

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseCleaner.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseCleaner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal;
+﻿using Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -14,12 +13,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
 {
     public class MySqlDatabaseCleaner : RelationalDatabaseCleaner
     {
-        private readonly IServiceProvider _serviceProvider;
         private readonly IMySqlOptions _options;
 
-        public MySqlDatabaseCleaner(IServiceProvider serviceProvider, IMySqlOptions options)
+        public MySqlDatabaseCleaner(IMySqlOptions options)
         {
-            _serviceProvider = serviceProvider;
             _options = options;
         }
 
@@ -29,7 +26,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake"),
-                    new MySqlLoggingDefinitions()));
+                    new MySqlLoggingDefinitions()),
+                _options);
 
         protected override bool AcceptIndex(DatabaseIndex index) => false;
         protected override bool AcceptTable(DatabaseTable table) => !(table is DatabaseView);

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseFacadeTestExtensions.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseFacadeTestExtensions.cs
@@ -7,9 +7,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
     public static class MySqlDatabaseFacadeTestExtensions
     {
         public static void EnsureClean(this DatabaseFacade databaseFacade)
-            => new MySqlDatabaseCleaner(
-                databaseFacade.GetInfrastructure(),
-                databaseFacade.GetService<IMySqlOptions>())
+            => new MySqlDatabaseCleaner(databaseFacade.GetService<IMySqlOptions>())
                 .Clean(databaseFacade);
     }
 }


### PR DESCRIPTION
Reinstate the `SetupMySqlOptions()` implementation and call it when scaffolding.

Fixes #917 