### PR TITLE
Implement `CURRENT_TIMESTAMP` support for `datetime`

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -689,11 +689,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
                         autoIncrement = true;
                         break;
                     case "datetime":
-                        if (!_options.ServerVersion.SupportsDateTime6)
+                        if (!_options.ServerVersion.SupportsDateTimeCurrentTimestamp)
                         {
                             throw new InvalidOperationException(
                                 $"Error in {table}.{name}: DATETIME does not support values generated " +
-                                $"on Add or Update in versions lower than {ServerVersion.GetSupport(ServerVersion.DateTime6SupportKey)}. Try explicitly setting the column type to TIMESTAMP.");
+                                $"on Add or Update in versions lower than {ServerVersion.GetSupport(ServerVersion.DateTimeCurrentTimestampSupportKey)}. Try explicitly setting the column type to TIMESTAMP.");
                         }
 
                         goto case "timestamp";
@@ -709,11 +709,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
                 switch (matchType)
                 {
                     case "datetime":
-                        if (!_options.ServerVersion.SupportsDateTime6)
+                        if (!_options.ServerVersion.SupportsDateTimeCurrentTimestamp)
                         {
                             throw new InvalidOperationException(
                                 $"Error in {table}.{name}: DATETIME does not support values generated " +
-                                $"on Add or Update in versions lower than {ServerVersion.GetSupport(ServerVersion.DateTime6SupportKey)}. Try explicitly setting the column type to TIMESTAMP.");
+                                $"on Add or Update in versions lower than {ServerVersion.GetSupport(ServerVersion.DateTimeCurrentTimestampSupportKey)}. Try explicitly setting the column type to TIMESTAMP.");
                         }
 
                         goto case "timestamp";

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -200,10 +200,10 @@ AND
                             }
                             else if (extra.IndexOf("on update", StringComparison.Ordinal) >= 0)
                             {
-                                if (defaultValue != null
-                                    && (extra.IndexOf(defaultValue, StringComparison.Ordinal) > 0
-                                        || string.Equals(dataType, "timestamp", StringComparison.OrdinalIgnoreCase)
-                                            && extra.IndexOf("CURRENT_TIMESTAMP", StringComparison.Ordinal) > 0))
+                                if (defaultValue != null && extra.IndexOf(defaultValue, StringComparison.Ordinal) > 0 ||
+                                    (string.Equals(dataType, "timestamp", StringComparison.OrdinalIgnoreCase) ||
+                                     string.Equals(dataType, "datetime", StringComparison.OrdinalIgnoreCase)) &&
+                                    extra.IndexOf("CURRENT_TIMESTAMP", StringComparison.Ordinal) > 0)
                                 {
                                     valueGenerated = ValueGenerated.OnAddOrUpdate;
                                 }
@@ -295,8 +295,9 @@ AND
         private string CreateDefaultValueString(string defaultValue, string dataType)
         {
             // Pending the MySqlConnector implement MySqlCommandBuilder class
-            if (string.Equals(dataType, "timestamp", StringComparison.OrdinalIgnoreCase)
-                && string.Equals(defaultValue, "CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase))
+            if ((string.Equals(dataType, "timestamp", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(dataType, "datetime", StringComparison.OrdinalIgnoreCase)) &&
+                string.Equals(defaultValue, "CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase))
             {
                 return defaultValue;
             }

--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -8,6 +8,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
     {
         #region Individual version strings for tests
 
+        public const string DateTimeCurrentTimestampMySqlSupportVersionString = "5.6.5-mysql";
+        public const string DateTimeCurrentTimestampMariaDbSupportVersionString = "10.0.1-mariadb";
+
         public const string DateTime6MySqlSupportVersionString = "5.6.4-mysql";
         public const string DateTime6MariaDbSupportVersionString = "10.1.2-mariadb";
 
@@ -54,6 +57,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
 
         #region SupportMap keys for test attributes
 
+        public const string DateTimeCurrentTimestampSupportKey = nameof(DateTimeCurrentTimestampSupportKey);
         public const string DateTime6SupportKey = nameof(DateTime6SupportKey);
         public const string LargerKeyLengthSupportKey = nameof(LargerKeyLengthSupportKey);
         public const string RenameIndexSupportKey = nameof(RenameIndexSupportKey);
@@ -73,6 +77,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
 
         protected static readonly Dictionary<string, ServerVersionSupport> SupportMap = new Dictionary<string, ServerVersionSupport>()
         {
+            { DateTimeCurrentTimestampSupportKey, new ServerVersionSupport(DateTimeCurrentTimestampMySqlSupportVersionString, DateTimeCurrentTimestampMariaDbSupportVersionString) },
             { DateTime6SupportKey, new ServerVersionSupport(DateTime6MySqlSupportVersionString, DateTime6MariaDbSupportVersionString) },
             { LargerKeyLengthSupportKey, new ServerVersionSupport(LargerKeyLengthMySqlSupportVersionString, LargerKeyLengthMariaDbSupportVersionString) },
             { RenameIndexSupportKey, new ServerVersionSupport(RenameIndexMySqlSupportVersionString/*, RenameIndexMariaDbSupportVersionString*/) },
@@ -91,6 +96,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
 
         #region Support checks for provider code
 
+        public virtual bool SupportsDateTimeCurrentTimestamp => SupportMap[DateTimeCurrentTimestampSupportKey].IsSupported(this);
         public virtual bool SupportsDateTime6 => SupportMap[DateTime6SupportKey].IsSupported(this);
         public virtual bool SupportsLargerKeyLength => SupportMap[LargerKeyLengthSupportKey].IsSupported(this);
         public virtual bool SupportsRenameIndex => SupportMap[RenameIndexSupportKey].IsSupported(this);


### PR DESCRIPTION
We did already implement this for `timestamp` columns.

For the following table:

```sql
CREATE TABLE IF NOT EXISTS `modTest`(
  `id` INT NOT NULL AUTO_INCREMENT,
  `modify_date1` DATETIME NULL,
  `modify_date2` DATETIME NOT NULL,
  `modify_date3` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `modify_date4` DATETIME NULL ON UPDATE CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
```

The following model and definition is now being scaffolded:

```c#
public partial class ModTest
{
    public int Id { get; set; }
    public DateTime? ModifyDate1 { get; set; }
    public DateTime ModifyDate2 { get; set; }
    public DateTime ModifyDate3 { get; set; }
    public DateTime? ModifyDate4 { get; set; }
}

protected override void OnModelCreating(ModelBuilder modelBuilder)
{
    modelBuilder.Entity<ModTest>(entity =>
    {
        entity.ToTable("modTest");

        entity.Property(e => e.Id)
            .HasColumnName("id")
            .HasColumnType("int(11)");

        entity.Property(e => e.ModifyDate1)
            .HasColumnName("modify_date1")
            .HasColumnType("datetime");

        entity.Property(e => e.ModifyDate2)
            .HasColumnName("modify_date2")
            .HasColumnType("datetime");

        entity.Property(e => e.ModifyDate3)
            .HasColumnName("modify_date3")
            .HasColumnType("datetime")
            .HasDefaultValueSql("CURRENT_TIMESTAMP");

        entity.Property(e => e.ModifyDate4)
            .HasColumnName("modify_date4")
            .HasColumnType("datetime")
            .ValueGeneratedOnAddOrUpdate();
    });

    OnModelCreatingPartial(modelBuilder);
}
```

Fixes #958 