### PR TITLE
Fix troublesome test class for strong named scenarios

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/MySqlComplianceTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlComplianceTest.cs
@@ -17,6 +17,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             typeof(SpatialQueryTestBase<>),
             typeof(MigrationsTestBase<>),
             typeof(QueryTaggingTestBase<>),
+            typeof(MappingQueryTestBase<>),
         };
 
         protected override Assembly TargetAssembly { get; } = typeof(MySqlComplianceTest).Assembly;

--- a/test/EFCore.MySql.FunctionalTests/Query/MappingQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/MappingQueryMySqlTest.cs
@@ -15,8 +15,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
     // another test class has created the needed tables, the tests will fail.
     // This is a non-deterministic behavior.
     // We therefore skip those dependent tests until the Northwind database will be
-    // initialized by a SQL dump file.
-    public class MappingQueryMySqlTest : MappingQueryTestBase<MappingQueryMySqlTest.MappingQueryMySqlFixture>
+    // initialized by a SQL dump file, by making the class internal instead of public.
+    // Remove `MappingQueryMySqlTest` from `MySqlComplianceTest.IgnoredTestBases` when fixed.
+    internal class MappingQueryMySqlTest : MappingQueryTestBase<MappingQueryMySqlTest.MappingQueryMySqlFixture>
     {
         public MappingQueryMySqlTest(MappingQueryMySqlFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)


### PR DESCRIPTION
This is now needed again, because we did rely on an ordering xUnit extension library, that is not strong named and therefore had to be dropped.