### PR TITLE
Override more tests that rely on implicit ordering behavior of SQL Server

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/Query/IncludeAsyncMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/IncludeAsyncMySqlTest.cs
@@ -1,4 +1,9 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 {
@@ -7,6 +12,40 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
         public IncludeAsyncMySqlTest(IncludeMySqlFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalFact]
+        public override async Task Include_duplicate_collection_result_operator()
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = await (from c1 in context.Set<Customer>()
+                                .Include(c => c.Orders)
+                                .OrderBy(c => c.CustomerID)
+                                .Take(2)
+                            from c2 in context.Set<Customer>()
+                                .Include(c => c.Orders)
+                                .OrderBy(c => c.CustomerID)
+                                .Skip(2)
+                                .Take(2)
+                            select new
+                            {
+                                c1,
+                                c2
+                            })
+                        .OrderBy(p => p.c1) // <-- needs explicit sorting
+                        .ThenBy(p => p.c2) // <-- needs explicit sorting
+                        .Take(1)
+                        .ToListAsync();
+
+                Assert.Equal(1, customers.Count);
+                Assert.Equal(6, customers.SelectMany(c => c.c1.Orders).Count());
+                Assert.True(customers.SelectMany(c => c.c1.Orders).All(o => o.Customer != null));
+                Assert.Equal(7, customers.SelectMany(c => c.c2.Orders).Count());
+                Assert.True(customers.SelectMany(c => c.c2.Orders).All(o => o.Customer != null));
+                Assert.Equal(15, context.ChangeTracker.Entries().Count());
+            }
         }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/IncludeMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/IncludeMySqlTest.cs
@@ -1,4 +1,8 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
@@ -9,6 +13,115 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             : base(fixture)
         {
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public override void Include_duplicate_collection_result_operator(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = useString
+                        ? (from c1 in context.Set<Customer>()
+                               .Include("Orders")
+                               .OrderBy(c => c.CustomerID)
+                               .Take(2)
+                           from c2 in context.Set<Customer>()
+                               .Include("Orders")
+                               .OrderBy(c => c.CustomerID)
+                               .Skip(2)
+                               .Take(2)
+                           select new
+                           {
+                               c1,
+                               c2
+                           })
+                        .OrderBy(p => p.c1) // <-- needs explicit sorting
+                        .ThenBy(p => p.c2) // <-- needs explicit sorting
+                        .Take(1)
+                        .ToList()
+                        : (from c1 in context.Set<Customer>()
+                               .Include(c => c.Orders)
+                               .OrderBy(c => c.CustomerID)
+                               .Take(2)
+                           from c2 in context.Set<Customer>()
+                               .Include(c => c.Orders)
+                               .OrderBy(c => c.CustomerID)
+                               .Skip(2)
+                               .Take(2)
+                           select new
+                           {
+                               c1,
+                               c2
+                           })
+                        .OrderBy(p => p.c1) // <-- needs explicit sorting
+                        .ThenBy(p => p.c2) // <-- needs explicit sorting
+                        .Take(1)
+                        .ToList();
+
+                Assert.Equal(1, customers.Count);
+                Assert.Equal(6, customers.SelectMany(c => c.c1.Orders).Count());
+                Assert.True(customers.SelectMany(c => c.c1.Orders).All(o => o.Customer != null));
+                Assert.Equal(7, customers.SelectMany(c => c.c2.Orders).Count());
+                Assert.True(customers.SelectMany(c => c.c2.Orders).All(o => o.Customer != null));
+                Assert.Equal(15, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers.Select(e => e.c1))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+
+                foreach (var customer in customers.Select(e => e.c2))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+            }
+        }
+
+        private static void CheckIsLoaded(
+            NorthwindContext context,
+            Customer customer,
+            bool ordersLoaded,
+            bool orderDetailsLoaded,
+            bool productLoaded)
+        {
+            context.ChangeTracker.AutoDetectChangesEnabled = false;
+
+            Assert.Equal(ordersLoaded, context.Entry(customer).Collection(e => e.Orders).IsLoaded);
+            if (customer.Orders != null)
+            {
+                foreach (var order in customer.Orders)
+                {
+                    Assert.Equal(ordersLoaded, context.Entry(order).Reference(e => e.Customer).IsLoaded);
+
+                    Assert.Equal(orderDetailsLoaded, context.Entry(order).Collection(e => e.OrderDetails).IsLoaded);
+                    if (order.OrderDetails != null)
+                    {
+                        foreach (var orderDetail in order.OrderDetails)
+                        {
+                            Assert.Equal(orderDetailsLoaded, context.Entry(orderDetail).Reference(e => e.Order).IsLoaded);
+
+                            Assert.Equal(productLoaded, context.Entry(orderDetail).Reference(e => e.Product).IsLoaded);
+                            if (orderDetail.Product != null)
+                            {
+                                Assert.False(context.Entry(orderDetail.Product).Collection(e => e.OrderDetails).IsLoaded);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/config.json.example
+++ b/test/EFCore.MySql.FunctionalTests/config.json.example
@@ -1,7 +1,7 @@
 ﻿{
   "Data": {
     "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;",
-    "ServerVersion": "8.0.0-mysql",
+    "ServerVersion": "8.0.18-mysql",
     "CommandTimeout": "600"
   }
 }


### PR DESCRIPTION
Override more tests that rely on implicit ordering behavior of SQL Server and implement explicit sorting instead. Without this fix, these 3 tests would only fail on `8.0.18-mysql` on Linux (but worked on lower versions and also work on all version on Windows).

Fixes the current CI pipeline that uses the `8.0.18-mysql` version on Linux.