### PR TITLE
Implement custom xUnit orderers

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/AssemblyInfo.cs
+++ b/test/EFCore.MySql.FunctionalTests/AssemblyInfo.cs
@@ -1,7 +1,14 @@
 using Xunit;
-//Optional
-// [assembly: CollectionBehavior(DisableTestParallelization = true)]
-//Optional
-[assembly: TestCaseOrderer("Xunit.Extensions.Ordering.TestCaseOrderer", "Xunit.Extensions.Ordering")]
-//Optional
-[assembly: TestCollectionOrderer("Xunit.Extensions.Ordering.CollectionOrderer", "Xunit.Extensions.Ordering")]
+
+//
+// Optional: Control the test execution order.
+//           This can be helpful for diffing etc.
+//
+
+#if FIXED_TEST_ORDER
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: TestCollectionOrderer("Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Xunit.MySqlTestCollectionOrderer", "Pomelo.EntityFrameworkCore.MySql.FunctionalTests")]
+[assembly: TestCaseOrderer("Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Xunit.MySqlTestCaseOrderer", "Pomelo.EntityFrameworkCore.MySql.FunctionalTests")]
+
+#endif

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Xunit/MySqlTestCaseOrderer.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Xunit/MySqlTestCaseOrderer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Xunit
+{
+    public class MySqlTestCaseOrderer : ITestCaseOrderer
+    {
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+            where TTestCase : ITestCase
+        {
+            var result = testCases.ToList();
+            result.Sort((x, y) => StringComparer.OrdinalIgnoreCase.Compare(x.TestMethod.Method.Name, y.TestMethod.Method.Name));
+            return result;
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Xunit/MySqlTestCollectionOrderer.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Xunit/MySqlTestCollectionOrderer.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Xunit
+{
+    public class MySqlTestCollectionOrderer : ITestCollectionOrderer
+    {
+        public IEnumerable<ITestCollection> OrderTestCollections(IEnumerable<ITestCollection> testCollections)
+            => testCollections.OrderBy(c => c.DisplayName);
+    }
+}


### PR DESCRIPTION
They can be enabled to ensure that all tests are run in sequence and alphabetical order.
Useful for diffing.
They are disabled by default for performance reasons.