### PR TITLE
Prepare codebase for .NET Standard 2.0

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,5 +3,6 @@
     <!-- Assign these values at the end of the project after TargetFramework has been assigned. TargetFramework is not assigned yet in Directory.Build.props. -->
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreApp30PackageVersion)</RuntimeFrameworkVersion>
     <NETStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.1' ">$(NETStandardLibrary21PackageVersion)</NETStandardImplicitPackageVersion>
+    <NETStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(NETStandardLibrary20PackageVersion)</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrator.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrator.cs
@@ -169,10 +169,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
             return migrationCommands;
         }
 
-        private IReadOnlyList<string> GetMigrationCommandTexts(IReadOnlyList<MigrationOperation> migrationOperations, bool beginTexts)
+        private string[] GetMigrationCommandTexts(IReadOnlyList<MigrationOperation> migrationOperations, bool beginTexts)
             => GetCustomCommands(migrationOperations)
                 .Select(t => PrepareString(beginTexts ? t.Item1 : t.Item2))
-                .ToList();
+                .ToArray();
 
         private static IReadOnlyList<Tuple<string, string>> GetCustomCommands(IReadOnlyList<MigrationOperation> migrationOperations)
             => _customMigrationCommands

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -85,7 +85,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
         {
             var schema = operation.GetType()
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty)
-                .Where(p => p.Name.Contains(nameof(AddForeignKeyOperation.Schema), StringComparison.Ordinal))
+                .Where(p => p.Name.IndexOf(nameof(AddForeignKeyOperation.Schema), StringComparison.Ordinal) >= 0)
                 .Select(p => p.GetValue(operation) as string)
                 .FirstOrDefault(schemaValue => schemaValue != null);
 

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -161,9 +161,9 @@ AND
                 {
                     while (reader.Read())
                     {
-                        var name = reader.GetString("TABLE_NAME");
-                        var type = reader.GetString("TABLE_TYPE");
-                        var comment = reader.GetString("TABLE_COMMENT");
+                        var name = reader.GetValueOrDefault<string>("TABLE_NAME");
+                        var type = reader.GetValueOrDefault<string>("TABLE_TYPE");
+                        var comment = reader.GetValueOrDefault<string>("TABLE_COMMENT");
 
                         var table = string.Equals(type, "base table", StringComparison.OrdinalIgnoreCase)
                             ? new DatabaseTable()
@@ -226,7 +226,7 @@ ORDER BY
                         {
                             var name = reader.GetValueOrDefault<string>("COLUMN_NAME");
                             var defaultValue = reader.GetValueOrDefault<string>("COLUMN_DEFAULT");
-                            var nullable = reader.GetBoolean("IS_NULLABLE");
+                            var nullable = reader.GetValueOrDefault<bool>("IS_NULLABLE");
                             var dataType = reader.GetValueOrDefault<string>("DATA_TYPE");
                             var charset = reader.GetValueOrDefault<string>("CHARACTER_SET_NAME");
                             var collation = reader.GetValueOrDefault<string>("COLLATION_NAME");
@@ -486,7 +486,7 @@ ORDER BY
                         while (reader.Read())
                         {
                             var referencedTableName = reader.GetString(2);
-                            var referencedTable = tables.Where(t => t.Name == referencedTableName).FirstOrDefault();
+                            var referencedTable = tables.FirstOrDefault(t => t.Name == referencedTableName);
                             if (referencedTable != null)
                             {
                                 var fkInfo = new DatabaseForeignKey

--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Data.Common;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
@@ -117,7 +117,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             //      Convert line break characters to their CHAR() representation as a workaround.
 
             if (_options.ReplaceLineBreaksWithCharFunction
-                && (value.Contains('\r') || value.Contains('\n')))
+                && (value.Contains("\r") || value.Contains("\n")))
             {
                 escapedLiteral = "CONCAT(" + escapedLiteral
                     .Replace("\r\n", "', CHAR(13, 10), '")

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -479,7 +479,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         {
             var storeTypeBaseName = base.ParseStoreTypeName(storeTypeName, out unicode, out size, out precision, out scale);
 
-            if (storeTypeName?.Contains("unsigned", StringComparison.OrdinalIgnoreCase) ?? false)
+            if ((storeTypeName?.IndexOf("unsigned", StringComparison.OrdinalIgnoreCase) ?? -1) >= 0)
             {
                 return storeTypeBaseName + " unsigned";
             }


### PR DESCRIPTION
.NET Standard 2.0 is used again in EF Core 3.1 for another year until .NET 5 for a smoother transition.
This PR prepares the general codebase, so the 3.0.x and 3.1.x branches will be compatible for the most part.