### PR TITLE
Implement alternatives to the current behavior to always throw, if a schema has been set for an object

### DIFF
--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -18,5 +18,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         bool NoBackslashEscapes { get; }
         bool ReplaceLineBreaksWithCharFunction { get; }
         MySqlDefaultDataTypeMappings DefaultDataTypeMappings { get; }
+        MySqlSchemaNameTranslator SchemaNameTranslator { get; }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -63,6 +63,18 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => ExecutionStrategy(c => new MySqlRetryingExecutionStrategy(c, maxRetryCount));
 
         /// <summary>
+        ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        /// </summary>
+        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
+        /// <param name="maxRetryDelay"> The maximum delay between retries. </param>
+        /// <param name="errorNumbersToAdd"> Additional error codes that should be considered transient. </param>
+        public virtual MySqlDbContextOptionsBuilder EnableRetryOnFailure(
+            int maxRetryCount,
+            TimeSpan maxRetryDelay,
+            [NotNull] ICollection<int> errorNumbersToAdd)
+            => ExecutionStrategy(c => new MySqlRetryingExecutionStrategy(c, maxRetryCount, maxRetryDelay, errorNumbersToAdd));
+
+        /// <summary>
         ///     Configures string escaping in SQL query generation to ignore backslashes, and assumes
         ///     that `sql_mode` has been set to `NO_BACKSLASH_ESCAPES`.
         ///     This applies to both constant and parameter values (i. e. user input, potentially).
@@ -105,15 +117,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => WithOption(e => e.WithDefaultDataTypeMappings(defaultDataTypeMappings(new MySqlDefaultDataTypeMappings())));
 
         /// <summary>
-        ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        ///     Configures the behavior for cases when a schema has been set for an entity. Because
+        ///     MySQL does not support the EF Core concept of schemas, the default is to throw an
+        ///     exception.
         /// </summary>
-        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
-        /// <param name="maxRetryDelay"> The maximum delay between retries. </param>
-        /// <param name="errorNumbersToAdd"> Additional error codes that should be considered transient. </param>
-        public virtual MySqlDbContextOptionsBuilder EnableRetryOnFailure(
-            int maxRetryCount,
-            TimeSpan maxRetryDelay,
-            [NotNull] ICollection<int> errorNumbersToAdd)
-            => ExecutionStrategy(c => new MySqlRetryingExecutionStrategy(c, maxRetryCount, maxRetryDelay, errorNumbersToAdd));
+        public virtual MySqlDbContextOptionsBuilder SchemaBehavior(MySqlSchemaBehavior behavior, MySqlSchemaNameTranslator translator = null)
+            => WithOption(e => e.WithSchemaBehavior(behavior, translator));
     }
 }

--- a/src/EFCore.MySql/Infrastructure/MySqlSchemaBehavior.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlSchemaBehavior.cs
@@ -1,0 +1,24 @@
+﻿namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
+{
+    public delegate string MySqlSchemaNameTranslator(string schemaName, string objectName);
+
+    public enum MySqlSchemaBehavior
+    {
+        /// <summary>
+        /// Throw an exception if a schema is being used. Any specified translator delegate will be ignored.
+        /// This is the default.
+        /// </summary>
+        Throw,
+
+        /// <summary>
+        /// Silently ignore any schema definitions. Any specified translator delegate will be ignored.
+        /// </summary>
+        Ignore,
+
+        /// <summary>
+        /// Use the specified translator delegate to translate from an input schema and object name to
+        /// an output object name whenever a schema is being used.
+        /// </summary>
+        Translate,
+    }
+}

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -83,6 +83,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
 
         protected virtual void CheckSchema(MigrationOperation operation)
         {
+            if (_options.SchemaNameTranslator != null)
+            {
+                return;
+            }
+            
             var schema = operation.GetType()
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty)
                 .Where(p => p.Name.IndexOf(nameof(AddForeignKeyOperation.Schema), StringComparison.Ordinal) >= 0)
@@ -95,7 +100,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
                     .GetProperty(nameof(AddForeignKeyOperation.Name), BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty)
                     ?.GetValue(operation) as string;
 
-                throw new InvalidOperationException($"A schema \"{schema}\" has been set for an object of type \"{operation.GetType().Name}\"{(string.IsNullOrEmpty(name) ? string.Empty : $" with the name of \"{name}\"")}. MySQL does not support the EF Core concept of schemas. Any schema property of any \"MigrationOperation\" must be null.");
+                throw new InvalidOperationException($"A schema \"{schema}\" has been set for an object of type \"{operation.GetType().Name}\"{(string.IsNullOrEmpty(name) ? string.Empty : $" with the name of \"{name}\"")}. MySQL does not support the EF Core concept of schemas. Any schema property of any \"MigrationOperation\" must be null. This behavior can be changed by setting the `SchemaBehavior` option in the `UseMySql` call.");
             }
         }
 


### PR DESCRIPTION
Threre are currently 3 options to choose from:

```c#
// Throw an exception, if a schema is being used. This is the default.
options.UseMySql(myConnectionString, b => b.SchemaBehavior(MySqlSchemaBehavior.Throw))

// Silently ignore any schema definitions.
options.UseMySql(myConnectionString, b => b.SchemaBehavior(MySqlSchemaBehavior.Ignore))

// Use the specified translator delegate to translate from an input schema and object name to
// an output object name whenever a schema is being used.
options.UseMySql(myConnectionString, b => b.SchemaBehavior(MySqlSchemaBehavior.Translate,
    (schema, entity) => $"{schema ?? "dbo"}_{entity}"))
```
This still needs some testing.

Fixes #972