### PR TITLE
TEXT, BLOB, GEOMETRY and JSON columns do not support default values

### DIFF
--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -37,12 +39,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
             {
                 var valueGenerationStrategy = MySqlValueGenerationStrategyCompatibility.GetValueGenerationStrategy(MigrationsAnnotations.For(target).ToArray());
 
-                // Ensure that null will be set for the columns default value, if CURRENT_TIMESTAMP has been required.
+                // Ensure that null will be set for the columns default value, if CURRENT_TIMESTAMP has been required,
+                // or when the store type of the column does not support default values at all.
                 inline = inline ||
-                             (storeType.StoreTypeNameBase == "datetime" ||
-                                storeType.StoreTypeNameBase == "timestamp") &&
-                             (valueGenerationStrategy == MySqlValueGenerationStrategy.IdentityColumn ||
-                                valueGenerationStrategy == MySqlValueGenerationStrategy.ComputedColumn);
+                         (storeType.StoreTypeNameBase == "datetime" ||
+                          storeType.StoreTypeNameBase == "timestamp") &&
+                         (valueGenerationStrategy == MySqlValueGenerationStrategy.IdentityColumn ||
+                          valueGenerationStrategy == MySqlValueGenerationStrategy.ComputedColumn) ||
+                         storeType.StoreTypeNameBase.Contains("text") ||
+                         storeType.StoreTypeNameBase.Contains("blob") ||
+                         storeType.StoreTypeNameBase == "geometry" ||
+                         storeType.StoreTypeNameBase == "json";
             }
 
             return base.Add(target, diffContext, inline);


### PR DESCRIPTION
`AddColumn()` calls in migrations, when later adding a required string property to an already established entity, will end up being generated with a generally unnecessary `defaultValue: ""` parameter. This might be a bug in EF Core.

But because MySQL does not support default values for various store types, this unexpected but usually harmless behavior can lead to an exception when applying the migration to the database.

This is being discussed in https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/615#issuecomment-562549763 and the following comments.

Fixes #615