### PR TITLE
Add release instructions and fix Ubuntu wait loop

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,15 +62,24 @@ jobs:
       ./build.sh
     displayName: Setup and Build Solution
   - bash: |
+      startTime=$SECONDS
       started="false"
-      for i in $(seq 0 300); do
+
+      while true; do
         if docker exec mysql mysqladmin -h localhost -P 3306 -u root -pPassword12! status; then
           started="true"
           break
         fi
-        sleep 1
-      done
 
+        duration=$(($SECONDS - $startTime))
+        echo "duration=$duration"
+        if (( $duration > 300 )); then
+          break
+        else
+          sleep 3
+        fi
+      done
+      
       if [ "$started" = "false" ]; then
         echo "$DOCKER_IMAGE container failed to start in 5 minutes" >&2
         exit 1
@@ -178,7 +187,7 @@ jobs:
           $started=$true
           break;
         }
-        Start-Sleep 1
+        Start-Sleep 3
       }
       if (!$started) {
         Write-Error "mysql container failed to start in 5 minutes"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,10 +1,18 @@
 <Project>
   <PropertyGroup Label="Version settings">
     <VersionPrefix>3.1.0</VersionPrefix>
+    <!--
+      Use the following values for the different release types:
+          - "preview1" to match preview releases upstream (EF Core)
+          - "rc1" targeting a public release of EF Core
+          - "rtm" for the initial public release of a major/minor version
+          - "servicing" for a release containig fixes for a previously published major/minior version
+    -->
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <!--
-        When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
+        When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages.
+        Set to 'true' for 'rtm' and 'servicing' releases.
     -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,20 +1,21 @@
 <Project>
   <PropertyGroup Label="Version settings">
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <!--
       Use the following values for the different release types:
-          - "preview1" to match preview releases upstream (EF Core)
-          - "rc1" targeting a public release of EF Core
+          - "preview" to match preview releases upstream (EF Core)
+          - "rc" targeting a public release of EF Core
           - "rtm" for the initial public release of a major/minor version
           - "servicing" for a release containig fixes for a previously published major/minior version
     -->
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages.
         Set to 'true' for 'rtm' and 'servicing' releases.
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup Label="Arcade settings">


### PR DESCRIPTION
- The original loop executed way shorter than 5 minutes.
- Insert instruction comments in the `Versions.props` file that describe the different settings for the different release types.
- Bump version to 3.2.0-preview1.