### PR TITLE
Reenable tests, because upstream issues got fixed

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/BuiltInDataTypesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BuiltInDataTypesMySqlTest.cs
@@ -4,7 +4,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -87,37 +86,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             Assert.Equal(expected.Ulong, actual.Ulong);
             Assert.Equal(expected.Decimal.TrimEnd('0'), actual.Decimal.TrimEnd('0')); // might have different scales
             Assert.Equal(expected.Char, actual.Char);
-        }
-
-        // Blocked by EF #11929
-        [ConditionalFact]
-        public override void Can_query_using_any_data_type()
-        {
-        }
-
-        [ConditionalFact]
-        public override void Can_query_using_any_nullable_data_type()
-        {
-        }
-
-        [ConditionalFact]
-        public override void Can_query_using_any_nullable_data_type_as_literal()
-        {
-        }
-
-        [ConditionalFact]
-        public override void Can_query_using_any_data_type_shadow()
-        {
-        }
-
-        [ConditionalFact]
-        public override void Can_query_using_any_data_type_nullable_shadow()
-        {
-        }
-
-        [ConditionalFact]
-        public override void Can_perform_query_with_ansi_strings_test()
-        {
         }
 
         [Fact]
@@ -1463,6 +1431,10 @@ UnicodeDataTypes.StringUnicode ---> [nullable longtext] [MaxLength = -1]
 
             public override bool SupportsBinaryKeys => true;
 
+            public override DateTime DefaultDateTime => new DateTime();
+
+            public override bool SupportsDecimalComparisons => false;
+
             protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.Instance;
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 
@@ -1489,10 +1461,6 @@ UnicodeDataTypes.StringUnicode ---> [nullable longtext] [MaxLength = -1]
 
                 MakeRequired<MappedDataTypes>(modelBuilder);
             }
-
-            public override DateTime DefaultDateTime => new DateTime();
-
-            public override bool SupportsDecimalComparisons => throw new NotImplementedException();
         }
 
         [Flags]

--- a/test/EFCore.MySql.FunctionalTests/CustomConvertersMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/CustomConvertersMySqlTest.cs
@@ -25,24 +25,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.Can_perform_query_with_ansi_strings_test();
         }
 
-        [ConditionalFact(Skip = "EF Core Issue#18147")]
-        public override void Value_conversion_is_appropriately_used_for_join_condition()
-        {
-            base.Value_conversion_is_appropriately_used_for_join_condition();
-        }
-
-        [ConditionalFact(Skip = "EF Core Issue#18147")]
-        public override void Value_conversion_is_appropriately_used_for_left_join_condition()
-        {
-            base.Value_conversion_is_appropriately_used_for_left_join_condition();
-        }
-
-        [ConditionalFact(Skip = "EF Core Issue#18147")]
-        public override void Where_bool_gets_converted_to_equality_when_value_conversion_is_used()
-        {
-            base.Where_bool_gets_converted_to_equality_when_value_conversion_is_used();
-        }
-        
         public class CustomConvertersMySqlFixture : CustomConvertersFixtureBase
         {
             public override bool StrictEquality => true;

--- a/test/EFCore.MySql.FunctionalTests/CustomConvertersMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/CustomConvertersMySqlTest.cs
@@ -2,7 +2,6 @@ using System;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 {
@@ -13,21 +12,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         {
         }
 
-        [ConditionalFact(Skip = "EF Core Issue#11929")]
-        public override void Can_query_using_any_data_type_nullable_shadow()
-        {
-            base.Can_query_using_any_data_type_nullable_shadow();
-        }
-
-        [ConditionalFact(Skip = "EF Core Issue#11929")]
-        public override void Can_perform_query_with_ansi_strings_test()
-        {
-            base.Can_perform_query_with_ansi_strings_test();
-        }
-
         public class CustomConvertersMySqlFixture : CustomConvertersFixtureBase
         {
-            public override bool StrictEquality => true;
+            public override bool StrictEquality => false;
 
             public override bool SupportsAnsi => true;
 
@@ -41,7 +28,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 
             public override DateTime DefaultDateTime => new DateTime();
 
-            public override bool SupportsDecimalComparisons => true;
+            public override bool SupportsDecimalComparisons => false;
         }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/LazyLoadProxyMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/LazyLoadProxyMySqlTest.cs
@@ -10,33 +10,44 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         public LazyLoadProxyMySqlTest(LoadMySqlFixture fixture)
             : base(fixture)
         {
+            ClearLog();
         }
 
-        [ConditionalFact(Skip = "EF Core Issue#1015")]
         public override void Top_level_projection_track_entities_before_passing_to_client_method()
         {
             base.Top_level_projection_track_entities_before_passing_to_client_method();
+            RecordLog();
 
             Assert.Equal(
-                @"@__p_0='707' (Nullable = true)
+                @"SELECT `p`.`Id`, `p`.`AlternateId`, `p`.`Discriminator`
+FROM `Parent` AS `p`
+ORDER BY `p`.`Id`
+LIMIT 1
 
-            SELECT [e].[Id], [e].[ParentId]
-            FROM [Child] AS [e]
-            WHERE [e].[ParentId] = @__p_0",
+@__p_0='707' (Nullable = true)
+
+SELECT `s`.`Id`, `s`.`ParentId`
+FROM `Single` AS `s`
+WHERE `s`.`ParentId` = @__p_0",
                 Sql,
                 ignoreLineEndingDifferences: true);
         }
 
-        protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
+        protected override void ClearLog()
+            => Fixture.TestSqlLoggerFactory.Clear();
 
-        protected override void RecordLog() => Sql = Fixture.TestSqlLoggerFactory.Sql;
+        protected override void RecordLog() =>
+            Sql = Fixture.TestSqlLoggerFactory.Sql;
 
         private string Sql { get; set; }
 
         public class LoadMySqlFixture : LoadFixtureBase
         {
-            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
-            protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.Instance;
+            public TestSqlLoggerFactory TestSqlLoggerFactory
+                => (TestSqlLoggerFactory)ListLoggerFactory;
+
+            protected override ITestStoreFactory TestStoreFactory
+                => MySqlTestStoreFactory.Instance;
         }
     }
 }


### PR DESCRIPTION
Reenable test again, because https://github.com/dotnet/efcore/issues/18147 and https://github.com/dotnet/efcore/issues/11929 got fixed.