### PR TITLE
Extend upon new MATCH...AGAINST support

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsEnums.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsEnums.cs
@@ -2,9 +2,8 @@
 {
     public enum MySqlMatchSearchMode
     {
-        WithQueryExpansion,
-        InNaturalLanguageMode,
-        InNaturalLanguageModeWithQueryExpansion,
-        InBooleanMode
+        NaturalLanguage = 0,
+        NaturalLanguageWithQueryExpansion = 1,
+        Boolean = 2,
     }
 }

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
@@ -161,14 +161,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
 
             switch (mySqlMatchExpression.SearchMode)
             {
-                case MySqlMatchSearchMode.InBooleanMode:
-                    Sql.Append(" IN BOOLEAN MODE");
+                case MySqlMatchSearchMode.NaturalLanguage:
                     break;
-                case MySqlMatchSearchMode.InNaturalLanguageModeWithQueryExpansion:
-                case MySqlMatchSearchMode.WithQueryExpansion:
+                case MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion:
                     Sql.Append(" WITH QUERY EXPANSION");
                     break;
-                case MySqlMatchSearchMode.InNaturalLanguageMode:
+                case MySqlMatchSearchMode.Boolean:
+                    Sql.Append(" IN BOOLEAN MODE");
                     break;
             }
 

--- a/src/EFCore.MySql/Query/Expressions/Internal/MySqlMatchExpression.cs
+++ b/src/EFCore.MySql/Query/Expressions/Internal/MySqlMatchExpression.cs
@@ -76,14 +76,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal
 
             switch (SearchMode)
             {
-                case MySqlMatchSearchMode.InBooleanMode:
-                    expressionPrinter.Append(" IN BOOLEAN MODE");
+                case MySqlMatchSearchMode.NaturalLanguage:
                     break;
-                case MySqlMatchSearchMode.InNaturalLanguageModeWithQueryExpansion:
-                case MySqlMatchSearchMode.WithQueryExpansion:
+                case MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion:
                     expressionPrinter.Append(" WITH QUERY EXPANSION");
                     break;
-                case MySqlMatchSearchMode.InNaturalLanguageMode:
+                case MySqlMatchSearchMode.Boolean:
+                    expressionPrinter.Append(" IN BOOLEAN MODE");
                     break;
             }
 

--- a/src/EFCore.MySql/Query/Internal/MySqlMethodCallTranslatorProvider.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlMethodCallTranslatorProvider.cs
@@ -1,12 +1,15 @@
 ﻿using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlMethodCallTranslatorProvider : RelationalMethodCallTranslatorProvider
     {
-        public MySqlMethodCallTranslatorProvider([NotNull] RelationalMethodCallTranslatorProviderDependencies dependencies)
+        public MySqlMethodCallTranslatorProvider(
+            [NotNull] RelationalMethodCallTranslatorProviderDependencies dependencies,
+            [NotNull] IMySqlOptions options)
             : base(dependencies)
         {
             var sqlExpressionFactory = dependencies.SqlExpressionFactory;
@@ -16,13 +19,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 new MySqlConvertTranslator(sqlExpressionFactory),
                 new MySqlDateTimeMethodTranslator(sqlExpressionFactory),
                 new MySqlDateDiffFunctionsTranslator(sqlExpressionFactory),
-                new MySqlMathMethodTranslator(sqlExpressionFactory), 
+                new MySqlMathMethodTranslator(sqlExpressionFactory),
                 new MySqlNewGuidTranslator(sqlExpressionFactory),
                 new MySqlObjectToStringTranslator(sqlExpressionFactory),
                 new MySqlStringMethodTranslator(sqlExpressionFactory),
                 new MySqlStringComparisonMethodTranslator(sqlExpressionFactory),
                 new MySqlRegexIsMatchTranslator(sqlExpressionFactory),
-                new MySqlDbFunctionsExtensionsMethodTranslator(sqlExpressionFactory),
+                new MySqlDbFunctionsExtensionsMethodTranslator(sqlExpressionFactory, options),
             });
         }
     }

--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -56,9 +56,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         // public const string AlternativeDefaultExpressionMySqlSupportVersionString = "?.?.?-mysql";
         public const string AlternativeDefaultExpressionMariaDbSupportVersionString = "10.2.7-mariadb"; // MDEV-13132
 
-        public const string MatchAgainstInsideCaseMySqlSupportVersionString = "5.6.0-mysql";
-        // public const string MatchAgainstInsideCaseMariaDbSupportVersionString = "?.?.?-mariadb";
-
         #endregion
 
         #region SupportMap keys for test attributes
@@ -79,7 +76,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public const string DefaultCharSetUtf8Mb4SupportKey = nameof(DefaultCharSetUtf8Mb4SupportKey);
         public const string DefaultExpressionSupportKey = nameof(DefaultExpressionSupportKey);
         public const string AlternativeDefaultExpressionSupportKey = nameof(AlternativeDefaultExpressionSupportKey);
-        public const string MatchAgainstInsideCaseSupportKey = nameof(MatchAgainstInsideCaseSupportKey);
 
         #endregion
 
@@ -100,7 +96,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             { DefaultCharSetUtf8Mb4SupportKey, new ServerVersionSupport(DefaultCharSetUtf8Mb4MySqlSupportVersionString/*, DefaultCharSetUtf8Mb4MariaDbSupportVersionString*/) },
             { DefaultExpressionSupportKey, new ServerVersionSupport(DefaultExpressionMySqlSupportVersionString/*, DefaultExpressionMariaDbSupportVersionString*/) },
             { AlternativeDefaultExpressionSupportKey, new ServerVersionSupport(/*AlternativeDefaultExpressionMySqlSupportVersionString, */AlternativeDefaultExpressionMariaDbSupportVersionString) },
-            { MatchAgainstInsideCaseSupportKey, new ServerVersionSupport(MatchAgainstInsideCaseMySqlSupportVersionString/*, MatchAgainstInsideCaseMariaDbSupportVersionString*/) },
         };
 
         #region Support checks for provider code
@@ -121,7 +116,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public virtual bool SupportsDefaultCharSetUtf8Mb4 => SupportMap[DefaultCharSetUtf8Mb4SupportKey].IsSupported(this);
         public virtual bool SupportsDefaultExpression => SupportMap[DefaultExpressionSupportKey].IsSupported(this);
         public virtual bool SupportsAlternativeDefaultExpression => SupportMap[AlternativeDefaultExpressionSupportKey].IsSupported(this);
-        public virtual bool SupportsMatchAgainstInsideCase => SupportMap[MatchAgainstInsideCaseSupportKey].IsSupported(this);
 
         #endregion
 

--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -56,6 +56,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         // public const string AlternativeDefaultExpressionMySqlSupportVersionString = "?.?.?-mysql";
         public const string AlternativeDefaultExpressionMariaDbSupportVersionString = "10.2.7-mariadb"; // MDEV-13132
 
+        public const string MatchAgainstInsideCaseMySqlSupportVersionString = "5.6.0-mysql";
+        // public const string MatchAgainstInsideCaseMariaDbSupportVersionString = "?.?.?-mariadb";
+
         #endregion
 
         #region SupportMap keys for test attributes
@@ -76,6 +79,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public const string DefaultCharSetUtf8Mb4SupportKey = nameof(DefaultCharSetUtf8Mb4SupportKey);
         public const string DefaultExpressionSupportKey = nameof(DefaultExpressionSupportKey);
         public const string AlternativeDefaultExpressionSupportKey = nameof(AlternativeDefaultExpressionSupportKey);
+        public const string MatchAgainstInsideCaseSupportKey = nameof(MatchAgainstInsideCaseSupportKey);
 
         #endregion
 
@@ -96,6 +100,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             { DefaultCharSetUtf8Mb4SupportKey, new ServerVersionSupport(DefaultCharSetUtf8Mb4MySqlSupportVersionString/*, DefaultCharSetUtf8Mb4MariaDbSupportVersionString*/) },
             { DefaultExpressionSupportKey, new ServerVersionSupport(DefaultExpressionMySqlSupportVersionString/*, DefaultExpressionMariaDbSupportVersionString*/) },
             { AlternativeDefaultExpressionSupportKey, new ServerVersionSupport(/*AlternativeDefaultExpressionMySqlSupportVersionString, */AlternativeDefaultExpressionMariaDbSupportVersionString) },
+            { MatchAgainstInsideCaseSupportKey, new ServerVersionSupport(MatchAgainstInsideCaseMySqlSupportVersionString/*, MatchAgainstInsideCaseMariaDbSupportVersionString*/) },
         };
 
         #region Support checks for provider code
@@ -116,6 +121,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public virtual bool SupportsDefaultCharSetUtf8Mb4 => SupportMap[DefaultCharSetUtf8Mb4SupportKey].IsSupported(this);
         public virtual bool SupportsDefaultExpression => SupportMap[DefaultExpressionSupportKey].IsSupported(this);
         public virtual bool SupportsAlternativeDefaultExpression => SupportMap[AlternativeDefaultExpressionSupportKey].IsSupported(this);
+        public virtual bool SupportsMatchAgainstInsideCase => SupportMap[MatchAgainstInsideCaseSupportKey].IsSupported(this);
 
         #endregion
 

--- a/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
@@ -17,10 +17,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
         }
 
         [ConditionalFact]
-        public virtual void Match_In_Natural_Language_Mode()
+        public virtual void Match_in_natural_language_mode()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.InNaturalLanguageMode));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.NaturalLanguage));
 
             Assert.Equal(3, count);
 
@@ -30,10 +30,10 @@ WHERE MATCH (`h`.`Name`) AGAINST ('First')");
         }
 
         [ConditionalFact]
-        public virtual void Match_In_Natural_Language_Mode_Keywords_Separated()
+        public virtual void Match_in_natural_language_mode_keywords_separated()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.InNaturalLanguageMode));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
 
             Assert.Equal(6, count);
 
@@ -43,10 +43,10 @@ WHERE MATCH (`h`.`Name`) AGAINST ('First, Second')");
         }
 
         [ConditionalFact]
-        public virtual void Match_In_Natural_Language_Mode_Multiple_Keywords()
+        public virtual void Match_in_natural_language_mode_multiple_keywords()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First Herb", MySqlMatchSearchMode.InNaturalLanguageMode));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First Herb", MySqlMatchSearchMode.NaturalLanguage));
 
             Assert.Equal(9, count);
 
@@ -56,10 +56,10 @@ WHERE MATCH (`h`.`Name`) AGAINST ('First Herb')");
         }
 
         [ConditionalFact]
-        public virtual void Match_In_Natural_Language_Mode_Multiple_Keywords_Separated()
+        public virtual void Match_in_natural_language_mode_multiple_keywords_separated()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.InNaturalLanguageMode));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
 
             Assert.Equal(6, count);
 
@@ -69,10 +69,10 @@ WHERE MATCH (`h`.`Name`) AGAINST ('First, Second')");
         }
 
         [ConditionalFact]
-        public virtual void Match_In_Boolean_Mode()
+        public virtual void Match_in_boolean_mode()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", MySqlMatchSearchMode.InBooleanMode));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", MySqlMatchSearchMode.Boolean));
 
             Assert.Equal(3, count);
 
@@ -82,10 +82,32 @@ WHERE MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE)");
         }
 
         [ConditionalFact]
-        public virtual void Match_In_Boolean_Mode_Keywords()
+        public virtual void Match_in_boolean_mode_with_search_mode_parameter()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First* Herb*", MySqlMatchSearchMode.InBooleanMode));
+
+            var searchMode = MySqlMatchSearchMode.Boolean;
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", searchMode));
+
+            Assert.Equal(3, count);
+
+            AssertSql(
+                @"@__searchMode_1='2'
+
+SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE CASE @__searchMode_1
+    WHEN 1 THEN MATCH (`h`.`Name`) AGAINST ('First*' WITH QUERY EXPANSION)
+    WHEN 2 THEN MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE)
+    ELSE MATCH (`h`.`Name`) AGAINST ('First*')
+END");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_in_boolean_mode_keywords()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First* Herb*", MySqlMatchSearchMode.Boolean));
 
             Assert.Equal(9, count);
 
@@ -95,10 +117,10 @@ WHERE MATCH (`h`.`Name`) AGAINST ('First* Herb*' IN BOOLEAN MODE)");
         }
 
         [ConditionalFact]
-        public virtual void Match_In_Boolean_Mode_Keyword_Excluded()
+        public virtual void Match_in_boolean_mode_keyword_excluded()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "Herb* -Second", MySqlMatchSearchMode.InBooleanMode));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "Herb* -Second", MySqlMatchSearchMode.Boolean));
 
             Assert.Equal(6, count);
 
@@ -108,10 +130,10 @@ WHERE MATCH (`h`.`Name`) AGAINST ('Herb* -Second' IN BOOLEAN MODE)");
         }
 
         [ConditionalFact]
-        public virtual void Match_With_Query_Expansion()
+        public virtual void Match_with_query_expansion()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.WithQueryExpansion));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion));
 
             Assert.Equal(9, count);
 

--- a/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
@@ -83,30 +83,8 @@ FROM `Herb` AS `h`
 WHERE MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE)");
         }
 
-        [SupportedServerVersionFact(ServerVersion.MatchAgainstInsideCaseSupportKey)]
-        public virtual void Match_in_boolean_mode_with_search_mode_parameter_mysql()
-        {
-            using var context = CreateContext();
-
-            var searchMode = MySqlMatchSearchMode.Boolean;
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", searchMode));
-
-            Assert.Equal(3, count);
-
-            AssertSql(
-                @"@__searchMode_1='2'
-
-SELECT COUNT(*)
-FROM `Herb` AS `h`
-WHERE CASE @__searchMode_1
-    WHEN 1 THEN MATCH (`h`.`Name`) AGAINST ('First*' WITH QUERY EXPANSION)
-    WHEN 2 THEN MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE)
-    ELSE MATCH (`h`.`Name`) AGAINST ('First*')
-END");
-        }
-
-        [SupportedServerVersionLessThanFact(ServerVersion.MatchAgainstInsideCaseSupportKey)]
-        public virtual void Match_in_boolean_mode_with_search_mode_parameter_mariadb()
+        [ConditionalFact]
+        public virtual void Match_in_boolean_mode_with_search_mode_parameter()
         {
             using var context = CreateContext();
 


### PR DESCRIPTION
This PR extends upon the work of @neonVoice's recent #1056 PR:

Add support for supplying the search mode as a parameter/variable instead of just as a constant value.
Simplify search mode names.
Remove redundant search mode (`IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION` and `WITH QUERY EXPANSION` are the same mode).
Introduce explicit search mode values.
