### PR TITLE
Improve database information output and configuration in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   dotnet_version: 3.1.x
-  dotnet_ef_tools_version: 3.1.0
+  dotnet_ef_tools_version: 3.1.3
 
 jobs:
 
@@ -163,16 +163,30 @@ jobs:
     vmImage: 'windows-2019'
   variables:
     sql_mode: $(current_mysql_mode)
+    lower_case_table_names: 2
+    mysql_ini_path: C:\tools\mysql\current\my.ini
+    mysql_data_path: C:\ProgramData\MySQL\data
+    mysql_service_name: MySQL
   steps:
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'
     inputs:
       version: $(dotnet_version)
   - pwsh: |
+      Set-PSDebug -Trace 1
+
       choco install mysql
 
-      C:\tools\mysql\current\bin\mysql.exe -h localhost -u root -pPassword12! -e "SELECT @@version;"
-      C:\tools\mysql\current\bin\mysql.exe -h localhost -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'Password12!';"
+      Stop-Service $(mysql_service_name)
+      "lower_case_table_names=$(lower_case_table_names)" >> $(mysql_ini_path)
+      Remove-Item $(mysql_data_path)\* -Recurse -Force
+      mysqld --defaults-file="$(mysql_ini_path)" --initialize-insecure
+      Start-Service $(mysql_service_name)
+
+      mysql -h localhost -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'Password12!';"
+      mysql -h localhost -u root -pPassword12! -e "SELECT @@version;"
+
+      Set-PSDebug -Trace 0
     displayName: Install Database Server
   - pwsh: |
       .\dotnet-env.ps1 dotnet --info
@@ -184,10 +198,16 @@ jobs:
       .\build.cmd
     displayName: Setup and Build Solution
   - pwsh: |
-      C:\tools\mysql\current\bin\mysql.exe -h localhost -u root -pPassword12! -e "SET GLOBAL sql_mode = '$(sql_mode)';"
+      mysql -h localhost -u root -pPassword12! -e "SET GLOBAL sql_mode = '$(sql_mode)';"
     displayName: Setup Database
+    ignoreLASTEXITCODE: true  
   - pwsh: |
-      C:\tools\mysql\current\bin\mysql.exe -h localhost -u root -pPassword12! -e "SHOW VARIABLES;';"
+      echo "$(mysql_ini_path) file:"
+      cat $(mysql_ini_path)
+      echo ""
+      echo "MySQL variables:"
+      mysql -h localhost -u root -pPassword12! -e "SHOW VARIABLES;';"
+      echo ""
       echo "Exit code: $LastExitCode"
     displayName: Database Information
     continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,12 @@ jobs:
       docker exec mysql mysql -h localhost -P 3306 -u root -pPassword12! -e "SET GLOBAL sql_mode = '$SQL_MODE';"
     displayName: Setup Database
   - bash: |
+      docker exec mysql mysql -h localhost -P 3306 -u root -pPassword12! -e "SHOW VARIABLES;';"
+      echo "Exit code: $?"
+    displayName: Database Information
+    continueOnError: true
+    failOnStderr: false
+  - bash: |
       ./dotnet-env.sh dotnet tool install --global dotnet-ef --version $(dotnet_ef_tools_version)
       ./dotnet-env.sh dotnet ef --version
     displayName: Install EF Core Tools
@@ -180,6 +186,12 @@ jobs:
   - pwsh: |
       C:\tools\mysql\current\bin\mysql.exe -h localhost -u root -pPassword12! -e "SET GLOBAL sql_mode = '$(sql_mode)';"
     displayName: Setup Database
+  - pwsh: |
+      C:\tools\mysql\current\bin\mysql.exe -h localhost -u root -pPassword12! -e "SHOW VARIABLES;';"
+      echo "Exit code: $LastExitCode"
+    displayName: Database Information
+    continueOnError: true
+    ignoreLASTEXITCODE: true
   - pwsh: |
       .\dotnet-env.ps1 dotnet tool install --global dotnet-ef --version $(dotnet_ef_tools_version)
       .\dotnet-env.ps1 dotnet ef --version


### PR DESCRIPTION
To support more advanced database test scenarios, we need to diversify our test environment a bit. E.g. the `lower_case_table_names` MySQL variable should be set to different values on Linux and Windows to test more scenarios for #1017.

Also updates all used versions to their latest releases.