### PR TITLE
Implement support for index/key prefix lengths

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlIndexBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlIndexBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -9,10 +10,20 @@ using Pomelo.EntityFrameworkCore.MySql.Extensions;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
-
     public static class MySqlIndexBuilderExtensions
     {
+        // TODO: Remove/Hide for .NET 5.
+        [Obsolete("This extension method is obsolete. Use IsFullText instead.")]
         public static IndexBuilder ForMySqlIsFullText([NotNull] this IndexBuilder indexBuilder, bool fullText = true)
+            => IsFullText(indexBuilder, fullText);
+
+        /// <summary>
+        /// Sets a value indicating whether the index is full text.
+        /// </summary>
+        /// <param name="indexBuilder"> The index builder. </param>
+        /// <param name="fullText"> The value to set. </param>
+        /// <returns> The index builder. </returns>
+        public static IndexBuilder IsFullText([NotNull] this IndexBuilder indexBuilder, bool fullText = true)
         {
             Check.NotNull(indexBuilder, nameof(indexBuilder));
 
@@ -21,11 +32,39 @@ namespace Microsoft.EntityFrameworkCore
             return indexBuilder;
         }
 
+        // TODO: Remove/Hide for .NET 5.
+        [Obsolete("This extension method is obsolete. Use IsSpatial instead.")]
         public static IndexBuilder ForMySqlIsSpatial([NotNull] this IndexBuilder indexBuilder, bool spatial = true)
+            => IsSpatial(indexBuilder, spatial);
+
+
+        /// <summary>
+        /// Sets a value indicating whether the index is spartial.
+        /// </summary>
+        /// <param name="indexBuilder"> The index builder. </param>
+        /// <param name="spatial"> The value to set. </param>
+        /// <returns> The index builder. </returns>
+        public static IndexBuilder IsSpatial([NotNull] this IndexBuilder indexBuilder, bool spatial = true)
         {
             Check.NotNull(indexBuilder, nameof(indexBuilder));
 
             indexBuilder.Metadata.SetIsSpatial(spatial);
+
+            return indexBuilder;
+        }
+
+        /// <summary>
+        /// Sets prefix lengths for the index.
+        /// </summary>
+        /// <param name="indexBuilder"> The index builder. </param>
+        /// <param name="prefixLengths">The prefix lengths to set, in the order the index columns where specified.
+        /// A value of `0` indicates, that the full length should be used for that column. </param>
+        /// <returns> The index builder. </returns>
+        public static IndexBuilder HasPrefixLengths([NotNull] this IndexBuilder indexBuilder, params int[] prefixLengths)
+        {
+            Check.NotNull(indexBuilder, nameof(indexBuilder));
+
+            indexBuilder.Metadata.SetPrefixLengths(prefixLengths);
 
             return indexBuilder;
         }

--- a/src/EFCore.MySql/Extensions/MySqlIndexBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlIndexBuilderExtensions.cs
@@ -60,11 +60,11 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="prefixLengths">The prefix lengths to set, in the order the index columns where specified.
         /// A value of `0` indicates, that the full length should be used for that column. </param>
         /// <returns> The index builder. </returns>
-        public static IndexBuilder HasPrefixLengths([NotNull] this IndexBuilder indexBuilder, params int[] prefixLengths)
+        public static IndexBuilder HasPrefixLength([NotNull] this IndexBuilder indexBuilder, params int[] prefixLengths)
         {
             Check.NotNull(indexBuilder, nameof(indexBuilder));
 
-            indexBuilder.Metadata.SetPrefixLengths(prefixLengths);
+            indexBuilder.Metadata.SetPrefixLength(prefixLengths);
 
             return indexBuilder;
         }

--- a/src/EFCore.MySql/Extensions/MySqlIndexExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlIndexExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
@@ -17,7 +14,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         ///     Returns a value indicating whether the index is full text.
         /// </summary>
         /// <param name="index"> The index. </param>
-        /// <returns> <c>true</c> if the index is clustered. </returns>
+        /// <returns> <c>true</c> if the index is full text. </returns>
         public static bool? IsFullText([NotNull] this IIndex index)
             => (bool?)index[MySqlAnnotationNames.FullTextIndex];
 
@@ -52,12 +49,53 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         public static ConfigurationSource? GetIsFullTextConfigurationSource([NotNull] this IConventionIndex property)
             => property.FindAnnotation(MySqlAnnotationNames.FullTextIndex)?.GetConfigurationSource();
 
+        /// <summary>
+        ///     Returns prefix lengths for the index.
+        /// </summary>
+        /// <param name="index"> The index. </param>
+        /// <returns> The prefix lengths.
+        /// A value of `0` indicates, that the full length should be used for that column. </returns>
+        public static int[] PrefixLengths([NotNull] this IIndex index)
+            => (int[])index[MySqlAnnotationNames.IndexPrefixLengths];
+
+        /// <summary>
+        ///     Sets prefix lengths for the index.
+        /// </summary>
+        /// <param name="values"> The prefix lengths to set.
+        /// A value of `0` indicates, that the full length should be used for that column. </param>
+        /// <param name="index"> The index. </param>
+        public static void SetPrefixLengths([NotNull] this IMutableIndex index, int[] values)
+            => index.SetOrRemoveAnnotation(
+                MySqlAnnotationNames.IndexPrefixLengths,
+                values);
+
+        /// <summary>
+        ///     Sets prefix lengths for the index.
+        /// </summary>
+        /// <param name="values"> The prefix lengths to set.
+        /// A value of `0` indicates, that the full length should be used for that column. </param>
+        /// <param name="index"> The index. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        public static void SetPrefixLengths(
+            [NotNull] this IConventionIndex index, int[] values, bool fromDataAnnotation = false)
+            => index.SetOrRemoveAnnotation(
+                MySqlAnnotationNames.IndexPrefixLengths,
+                values,
+                fromDataAnnotation);
+
+        /// <summary>
+        ///     Returns the <see cref="ConfigurationSource" /> for prefix lengths of the index.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The <see cref="ConfigurationSource" /> for prefix lengths of the index. </returns>
+        public static ConfigurationSource? GetPrefixLengthsConfigurationSource([NotNull] this IConventionIndex property)
+            => property.FindAnnotation(MySqlAnnotationNames.IndexPrefixLengths)?.GetConfigurationSource();
 
         /// <summary>
         ///     Returns a value indicating whether the index is spartial.
         /// </summary>
         /// <param name="index"> The index. </param>
-        /// <returns> <c>true</c> if the index is clustered. </returns>
+        /// <returns> <c>true</c> if the index is spartial. </returns>
         public static bool? IsSpatial([NotNull] this IIndex index)
             => (bool?)index[MySqlAnnotationNames.SpatialIndex];
 

--- a/src/EFCore.MySql/Extensions/MySqlIndexExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlIndexExtensions.cs
@@ -55,8 +55,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// <param name="index"> The index. </param>
         /// <returns> The prefix lengths.
         /// A value of `0` indicates, that the full length should be used for that column. </returns>
-        public static int[] PrefixLengths([NotNull] this IIndex index)
-            => (int[])index[MySqlAnnotationNames.IndexPrefixLengths];
+        public static int[] PrefixLength([NotNull] this IIndex index)
+            => (int[])index[MySqlAnnotationNames.IndexPrefixLength];
 
         /// <summary>
         ///     Sets prefix lengths for the index.
@@ -64,9 +64,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// <param name="values"> The prefix lengths to set.
         /// A value of `0` indicates, that the full length should be used for that column. </param>
         /// <param name="index"> The index. </param>
-        public static void SetPrefixLengths([NotNull] this IMutableIndex index, int[] values)
+        public static void SetPrefixLength([NotNull] this IMutableIndex index, int[] values)
             => index.SetOrRemoveAnnotation(
-                MySqlAnnotationNames.IndexPrefixLengths,
+                MySqlAnnotationNames.IndexPrefixLength,
                 values);
 
         /// <summary>
@@ -76,10 +76,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// A value of `0` indicates, that the full length should be used for that column. </param>
         /// <param name="index"> The index. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        public static void SetPrefixLengths(
+        public static void SetPrefixLength(
             [NotNull] this IConventionIndex index, int[] values, bool fromDataAnnotation = false)
             => index.SetOrRemoveAnnotation(
-                MySqlAnnotationNames.IndexPrefixLengths,
+                MySqlAnnotationNames.IndexPrefixLength,
                 values,
                 fromDataAnnotation);
 
@@ -88,8 +88,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The <see cref="ConfigurationSource" /> for prefix lengths of the index. </returns>
-        public static ConfigurationSource? GetPrefixLengthsConfigurationSource([NotNull] this IConventionIndex property)
-            => property.FindAnnotation(MySqlAnnotationNames.IndexPrefixLengths)?.GetConfigurationSource();
+        public static ConfigurationSource? GetPrefixLengthConfigurationSource([NotNull] this IConventionIndex property)
+            => property.FindAnnotation(MySqlAnnotationNames.IndexPrefixLength)?.GetConfigurationSource();
 
         /// <summary>
         ///     Returns a value indicating whether the index is spartial.

--- a/src/EFCore.MySql/Extensions/MySqlKeyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlKeyBuilderExtensions.cs
@@ -15,11 +15,11 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="prefixLengths">The prefix lengths to set, in the order the key columns where specified.
         /// A value of `0` indicates, that the full length should be used for that column. </param>
         /// <returns> The key builder. </returns>
-        public static KeyBuilder HasPrefixLengths([NotNull] this KeyBuilder keyBuilder, params int[] prefixLengths)
+        public static KeyBuilder HasPrefixLength([NotNull] this KeyBuilder keyBuilder, params int[] prefixLengths)
         {
             Check.NotNull(keyBuilder, nameof(keyBuilder));
 
-            keyBuilder.Metadata.SetPrefixLengths(prefixLengths);
+            keyBuilder.Metadata.SetPrefixLength(prefixLengths);
 
             return keyBuilder;
         }

--- a/src/EFCore.MySql/Extensions/MySqlKeyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlKeyBuilderExtensions.cs
@@ -1,0 +1,27 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.Extensions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class MySqlKeyBuilderExtensions
+    {
+        /// <summary>
+        /// Sets prefix lengths for the key.
+        /// </summary>
+        /// <param name="keyBuilder"> The key builder. </param>
+        /// <param name="prefixLengths">The prefix lengths to set, in the order the key columns where specified.
+        /// A value of `0` indicates, that the full length should be used for that column. </param>
+        /// <returns> The key builder. </returns>
+        public static KeyBuilder HasPrefixLengths([NotNull] this KeyBuilder keyBuilder, params int[] prefixLengths)
+        {
+            Check.NotNull(keyBuilder, nameof(keyBuilder));
+
+            keyBuilder.Metadata.SetPrefixLengths(prefixLengths);
+
+            return keyBuilder;
+        }
+    }
+}

--- a/src/EFCore.MySql/Extensions/MySqlKeyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlKeyExtensions.cs
@@ -16,8 +16,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// <param name="key"> The key. </param>
         /// <returns> The prefix lengths.
         /// A value of `0` indicates, that the full length should be used for that column. </returns>
-        public static int[] PrefixLengths([NotNull] this IKey key)
-            => (int[])key[MySqlAnnotationNames.IndexPrefixLengths];
+        public static int[] PrefixLength([NotNull] this IKey key)
+            => (int[])key[MySqlAnnotationNames.IndexPrefixLength];
 
         /// <summary>
         ///     Sets prefix lengths for the key.
@@ -25,9 +25,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// <param name="values"> The prefix lengths to set.
         /// A value of `0` indicates, that the full length should be used for that column. </param>
         /// <param name="key"> The key. </param>
-        public static void SetPrefixLengths([NotNull] this IMutableKey key, int[] values)
+        public static void SetPrefixLength([NotNull] this IMutableKey key, int[] values)
             => key.SetOrRemoveAnnotation(
-                MySqlAnnotationNames.IndexPrefixLengths,
+                MySqlAnnotationNames.IndexPrefixLength,
                 values);
 
         /// <summary>
@@ -37,10 +37,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// A value of `0` indicates, that the full length should be used for that column. </param>
         /// <param name="key"> The key. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        public static void SetPrefixLengths(
+        public static void SetPrefixLength(
             [NotNull] this IConventionKey key, int[] values, bool fromDataAnnotation = false)
             => key.SetOrRemoveAnnotation(
-                MySqlAnnotationNames.IndexPrefixLengths,
+                MySqlAnnotationNames.IndexPrefixLength,
                 values,
                 fromDataAnnotation);
 
@@ -49,7 +49,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The <see cref="ConfigurationSource" /> for prefix lengths of the key. </returns>
-        public static ConfigurationSource? GetPrefixLengthsConfigurationSource([NotNull] this IConventionKey property)
-            => property.FindAnnotation(MySqlAnnotationNames.IndexPrefixLengths)?.GetConfigurationSource();
+        public static ConfigurationSource? GetPrefixLengthConfigurationSource([NotNull] this IConventionKey property)
+            => property.FindAnnotation(MySqlAnnotationNames.IndexPrefixLength)?.GetConfigurationSource();
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlKeyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlKeyExtensions.cs
@@ -1,0 +1,55 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Extensions
+{
+    /// <summary>
+    ///     Extension methods for <see cref="IKey" /> for SQL Server-specific metadata.
+    /// </summary>
+    public static class MySqlKeyExtensions
+    {
+        /// <summary>
+        ///     Returns prefix lengths for the key.
+        /// </summary>
+        /// <param name="key"> The key. </param>
+        /// <returns> The prefix lengths.
+        /// A value of `0` indicates, that the full length should be used for that column. </returns>
+        public static int[] PrefixLengths([NotNull] this IKey key)
+            => (int[])key[MySqlAnnotationNames.IndexPrefixLengths];
+
+        /// <summary>
+        ///     Sets prefix lengths for the key.
+        /// </summary>
+        /// <param name="values"> The prefix lengths to set.
+        /// A value of `0` indicates, that the full length should be used for that column. </param>
+        /// <param name="key"> The key. </param>
+        public static void SetPrefixLengths([NotNull] this IMutableKey key, int[] values)
+            => key.SetOrRemoveAnnotation(
+                MySqlAnnotationNames.IndexPrefixLengths,
+                values);
+
+        /// <summary>
+        ///     Sets prefix lengths for the key.
+        /// </summary>
+        /// <param name="values"> The prefix lengths to set.
+        /// A value of `0` indicates, that the full length should be used for that column. </param>
+        /// <param name="key"> The key. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        public static void SetPrefixLengths(
+            [NotNull] this IConventionKey key, int[] values, bool fromDataAnnotation = false)
+            => key.SetOrRemoveAnnotation(
+                MySqlAnnotationNames.IndexPrefixLengths,
+                values,
+                fromDataAnnotation);
+
+        /// <summary>
+        ///     Returns the <see cref="ConfigurationSource" /> for prefix lengths of the key.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The <see cref="ConfigurationSource" /> for prefix lengths of the key. </returns>
+        public static ConfigurationSource? GetPrefixLengthsConfigurationSource([NotNull] this IConventionKey property)
+            => property.FindAnnotation(MySqlAnnotationNames.IndexPrefixLengths)?.GetConfigurationSource();
+    }
+}

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
@@ -26,6 +26,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
         public const string SpatialIndex = Prefix + "SpatialIndex";
         public const string CharSet = Prefix + "CharSet";
         public const string Collation = Prefix + "Collation";
-        public const string IndexPrefixLengths = Prefix + "IndexPrefixLengths";
+        public const string IndexPrefixLength = Prefix + "IndexPrefixLength";
     }
 }

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
@@ -20,17 +20,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public const string ValueGenerationStrategy = Prefix + "ValueGenerationStrategy";
-
         public const string LegacyValueGeneratedOnAdd = Prefix + "ValueGeneratedOnAdd";
-
         public const string LegacyValueGeneratedOnAddOrUpdate = Prefix + "ValueGeneratedOnAddOrUpdate";
-
         public const string FullTextIndex = Prefix + "FullTextIndex";
-
         public const string SpatialIndex = Prefix + "SpatialIndex";
-
         public const string CharSet = Prefix + "CharSet";
-
         public const string Collation = Prefix + "Collation";
+        public const string IndexPrefixLengths = Prefix + "IndexPrefixLengths";
     }
 }

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -325,7 +325,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
                 .Append(" ON ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                 .Append(" (")
-                .Append(ColumnListWithIndexPrefixLengths(operation, operation.Columns))
+                .Append(ColumnListWithIndexPrefixLength(operation, operation.Columns))
                 .Append(")");
 
             IndexOptions(operation, model, builder);
@@ -1054,7 +1054,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
             IndexTraits(operation, model, builder);
 
             builder.Append("(")
-                .Append(ColumnListWithIndexPrefixLengths(operation, operation.Columns))
+                .Append(ColumnListWithIndexPrefixLength(operation, operation.Columns))
                 .Append(")");
         }
 
@@ -1080,7 +1080,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
             IndexTraits(operation, model, builder);
 
             builder.Append("(")
-                .Append(ColumnListWithIndexPrefixLengths(operation, operation.Columns))
+                .Append(ColumnListWithIndexPrefixLength(operation, operation.Columns))
                 .Append(")");
         }
 
@@ -1200,8 +1200,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
             }
         }
 
-        private string ColumnListWithIndexPrefixLengths(MigrationOperation operation, string[] columns)
-            => operation[MySqlAnnotationNames.IndexPrefixLengths] is int[] prefixValues
+        private string ColumnListWithIndexPrefixLength(MigrationOperation operation, string[] columns)
+            => operation[MySqlAnnotationNames.IndexPrefixLength] is int[] prefixValues
                 ? ColumnList(
                     columns,
                     (c, i) => prefixValues.Length > i && prefixValues[i] > 0

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -436,7 +436,7 @@ ORDER BY
 
                                 if (prefixLengths.Length > 0)
                                 {
-                                    key[MySqlAnnotationNames.IndexPrefixLengths] = prefixLengths;
+                                    key[MySqlAnnotationNames.IndexPrefixLength] = prefixLengths;
                                 }
 
                                 table.PrimaryKey = key;
@@ -496,7 +496,7 @@ ORDER BY
 
                                 if (prefixLengths.Length > 0)
                                 {
-                                    index[MySqlAnnotationNames.IndexPrefixLengths] = prefixLengths;
+                                    index[MySqlAnnotationNames.IndexPrefixLength] = prefixLengths;
                                 }
 
                                 table.Indexes.Add(index);

--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -131,7 +131,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             {
                 if (_mySqlOptionsExtension.UpdateSqlModeOnOpen && _mySqlOptionsExtension.NoBackslashEscapes)
                 {
-                    AppendToSqlMode(NoBackslashEscapes);
+                    AddSqlMode(NoBackslashEscapes);
                 }
             }
 
@@ -146,17 +146,23 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             {
                 if (_mySqlOptionsExtension.UpdateSqlModeOnOpen && _mySqlOptionsExtension.NoBackslashEscapes)
                 {
-                    await AppendToSqlModeAsync(NoBackslashEscapes);
+                    await AddSqlModeAsync(NoBackslashEscapes);
                 }
             }
 
             return result;
         }
 
-        public virtual void AppendToSqlMode(string mode)
-            => Dependencies.CurrentContext.Context?.Database.ExecuteSqlRaw(@"SET SESSION sql_mode = CONCAT(@@sql_mode, ',', @p0)", new MySqlParameter("@p0", mode));
+        public virtual void AddSqlMode(string mode)
+            => Dependencies.CurrentContext.Context?.Database.ExecuteSqlInterpolated($@"SET SESSION sql_mode = CONCAT(@@sql_mode, ',', {mode});");
 
-        public virtual Task AppendToSqlModeAsync(string mode)
-            => Dependencies.CurrentContext.Context?.Database.ExecuteSqlRawAsync(@"SET SESSION sql_mode = CONCAT(@@sql_mode, ',', @p0)", new MySqlParameter("@p0", mode));
+        public virtual Task AddSqlModeAsync(string mode)
+            => Dependencies.CurrentContext.Context?.Database.ExecuteSqlInterpolatedAsync($@"SET SESSION sql_mode = CONCAT(@@sql_mode, ',', {mode});");
+
+        public virtual void RemoveSqlMode(string mode)
+            => Dependencies.CurrentContext.Context?.Database.ExecuteSqlInterpolated($@"SET SESSION sql_mode = REPLACE(@@sql_mode, {mode}, '');");
+
+        public virtual void RemoveSqlModeAsync(string mode)
+            => Dependencies.CurrentContext.Context?.Database.ExecuteSqlInterpolatedAsync($@"SET SESSION sql_mode = REPLACE(@@sql_mode, {mode}, '');");
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -395,6 +395,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
                     var maxSize = 8000 / bytesPerChar;
 
+                    // Obsolete: Remove this for .NET 5 release, because of `HasPrefixLength()` support.
                     var size = mappingInfo.Size ??
                                (mappingInfo.IsKeyOrIndex
                                    // Allow to use at most half of the max key length, so at least 2 columns can fit

--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage
 {

--- a/src/EFCore.MySql/Storage/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.cs
@@ -11,7 +11,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
     {
         private static readonly Regex _versionRegex = new Regex(@"\d+\.\d+\.?(?:\d+)?");
 
-        public static ServerVersion Default = new ServerVersion(new Version(8, 0, 18), ServerType.MySql);
+        public static ServerVersion Default = new ServerVersion(new Version(8, 0, 19), ServerType.MySql);
 
         public ServerVersion()
             : this(null)

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.cs
@@ -924,7 +924,7 @@ ALTER TABLE `People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replace("\n"
                     Name = "IX_IceCreams_Brand_Name",
                     Table = "IceCreams",
                     Columns = new[] { "Name", "Brand" },
-                    [MySqlAnnotationNames.IndexPrefixLengths] = new [] { 0, 20 }
+                    [MySqlAnnotationNames.IndexPrefixLength] = new [] { 0, 20 }
                 });
 
             Assert.Equal(
@@ -958,7 +958,7 @@ ALTER TABLE `People` DROP PRIMARY KEY;".Replace("\r", string.Empty).Replace("\n"
                     PrimaryKey = new AddPrimaryKeyOperation
                     {
                         Columns = new[] { "Name", "Brand" },
-                        [MySqlAnnotationNames.IndexPrefixLengths] = new [] { 0, 20 }
+                        [MySqlAnnotationNames.IndexPrefixLength] = new [] { 0, 20 }
                     },
                 });
 

--- a/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
-using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes;
-using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
@@ -202,7 +200,7 @@ WHERE MATCH (`h`.`Name`) AGAINST ('First' WITH QUERY EXPANSION)");
                     {
                         herb.HasData(MatchQueryData.CreateHerbs());
                         herb.HasKey(h => h.Id);
-                        herb.HasIndex(h => h.Name).ForMySqlIsFullText();
+                        herb.HasIndex(h => h.Name).IsFullText();
                     });
             }
 

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -15,6 +15,7 @@ using Pomelo.EntityFrameworkCore.MySql.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.Extensions.DependencyInjection;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
 // ReSharper disable InconsistentNaming
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Scaffolding
@@ -427,14 +428,39 @@ CREATE TABLE PrimaryKeyName (
                 Enumerable.Empty<string>(),
                 Enumerable.Empty<string>(),
                 dbModel =>
-                    {
-                        var pk = dbModel.Tables.Single().PrimaryKey;
+                {
+                    var pk = dbModel.Tables.Single().PrimaryKey;
 
-                        Assert.Equal("PrimaryKeyName", pk.Table.Name);
-                        Assert.Equal("PK", pk.Name);
-                        Assert.Equal(new List<string> { "Id" }, pk.Columns.Select(ic => ic.Name).ToList());
-                    },
+                    Assert.Equal("PrimaryKeyName", pk.Table.Name);
+                    Assert.Equal("PK", pk.Name);
+                    Assert.Equal(new List<string> { "Id" }, pk.Columns.Select(ic => ic.Name).ToList());
+                },
                 @"DROP TABLE PrimaryKeyName;");
+        }
+
+        [Fact]
+        public void Prefix_lengths_for_primary_key()
+        {
+            Test(
+                @"
+CREATE TABLE `IceCreams` (
+    `Brand` longtext NOT NULL,
+    `Name` varchar(255) NOT NULL,
+    PRIMARY KEY (`Name`, `Brand`(20))
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var pk = dbModel.Tables.Single().PrimaryKey;
+
+                    Assert.Equal("IceCreams", pk.Table.Name);
+                    Assert.Equal(2, pk.Columns.Count);
+                    Assert.Equal("Name", pk.Columns[0].Name);
+                    Assert.Equal("Brand", pk.Columns[1].Name);
+                    Assert.Equal(new [] { 0, 20 }, pk.FindAnnotation(MySqlAnnotationNames.IndexPrefixLengths)?.Value);
+                },
+                @"DROP TABLE IF EXISTS `IceCreams`;");
         }
 
         #endregion
@@ -540,6 +566,35 @@ CREATE UNIQUE INDEX IX_UNIQUE on UniqueIndex (Id2);",
                         Assert.Equal(new List<string> { "Id2" }, index.Columns.Select(ic => ic.Name).ToList());
                     },
                 @"DROP TABLE UniqueIndex;");
+        }
+
+        [Fact]
+        public void Prefix_lengths_for_index()
+        {
+            Test(
+                @"
+CREATE TABLE `IceCreams` (
+    `IceCreamId` int NOT NULL,
+    `Brand` longtext NOT NULL,
+    `Name` varchar(255) NOT NULL,
+    PRIMARY KEY (`IceCreamId`)
+);
+
+CREATE INDEX `IX_IceCreams_Brand_Name` ON `IceCreams` (`Name`, `Brand`(20));
+",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var index = dbModel.Tables.Single().Indexes.Single();
+
+                    Assert.Equal("IceCreams", index.Table.Name);
+                    Assert.Equal(2, index.Columns.Count);
+                    Assert.Equal("Name", index.Columns[0].Name);
+                    Assert.Equal("Brand", index.Columns[1].Name);
+                    Assert.Equal(new [] { 0, 20 }, index.FindAnnotation(MySqlAnnotationNames.IndexPrefixLengths)?.Value);
+                },
+                @"DROP TABLE IF EXISTS `IceCreams`;");
         }
 
         #endregion
@@ -817,7 +872,7 @@ DROP TABLE PrincipalTable;");
 
         #endregion
 
-        public class MySqlDatabaseModelFixture : SharedStoreFixtureBase<DbContext>
+        public class MySqlDatabaseModelFixture : SharedStoreFixtureBase<PoolableDbContext>
         {
             protected override string StoreName { get; } = nameof(MySqlDatabaseModelFactoryTest);
             protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.Instance;

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -458,7 +458,7 @@ CREATE TABLE `IceCreams` (
                     Assert.Equal(2, pk.Columns.Count);
                     Assert.Equal("Name", pk.Columns[0].Name);
                     Assert.Equal("Brand", pk.Columns[1].Name);
-                    Assert.Equal(new [] { 0, 20 }, pk.FindAnnotation(MySqlAnnotationNames.IndexPrefixLengths)?.Value);
+                    Assert.Equal(new [] { 0, 20 }, pk.FindAnnotation(MySqlAnnotationNames.IndexPrefixLength)?.Value);
                 },
                 @"DROP TABLE IF EXISTS `IceCreams`;");
         }
@@ -592,7 +592,7 @@ CREATE INDEX `IX_IceCreams_Brand_Name` ON `IceCreams` (`Name`, `Brand`(20));
                     Assert.Equal(2, index.Columns.Count);
                     Assert.Equal("Name", index.Columns[0].Name);
                     Assert.Equal("Brand", index.Columns[1].Name);
-                    Assert.Equal(new [] { 0, 20 }, index.FindAnnotation(MySqlAnnotationNames.IndexPrefixLengths)?.Value);
+                    Assert.Equal(new [] { 0, 20 }, index.FindAnnotation(MySqlAnnotationNames.IndexPrefixLength)?.Value);
                 },
                 @"DROP TABLE IF EXISTS `IceCreams`;");
         }


### PR DESCRIPTION
The following code can be used to specify prefix lengths for indices:

```c#
// One column:
entity.HasIndex(e => e.SingleProperty)
    .HasPrefixLength(48);

// Multiple columns:
entity.HasIndex(e => new { e.FirstProperty, e.SecondProperty })
    .HasPrefixLength(0, 32);
```

The code to specify prefix lengths for keys is similar:

```c#
// One column:
entity.HasKey(e => e.SingleProperty)
    .HasPrefixLength(48);

// Multiple columns:
entity.HasKey(e => new { e.FirstProperty, e.SecondProperty })
    .HasPrefixLength(0, 32);
```

If you want to specify the usage of the whole length of a column as part of an index/key, specify the length as `0`, as can be seen in the `Multiple columns` examples.

~~I am not sure, if we should use the singular `HasPrefixLength`, instead of the plural.~~

Closes #936 

Also addresses #872, #380, #298, #259, #136, #99, #81 and #7