### PR TITLE
An item with the same key has already been added. Key: Microsoft.Enti…

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore
             };
 
             connectionString = csb.ConnectionString;
-            var extension = GetOrCreateExtension(optionsBuilder).WithConnectionString(connectionString);
+            var extension = (MySqlOptionsExtension)GetOrCreateExtension(optionsBuilder).WithConnectionString(connectionString);
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
             ConfigureWarnings(optionsBuilder);
             mySqlOptionsAction?.Invoke(new MySqlDbContextOptionsBuilder(optionsBuilder));

--- a/src/EFCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
@@ -14,6 +14,8 @@ using MySql.Data.MySqlClient;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
+    // TODO: Rename to MySqlDbContextOptionsBuilderExtensions for .NET Core 5.0, which is in line with Npgsql, but
+    //       not with SqlServer.
     public static class MySqlDbContextOptionsExtensions
     {
         public static DbContextOptionsBuilder UseMySql(
@@ -66,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
 
-            var extension = GetOrCreateExtension(optionsBuilder).WithConnection(connection);
+            var extension = (MySqlOptionsExtension)GetOrCreateExtension(optionsBuilder).WithConnection(connection);
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
             ConfigureWarnings(optionsBuilder);
             mySqlOptionsAction?.Invoke(new MySqlDbContextOptionsBuilder(optionsBuilder));

--- a/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
+using Xunit;
+
+namespace Pomelo.EntityFrameworkCore.MySql
+{
+    public class MySqlDbContextOptionsBuilderExtensionsTest
+    {
+        [Fact]
+        public void Multiple_UseMySql_calls_each_get_fully_applied()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=first;",
+                options =>
+                    options.DefaultDataTypeMappings(
+                        mappings =>
+                            mappings.WithClrBoolean(MySqlBooleanType.Bit1)));
+
+            builder.UseMySql(
+                "Server=second;",
+                options =>
+                    options.DefaultDataTypeMappings(
+                        mappings =>
+                            mappings.WithClrBoolean(MySqlBooleanType.TinyInt1)));
+
+            var mySqlOptionsExtension = builder.Options.GetExtension<MySqlOptionsExtension>();
+            Assert.StartsWith("Server=second;", mySqlOptionsExtension.ConnectionString, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(MySqlBooleanType.TinyInt1, mySqlOptionsExtension.DefaultDataTypeMappings.ClrBoolean);
+        }
+    }
+}


### PR DESCRIPTION
Fixed issue #376
Fixed issue #356

I have fixed the issue as it was missing the casting of 'MySqlOptionsExtension' class. 

1. So first time if object dosen't exists then GetOrCreateExtension returns 'MySqlOptionsExtension' class. 

2. But second time if it exists then it returns the base class of 'MySqlOptionsExtension' which is RelationalOptionsExtension.

That's why update extension was not happening. 

Check the same code in entity framwork core for sql server [here](https://github.com/dotnet/efcore/blob/master/src/EFCore.SqlServer/Extensions/SqlServerDbContextOptionsBuilderExtensions.cs).
