### PR TITLE
Pack NTS project and fix debugging output

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <StrongNameKeyId>Pomelo.EntityFrameworkCore.MySql</StrongNameKeyId>
-    <PackageTags>Entity Framework Core MySQL;entity-framework-core-mysql;EF MySQL;EF Core MySQL</PackageTags>
+    <PackageTags>pomelo;mysql;mariadb;Entity Framework Core;entity-framework-core;ef;efcore;ef core;orm;sql</PackageTags>
     <Product>Pomelo.EntityFrameworkCore.MySql</Product>
     <Authors>Pomelo Foundation</Authors>
     <Company>Pomelo Foundation</Company>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   dotnet_version: 3.1.x
-  dotnet_ef_tools_version: 3.1.3
+  dotnet_ef_tools_version: 3.1.5
 
 jobs:
 
@@ -266,7 +266,7 @@ jobs:
       set -e
 
       pack="false"
-      pack_nuget_org="false"
+      pack_nuget_org=""
       pack_wip="false"
 
       echo "Build.SourceBranch=$(Build.SourceBranch)"
@@ -301,17 +301,33 @@ jobs:
           "/p:DotNetFinalVersionKind=$final_version_kind" \
           "/p:ContinuousIntegrationBuild=true" \
           src/EFCore.MySql/
+        ./dotnet-env.sh dotnet pack \
+          -c Release \
+          "/p:OfficialBuildId=$(Build.BuildNumber)" \
+          "/p:DotNetFinalVersionKind=$final_version_kind" \
+          "/p:ContinuousIntegrationBuild=true" \
+          src/EFCore.MySql.NTS/
       fi
 
+      # If ALL nupkg files end in the branch name (no "preview-" etc.), we consider
+      # this an official release and push this to nuget.org.
+      # Otherwise, this release will be pushed exclusively to AZDO as a nightly build.
       if [ "$final_version_kind" != "" ]; then
         IFS=$'\n'
         for i in $(find artifacts -name "*.nupkg"); do
           filename=$(basename $i)
-          if [ "$filename" = "Pomelo.EntityFrameworkCore.MySql.$(Build.SourceBranchName).nupkg" ]; then
+          if { [ "$pack_nuget_org" == "" ] || [ "$pack_nuget_org" == "true" ]; } && [ "$filename" = "*.$(Build.SourceBranchName).nupkg" ]; then
             pack_nuget_org="true"
+          elif [ $pack_nuget_org = "true" ]; then
+            pack_nuget_org="false"
+            break
           fi
         done
         unset IFS
+      fi
+
+      if [ "$pack_nuget_org" == "" ]; then
+        pack_nuget_org="false"
       fi
 
       echo "Pack.Pack=$pack"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <MicrosoftNETCoreAppInternalPackageVersion>3.1.3-servicing.20128.1</MicrosoftNETCoreAppInternalPackageVersion>
     <!-- EFCore.MySql Dependencies -->
     <MicrosoftEntityFrameworkCoreRelationalVersion>3.1.3</MicrosoftEntityFrameworkCoreRelationalVersion>
-    <MySqlConnectorVersion>0.69.1</MySqlConnectorVersion>
+    <MySqlConnectorVersion>0.69.2</MySqlConnectorVersion>
     <PomeloJsonObjectVersion>2.2.1</PomeloJsonObjectVersion>
     <MicrosoftExtensionsCachingMemoryVersion>3.1.3</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsDependencyInjection>3.1.3</MicrosoftExtensionsDependencyInjection>

--- a/src/EFCore.MySql.NTS/EFCore.MySql.NTS.csproj
+++ b/src/EFCore.MySql.NTS/EFCore.MySql.NTS.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>Pomelo.EntityFrameworkCore.MySql.NetTopologySuite</AssemblyName>
     <RootNamespace>Pomelo.EntityFrameworkCore.MySql</RootNamespace>
     <IsPackable>true</IsPackable>
-    <PackageTags>$(PackageTags);MySQL;GIS;OpenGIS;NTS;OGC;Spatial</PackageTags>
+    <PackageTags>$(PackageTags);gis;opengis;nts;ogc;spatial</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/EFCore.MySql.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
+++ b/src/EFCore.MySql.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.IO;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MySql.Data.Types;
@@ -39,21 +37,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.ValueConversion.Internal
         private static readonly ConcurrentDictionary<uint, NtsGeometryServices> _geometryServiceses = new ConcurrentDictionary<uint, NtsGeometryServices>();
 
         private static MySqlGeometry ConvertToProviderCore(TGeometry v)
-        {
-            var geometry = MySqlGeometry.FromWkb(v.SRID, v.ToBinary());
-#if DEBUG
-            var hexString = BitConverter.ToString(geometry.Value).Replace("-", string.Empty);
-            Debug.WriteLine("Spatial to provider: " + hexString);
-#endif
-            return geometry;
-        }
+            => MySqlGeometry.FromWkb(v.SRID, v.ToBinary());
 
         private static TGeometry ConvertFromProviderCore(MySqlGeometry v)
         {
-#if DEBUG
-            var hexString = BitConverter.ToString(v.Value).Replace("-", string.Empty);
-            Debug.WriteLine("Spatial from provider: " + hexString);
-#endif
             using var memoryStream = new MemoryStream(v.Value);
 
             // MySQL starts it's spatial data with a 4 byte SRID, that is unexpected by WKBReader.


### PR DESCRIPTION
Packages `EFCore.MySql.NTS` for AZDO and nuget.org.
Removes debugging output from MySqlConnector and EFCore.MySql.NTS.

With this PR, spatial support is available in our [nightly build feed](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql#nightly-builds) (when enabling `preview` versions in your project/solution) using the `Pomelo.EntityFrameworkCore.MySql.NetTopologySuite` package.

Related to #1097 and #488