### PR TITLE
Update to MySqlConnector 1.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <MicrosoftNETCoreAppInternalPackageVersion>3.1.3-servicing.20128.1</MicrosoftNETCoreAppInternalPackageVersion>
     <!-- EFCore.MySql Dependencies -->
     <MicrosoftEntityFrameworkCoreRelationalVersion>3.1.3</MicrosoftEntityFrameworkCoreRelationalVersion>
-    <MySqlConnectorVersion>0.69.2</MySqlConnectorVersion>
+    <MySqlConnectorVersion>1.0.0</MySqlConnectorVersion>
     <PomeloJsonObjectVersion>2.2.1</PomeloJsonObjectVersion>
     <MicrosoftExtensionsCachingMemoryVersion>3.1.3</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsDependencyInjection>3.1.3</MicrosoftExtensionsDependencyInjection>

--- a/src/EFCore.MySql.NTS/Storage/Internal/MySqlGeometryTypeMapping.cs
+++ b/src/EFCore.MySql.NTS/Storage/Internal/MySqlGeometryTypeMapping.cs
@@ -6,10 +6,9 @@ using System.Data.Common;
 using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
-using MySql.Data.MySqlClient; // Note: Hard reference to MySqlClient here.
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MySql.Data.Types;
+using MySqlConnector;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;

--- a/src/EFCore.MySql.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
+++ b/src/EFCore.MySql.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
@@ -4,7 +4,7 @@
 using System.Collections.Concurrent;
 using System.IO;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MySql.Data.Types;
+using MySqlConnector;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;

--- a/src/EFCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
@@ -9,7 +9,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore

--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Internal

--- a/src/EFCore.MySql/MySqlRetryingExecutionStrategy.cs
+++ b/src/EFCore.MySql/MySqlRetryingExecutionStrategy.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 //ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -16,7 +16,7 @@ using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;

--- a/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System.Data.Common;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {

--- a/src/EFCore.MySql/Storage/Internal/MySqlDatabaseCreator.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDatabaseCreator.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
@@ -330,10 +330,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         // Clear connection pools in case there are active connections that are pooled
-        private static void ClearAllPools() => global::MySql.Data.MySqlClient.MySqlConnection.ClearAllPools();
+        private static void ClearAllPools() => MySqlConnection.ClearAllPools();
 
         // Clear connection pool for the database connection since after the 'create database' call, a previously
         // invalid connection may now be valid.
-        private void ClearPool() => global::MySql.Data.MySqlClient.MySqlConnection.ClearPool((global::MySql.Data.MySqlClient.MySqlConnection)_relationalConnection.DbConnection);
+        private void ClearPool() => MySqlConnection.ClearPool((MySqlConnection)_relationalConnection.DbConnection);
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
@@ -1,6 +1,6 @@
 using System;
 using Microsoft.EntityFrameworkCore.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal

--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -10,7 +10,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 

--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalTransaction.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalTransaction.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {

--- a/src/EFCore.MySql/Storage/Internal/MySqlScaffoldingConnectionSettings.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlScaffoldingConnectionSettings.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Data.Common;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {

--- a/src/EFCore.MySql/Storage/Internal/MySqlTransientExceptionDetector.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTransientExceptionDetector.cs
@@ -3,7 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {

--- a/src/EFCore.MySql/ValueGeneration/Internal/MySqlSequentialGuidValueGenerator.cs
+++ b/src/EFCore.MySql/ValueGeneration/Internal/MySqlSequentialGuidValueGenerator.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.ValueGeneration.Internal
 {

--- a/test/EFCore.MySql.FunctionalTests/ConnectionSettingsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/ConnectionSettingsMySqlTest.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;

--- a/test/EFCore.MySql.FunctionalTests/Query/FromSqlQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/FromSqlQueryMySqlTest.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query

--- a/test/EFCore.MySql.FunctionalTests/Query/FromSqlSprocQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/FromSqlSprocQueryMySqlTest.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 {

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Attributes;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Xunit;

--- a/test/EFCore.MySql.FunctionalTests/Query/SqlExecutorMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SqlExecutorMySqlTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStore.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStore.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.Configuration;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
 {

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/TestMySqlRetryingExecutionStrategy.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/TestMySqlRetryingExecutionStrategy.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
 {

--- a/test/EFCore.MySql.IntegrationTests/Commands/TestMigrateCommand.cs
+++ b/test/EFCore.MySql.IntegrationTests/Commands/TestMigrateCommand.cs
@@ -1,6 +1,6 @@
 using System;
 using Microsoft.EntityFrameworkCore;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Commands{

--- a/test/EFCore.MySql.IntegrationTests/Startup.cs
+++ b/test/EFCore.MySql.IntegrationTests/Startup.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Newtonsoft.Json;
 
 namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests

--- a/test/EFCore.MySql.IntegrationTests/Tests/Connection/ConnectionTest.cs
+++ b/test/EFCore.MySql.IntegrationTests/Tests/Connection/ConnectionTest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Models;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Tests.Connection

--- a/test/EFCore.MySql.IntegrationTests/Tests/Models/GeneratedTypesTest.cs
+++ b/test/EFCore.MySql.IntegrationTests/Tests/Models/GeneratedTypesTest.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Models;
 using Microsoft.EntityFrameworkCore;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Tests.Attributes;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Xunit;

--- a/test/EFCore.MySql.Tests/ValueGeneration/Internal/MysqlSequentialGuidValueGeneratorTest.cs
+++ b/test/EFCore.MySql.Tests/ValueGeneration/Internal/MysqlSequentialGuidValueGeneratorTest.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using Moq;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using Pomelo.EntityFrameworkCore.MySql.ValueGeneration.Internal;


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.