### PR TITLE
Optimizes bool translations in a backwards compatible way

### DIFF
--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -19,5 +19,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         bool ReplaceLineBreaksWithCharFunction { get; }
         MySqlDefaultDataTypeMappings DefaultDataTypeMappings { get; }
         MySqlSchemaNameTranslator SchemaNameTranslator { get; }
+        bool IndexOptimizedBooleanColumns { get; }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -20,6 +20,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         public MySqlOptionsExtension()
         {
             ReplaceLineBreaksWithCharFunction = true;
+
+            // TODO: Change to `true` for EF Core 5.
+            IndexOptimizedBooleanColumns = false;
         }
 
         public MySqlOptionsExtension([NotNull] MySqlOptionsExtension copyFrom)
@@ -34,6 +37,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             DefaultDataTypeMappings = copyFrom.DefaultDataTypeMappings;
             SchemaBehavior = copyFrom.SchemaBehavior;
             SchemaNameTranslator = copyFrom.SchemaNameTranslator;
+            IndexOptimizedBooleanColumns = copyFrom.IndexOptimizedBooleanColumns;
         }
 
         /// <summary>
@@ -84,6 +88,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
 
         public MySqlSchemaBehavior SchemaBehavior { get; private set; }
         public MySqlSchemaNameTranslator SchemaNameTranslator { get; private set; }
+        public bool IndexOptimizedBooleanColumns { get; private set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -176,7 +181,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
 
             return clone;
         }
-        
+
+        public MySqlOptionsExtension WithIndexOptimizedBooleanColumns(bool enable)
+        {
+            var clone = (MySqlOptionsExtension)Clone();
+            clone.IndexOptimizedBooleanColumns = enable;
+            return clone;
+        }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -240,6 +252,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.DefaultDataTypeMappings?.GetHashCode() ?? 0L);
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ Extension.SchemaBehavior.GetHashCode();
                     _serviceProviderHash = (_serviceProviderHash * 397) ^ (Extension.SchemaNameTranslator?.GetHashCode() ?? 0L);
+                    _serviceProviderHash = (_serviceProviderHash * 397) ^ Extension.IndexOptimizedBooleanColumns.GetHashCode();
                 }
 
                 return _serviceProviderHash.Value;
@@ -263,6 +276,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                     = (Extension.DefaultDataTypeMappings?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
                 debugInfo["MySql:" + nameof(MySqlDbContextOptionsBuilder.SchemaBehavior)]
                     = Extension.SchemaBehavior.GetHashCode().ToString(CultureInfo.InvariantCulture);
+                debugInfo["MySql:" + nameof(MySqlDbContextOptionsBuilder.EnableIndexOptimizedBooleanColumns)]
+                    = Extension.IndexOptimizedBooleanColumns.GetHashCode().ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -123,5 +123,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         public virtual MySqlDbContextOptionsBuilder SchemaBehavior(MySqlSchemaBehavior behavior, MySqlSchemaNameTranslator translator = null)
             => WithOption(e => e.WithSchemaBehavior(behavior, translator));
+
+        /// <summary>
+        ///     Configures the context to optimize `System.Boolean` mapped columns for index usage,
+        ///     by translating `e.BoolColumn` to `BoolColumn = TRUE` and `!e.BoolColumn` to `BoolColumn = FALSE`.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder EnableIndexOptimizedBooleanColumns(bool enable = true)
+            => WithOption(e => e.WithIndexOptimizedBooleanColumns(enable));
     }
 }

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQueryTranslationPostprocessor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQueryTranslationPostprocessor.cs
@@ -22,7 +22,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
         {
             query = base.Process(query);
 
-            query = new MySqlBoolOptimizingExpressionVisitor(SqlExpressionFactory).Visit(query);
+            if (_options.IndexOptimizedBooleanColumns)
+            {
+                query = new MySqlBoolOptimizingExpressionVisitor(SqlExpressionFactory).Visit(query);
+            }
+
             query = new MySqlCompatibilityExpressionVisitor(_options).Visit(query);
 
             return query;

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlFixture.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlFixture.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
@@ -9,6 +10,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
     public class GearsOfWarQueryMySqlFixture : GearsOfWarQueryRelationalFixture
     {
         protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.Instance;
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            var optionsBuilder = base.AddOptions(builder);
+
+            new MySqlDbContextOptionsBuilder(optionsBuilder)
+                .EnableIndexOptimizedBooleanColumns(true);
+
+            return optionsBuilder;
+        }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlFixture.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlFixture.cs
@@ -1,5 +1,7 @@
+using Microsoft.EntityFrameworkCore;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
@@ -7,5 +9,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
     public class GearsOfWarQueryMySqlFixture : GearsOfWarQueryRelationalFixture
     {
         protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.Instance;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder.Entity<Weapon>().HasIndex(e => e.IsAutomatic);
+        }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.MySql.cs
@@ -1,0 +1,152 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
+using Xunit;
+
+// ReSharper disable RedundantBoolCompare
+// ReSharper disable NegativeEqualityExpression
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
+{
+    public partial class GearsOfWarQueryMySqlTest
+    {
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_bool_optimization(bool isAsync)
+        {
+            // Relates to MySqlBoolOptimizingExpressionVisitor.
+            await AssertQuery(
+                isAsync,
+                ss => from w in ss.Set<Weapon>()
+                    where w.IsAutomatic
+                    select w.Name);
+
+            AssertSql(
+                @"SELECT `w`.`Name`
+FROM `Weapons` AS `w`
+WHERE `w`.`IsAutomatic` <> FALSE");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_bool_optimization_not(bool isAsync)
+        {
+            // Relates to MySqlBoolOptimizingExpressionVisitor.
+            await AssertQuery(
+                isAsync,
+                ss => from w in ss.Set<Weapon>()
+                    where !w.IsAutomatic
+                    select w.Name);
+
+            AssertSql(
+                @"SELECT `w`.`Name`
+FROM `Weapons` AS `w`
+WHERE NOT (`w`.`IsAutomatic`)");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_bool_optimization_equals_true(bool isAsync)
+        {
+            // Relates to MySqlBoolOptimizingExpressionVisitor.
+            await AssertQuery(
+                isAsync,
+                ss => from w in ss.Set<Weapon>()
+                    where w.IsAutomatic == true
+                    select w.Name);
+
+            AssertSql(
+                @"SELECT `w`.`Name`
+FROM `Weapons` AS `w`
+WHERE `w`.`IsAutomatic` = TRUE");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_bool_optimization_equals_false(bool isAsync)
+        {
+            // Relates to MySqlBoolOptimizingExpressionVisitor.
+            await AssertQuery(
+                isAsync,
+                ss => from w in ss.Set<Weapon>()
+                    where w.IsAutomatic == false
+                    select w.Name);
+
+            AssertSql(
+                @"SELECT `w`.`Name`
+FROM `Weapons` AS `w`
+WHERE `w`.`IsAutomatic` = FALSE");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_bool_optimization_not_equals_true(bool isAsync)
+        {
+            // Relates to MySqlBoolOptimizingExpressionVisitor.
+            await AssertQuery(
+                isAsync,
+                ss => from w in ss.Set<Weapon>()
+                    where w.IsAutomatic != true
+                    select w.Name);
+
+            AssertSql(
+                @"SELECT `w`.`Name`
+FROM `Weapons` AS `w`
+WHERE `w`.`IsAutomatic` <> TRUE");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_bool_optimization_not_equals_false(bool isAsync)
+        {
+            // Relates to MySqlBoolOptimizingExpressionVisitor.
+            await AssertQuery(
+                isAsync,
+                ss => from w in ss.Set<Weapon>()
+                    where w.IsAutomatic != false
+                    select w.Name);
+
+            AssertSql(
+                @"SELECT `w`.`Name`
+FROM `Weapons` AS `w`
+WHERE `w`.`IsAutomatic` <> FALSE");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_bool_optimization_not_parenthesis_equals_true(bool isAsync)
+        {
+            // Relates to MySqlBoolOptimizingExpressionVisitor.
+            await AssertQuery(
+                isAsync,
+                ss => from w in ss.Set<Weapon>()
+                    where !(w.IsAutomatic == true)
+                    select w.Name);
+
+            AssertSql(
+                @"SELECT `w`.`Name`
+FROM `Weapons` AS `w`
+WHERE `w`.`IsAutomatic` <> TRUE");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_bool_optimization_not_parenthesis_equals_false(bool isAsync)
+        {
+            // Relates to MySqlBoolOptimizingExpressionVisitor.
+            await AssertQuery(
+                isAsync,
+                ss => from w in ss.Set<Weapon>()
+                    where !(w.IsAutomatic == false)
+                    select w.Name);
+
+            AssertSql(
+                @"SELECT `w`.`Name`
+FROM `Weapons` AS `w`
+WHERE `w`.`IsAutomatic` <> FALSE");
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.MySql.cs
@@ -70,7 +70,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 
             AssertSingleStatementWithKeyUsage(@"SELECT `w`.`Name`
 FROM `Weapons` AS `w`
-WHERE `w`.`IsAutomatic` <> FALSE",
+WHERE `w`.`IsAutomatic` = TRUE",
                 "IX_Weapons_IsAutomatic");
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.MySql.cs
@@ -88,7 +88,7 @@ WHERE `w`.`IsAutomatic` <> FALSE",
             AssertSingleStatementWithKeyUsage(
                 @"SELECT `w`.`Name`
 FROM `Weapons` AS `w`
-WHERE NOT (`w`.`IsAutomatic`)",
+WHERE `w`.`IsAutomatic` = FALSE",
                 "IX_Weapons_IsAutomatic");
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -16,7 +15,7 @@ using Xunit.Abstractions;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 {
-    public class GearsOfWarQueryMySqlTest : GearsOfWarQueryTestBase<GearsOfWarQueryMySqlFixture>
+    public partial class GearsOfWarQueryMySqlTest : GearsOfWarQueryTestBase<GearsOfWarQueryMySqlFixture>
     {
         private readonly MySqlTypeMappingSource _typeMappingSource;
 


### PR DESCRIPTION
Optimizes bool translations in a way, that is backwards compatible, yet still uses available indices.
Adds additional tests to ensure expected translations.

This optimization can be controlled with the new `EnableIndexOptimizedBooleanColumns` option, that needs to be explicitly enabled for Pomelo/EF Core < `5.0.0`, but will be implicitly enabled from `5.0.0` onward, and will then be a **breaking change**.

If `EnableIndexOptimizedBooleanColumns` is set to `true`, then `.Where(e => e.BoolColumn)` matches only to `1` (instead of any value except `0`).

This does not matter for `bit(1)` columns, because these can only contain the values `0` or `1` anyway.

If `tinyint(1)` is mapped to `System.Boolean` (default) however, the column could contain other values than `0` or `1`.

Other optimization implementations failed due to at least one non-indexable case for a currently supported database version.

Addresses https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1104#issuecomment-645018703