### PR TITLE
Generate SRID restricted columns not just for GEOMETRY, but also for GEOMETRY derived types

### DIFF
--- a/src/EFCore.MySql.NTS/Storage/Internal/MySqlNetTopologySuiteTypeMappingSourcePlugin.cs
+++ b/src/EFCore.MySql.NTS/Storage/Internal/MySqlNetTopologySuiteTypeMappingSourcePlugin.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/test/EFCore.MySql.FunctionalTests/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.MySql.cs
@@ -83,6 +83,34 @@ ALTER TABLE `Cars` ADD CONSTRAINT `FK_Cars_LicensePlates_LicensePlateNumber` FOR
                 ignoreLineEndingDifferences: true);
         }
 
+        [ConditionalFact]
+        public virtual void CreateTable_uses_srid_geometry_derived()
+        {
+            Generate(
+                new CreateTableOperation
+                {
+                    Name = "IceCreamShops",
+                    Columns =
+                    {
+                        new AddColumnOperation
+                        {
+                            Name = "Location",
+                            ClrType = typeof(Point),
+                            ColumnType = "POINT",
+                            [MySqlAnnotationNames.SpatialReferenceSystemId] = 4326,
+                        }
+                    }
+                });
+
+            Assert.Equal(
+                @"CREATE TABLE `IceCreamShops` (
+    `Location` POINT NOT NULL /*!80003 SRID 4326 */
+);
+",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
         private static void SetupModel(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Car>(entity =>


### PR DESCRIPTION
This PR fixes the issue, that SRID restricted columns were only generated for `geometry` columns, and not its derived store types (like `point` etc).

