### PR TITLE
Fix CURRENT_TIMESTAMP discovery for MariaDB and for columns with precision when scaffolding

### DIFF
--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -380,10 +380,11 @@ ORDER BY
                 return null;
             }
 
-            // Pending the MySqlConnector implement MySqlCommandBuilder class
+            // MySQL uses `CURRENT_TIMESTAMP` (or `CURRENT_TIMESTAMP(6)`),
+            // while MariaDB uses `current_timestamp()` (or `current_timestamp(6)`).
             if ((string.Equals(dataType, "timestamp", StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(dataType, "datetime", StringComparison.OrdinalIgnoreCase)) &&
-                string.Equals(defaultValue, "CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase))
+                Regex.IsMatch(defaultValue, @"^CURRENT_TIMESTAMP(?:\(\d*\))?$", RegexOptions.IgnoreCase))
             {
                 return defaultValue;
             }


### PR DESCRIPTION
Fixes https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/171#issuecomment-657258642