### PR TITLE
Add byte[], decimal, double and float data type support to HEX() client-side handling

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
@@ -570,6 +570,8 @@ namespace Microsoft.EntityFrameworkCore
                 return null;
             }
 
+            var bytes = value as byte[];
+
             if (value is string stringValue)
             {
                 if (stringValue == string.Empty)
@@ -577,7 +579,16 @@ namespace Microsoft.EntityFrameworkCore
                     return string.Empty;
                 }
 
-                var bytes = Encoding.UTF8.GetBytes(stringValue);
+                bytes = Encoding.UTF8.GetBytes(stringValue);
+            }
+
+            if (bytes != null)
+            {
+                if (bytes.Length <= 0)
+                {
+                    return string.Empty;
+                }
+
                 var sb = new StringBuilder(bytes.Length * 2);
                 var lastCharIndex = bytes.Length - 1;
 
@@ -592,7 +603,12 @@ namespace Microsoft.EntityFrameworkCore
                 return sb.ToString();
             }
 
-            if (typeof(T).IsInteger() &&
+            var type = typeof(T).UnwrapNullableType();
+
+            if ((type.IsInteger() ||
+                 type == typeof(decimal) ||
+                 type == typeof(double) ||
+                 type == typeof(float)) &&
                 value is IConvertible convertible)
             {
                 return convertible


### PR DESCRIPTION
Fixes usage of `byte[]` (and other types) in cases where the expression is not translated into SQL but executed client side.

Fixes https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1119#issuecomment-657281275

The following does work now:

```c#
using System;
using System.Collections;
using System.Collections.Generic;
using System.Diagnostics;
using System.Linq;
using System.Text;
using Microsoft.EntityFrameworkCore;
using Microsoft.Extensions.Logging;

namespace IssueConsoleTemplate
{
    public class Container
    {
        public int ContainerId { get; set; }
        public string Name { get; set; }
        
        public ICollection<File> Files { get; set; } = new HashSet<File>();
    }

    public class File
    {
        public int FileId { get; set; }
        public string Name { get; set; }
        public byte[] Hash { get; set; }
        public int ContainerId { get; set; }
        
        public Container Container { get; set; }
    }
    
    public class Context : DbContext
    {
        public DbSet<Container> Containers { get; set; }
        public DbSet<File> Files { get; set; }

        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
        {
            optionsBuilder
                .UseMySql(
                    "server=127.0.0.1;port=3306;user=root;password=;database=Issue1119",
                    b => b.ServerVersion("8.0.20-mysql"))
                .UseLoggerFactory(
                    LoggerFactory.Create(
                        b => b
                            .AddConsole()
                            .AddFilter(level => level >= LogLevel.Information)))
                .EnableSensitiveDataLogging()
                .EnableDetailedErrors();
        }

        protected override void OnModelCreating(ModelBuilder modelBuilder)
        {
            modelBuilder.Entity<Container>()
                .HasData(
                    new Container
                    {
                        ContainerId = 1,
                        Name = "Folder",
                    });
            
            modelBuilder.Entity<File>()
                .HasData(
                    new File
                    {
                        FileId = 1,
                        Name = "File.ext",
                        Hash = Encoding.UTF8.GetBytes("The answer to the ultimate question"),
                        ContainerId = 1,
                    });
        }
    }

    internal static class Program
    {
        private static void Main()
        {
            using var context = new Context();

            context.Database.EnsureDeleted();
            context.Database.EnsureCreated();

            var hash = Encoding.UTF8.GetBytes("The answer to the ultimate question");

            var containers = context.Containers
                .Include(c => c.Files)
                .Where(c => c.Files.Select(f => EF.Functions.Hex(f.Hash)).Contains(EF.Functions.Hex(hash)))
                .ToList();
            
            Debug.Assert(containers.Count == 1);
            Debug.Assert(containers[0].Files.Count == 1);
            Debug.Assert(containers[0].Files.First().Hash.SequenceEqual(hash));
        }
    }
}
```