### PR TITLE
Use case-insensitive comparison on table names when scaffolding foreign key constraints [copy of original 1017]

### DIFF
--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -568,7 +568,7 @@ ORDER BY
                         while (reader.Read())
                         {
                             var referencedTableName = reader.GetString(2);
-                            var referencedTable = tables.FirstOrDefault(t => t.Name == referencedTableName);
+                            var referencedTable = tables.FirstOrDefault(t => string.Equals(t.Name, referencedTableName, StringComparison.OrdinalIgnoreCase));
                             if (referencedTable != null)
                             {
                                 var fkInfo = new DatabaseForeignKey {Name = reader.GetString(0), OnDelete = ConvertToReferentialAction(reader.GetString(4)), Table = table, PrincipalTable = referencedTable};

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -568,7 +568,13 @@ ORDER BY
                         while (reader.Read())
                         {
                             var referencedTableName = reader.GetString(2);
-                            var referencedTable = tables.FirstOrDefault(t => string.Equals(t.Name, referencedTableName, StringComparison.OrdinalIgnoreCase));
+                            var referencedTable = tables.FirstOrDefault(t => t.Name == referencedTableName);
+                            if (referencedTable == null)
+                            {
+                                // if the casing of the constraint doesn't match the casing of the table name, try and find a matching table with a
+                                // different case, but ensure that there's only one possible match or we can't be certain which is the right table.
+                                referencedTable = tables.SingleOrDefault(t => string.Equals(t.Name, referencedTableName, StringComparison.OrdinalIgnoreCase));
+                            }
                             if (referencedTable != null)
                             {
                                 var fkInfo = new DatabaseForeignKey {Name = reader.GetString(0), OnDelete = ConvertToReferentialAction(reader.GetString(4)), Table = table, PrincipalTable = referencedTable};

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -571,9 +571,11 @@ ORDER BY
                             var referencedTable = tables.FirstOrDefault(t => t.Name == referencedTableName);
                             if (referencedTable == null)
                             {
-                                // if the casing of the constraint doesn't match the casing of the table name, try and find a matching table with a
-                                // different case, but ensure that there's only one possible match or we can't be certain which is the right table.
-                                referencedTable = tables.SingleOrDefault(t => string.Equals(t.Name, referencedTableName, StringComparison.OrdinalIgnoreCase));
+                                // On operation systems with insensitive file name handling, the saved reference table name might have a
+                                // different casing than the actual table name. (#1017)
+                                // In the unlikely event that there are multiple tables with the same spelling, differing only in casing,
+                                // we can't be certain which is the right match, so rather fail to be safe.
+                                referencedTable = tables.Single(t => string.Equals(t.Name, referencedTableName, StringComparison.OrdinalIgnoreCase));
                             }
                             if (referencedTable != null)
                             {

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -877,10 +877,10 @@ DROP TABLE DependentTable;
 DROP TABLE PrincipalTable;");
         }
 
-        // Important: the inconsistent casing of the referenced table name is intentional. Do not change.
         [Fact]
         public void Ensure_constraints_scaffold_with_case_mismatch()
         {
+            // Important: the inconsistent casing of the referenced table name is intentional. Do not change.
             Test(
                 @"
 CREATE TABLE `PrincipalTable` (
@@ -906,7 +906,6 @@ CREATE TABLE `DependentTable` (
                     Assert.NotNull(dependent);
 
                     Assert.Contains(dependent.ForeignKeys, t => t.PrincipalTable.Name == principal.Name);
-                    Assert.True(true);
                 },
                 @"
 DROP TABLE DependentTable;

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -877,6 +877,42 @@ DROP TABLE DependentTable;
 DROP TABLE PrincipalTable;");
         }
 
+        // Important: the inconsistent casing of the referenced table name is intentional. Do not change.
+        [Fact]
+        public void Ensure_constraints_scaffold_with_case_mismatch()
+        {
+            Test(
+                @"
+CREATE TABLE `PrincipalTable` (
+  `Id` INT NOT NULL,
+  PRIMARY KEY (`Id`));
+
+CREATE TABLE `DependentTable` (
+  `Id` INT NOT NULL,
+  `ForeignKeyId` INT NOT NULL,
+  PRIMARY KEY (`Id`),
+  CONSTRAINT `ForeignKey_Id`
+    FOREIGN KEY (`ForeignKeyId`)
+    REFERENCES `principaltable` (`Id`)
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var principal = dbModel.Tables.FirstOrDefault(t => t.Name == "PrincipalTable");
+                    var dependent = dbModel.Tables.FirstOrDefault(t => t.Name == "DependentTable");
+
+                    Assert.NotNull(principal);
+                    Assert.NotNull(dependent);
+
+                    Assert.Contains(dependent.ForeignKeys, t => t.PrincipalTable.Name == principal.Name);
+                    Assert.True(true);
+                },
+                @"
+DROP TABLE DependentTable;
+DROP TABLE PrincipalTable;"
+                );
+        }
         #endregion
 
         #region Warnings

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -880,27 +880,33 @@ DROP TABLE PrincipalTable;");
         [Fact]
         public void Ensure_constraints_scaffold_with_case_mismatch()
         {
-            // Important: the inconsistent casing of the referenced table name is intentional. Do not change.
+            // The lower case table reference to a mixed cased table will only be accepted under certain conditions
+            // (lower_case_table_names <> 0).
             Test(
                 @"
 CREATE TABLE `PrincipalTable` (
   `Id` INT NOT NULL,
   PRIMARY KEY (`Id`));
 
+set @sql = concat('
 CREATE TABLE `DependentTable` (
   `Id` INT NOT NULL,
   `ForeignKeyId` INT NOT NULL,
   PRIMARY KEY (`Id`),
   CONSTRAINT `ForeignKey_Id`
     FOREIGN KEY (`ForeignKeyId`)
-    REFERENCES `principaltable` (`Id`)
-);",
+    REFERENCES `', IF(@@lower_case_table_names <> 0, LOWER('PrincipalTable'), 'PrincipalTable'), '` (`Id`)
+)');
+
+PREPARE dynamic_statement FROM @sql;
+EXECUTE dynamic_statement;
+DEALLOCATE PREPARE dynamic_statement;",
                 Enumerable.Empty<string>(),
                 Enumerable.Empty<string>(),
                 dbModel =>
                 {
-                    var principal = dbModel.Tables.FirstOrDefault(t => t.Name == "PrincipalTable");
-                    var dependent = dbModel.Tables.FirstOrDefault(t => t.Name == "DependentTable");
+                    var principal = dbModel.Tables.FirstOrDefault(t => string.Equals(t.Name, "PrincipalTable", StringComparison.OrdinalIgnoreCase));
+                    var dependent = dbModel.Tables.FirstOrDefault(t => string.Equals(t.Name, "DependentTable", StringComparison.OrdinalIgnoreCase));
 
                     Assert.NotNull(principal);
                     Assert.NotNull(dependent);
@@ -910,8 +916,9 @@ CREATE TABLE `DependentTable` (
                 @"
 DROP TABLE DependentTable;
 DROP TABLE PrincipalTable;"
-                );
+            );
         }
+
         #endregion
 
         #region Warnings


### PR DESCRIPTION
Since it looks like @dhirensham abandoned #1017 and we currently have a related [question](https://stackoverflow.com/questions/63440367/referenced-table-is-not-in-dictionary/63448835) on StackOverflow, I took the liberty to apply the requested changes myself.

Because the [original PR](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1017) did not `allow edits be maintainers`, I had to duplicate it.