### PR TITLE
Fix and extend spatial support

### DIFF
--- a/src/EFCore.MySql.NTS/Extensions/MySqlSpatialDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql.NTS/Extensions/MySqlSpatialDbFunctionsExtensions.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using JetBrains.Annotations;
+using NetTopologySuite.Geometries;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Used to specify one of multiple spherical distance algorithms.
+    /// </summary>
+    public enum SpatialDistanceAlgorithm
+    {
+        /// <summary>
+        /// Uses the native server implementation of the `ST_Distance_Sphere()` function.
+        /// If the function is not implemented, the `Andoyer` algorithm is used as a fallback.
+        /// </summary>
+        Native,
+        /// <summary>
+        /// For MySQL, uses the native server implementation of the `ST_Distance()` function, which already
+        /// implements the Andoyer algorithm when used with SRID 4326.
+        /// If the function is not implemented, a custom implementation of the `Andoyer` algorithm is used.
+        /// </summary>
+        Andoyer,
+        /// <summary>
+        /// Uses a custom implementation of the `Haversine` algorithm.
+        /// </summary>
+        Haversine,
+    }
+
+    /// <summary>
+    ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
+    ///     The methods on this class are accessed via <see cref="EF.Functions" />.
+    /// </summary>
+    public static class MySqlSpatialDbFunctionsExtensions
+    {
+        /// <summary>
+        ///     Returns the distance between g1 and g2, measured in the length unit of the spatial reference system
+        ///     (SRS) of the geometry arguments.
+        ///     For MySQL 8, this is equivalent of calling ST_Distance() when using an SRID of `0`.
+        ///     For MySQL &lt; 8 and MariaDB, this is equivalent of calling ST_Distance() with any SRID.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="g1">First geometry argument.</param>
+        /// <param name="g2">Second geometry argument.</param>
+        /// <returns>Distance betweeen g1 and g2.</returns>
+        public static double SpatialDistancePlanar(
+            [CanBeNull] this DbFunctions _,
+            Geometry g1,
+            Geometry g2)
+        {
+            throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(SpatialDistancePlanar)));
+        }
+
+        /// <summary>
+        ///     Returns the mimimum spherical distance between Point or MultiPoint arguments on a sphere in meters,
+        ///     by using the specified algorithm.
+        ///     It is assumed that `g1` and `g2` are associated with an SRID of `4326`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="g1">First geometry argument.</param>
+        /// <param name="g2">Second geometry argument.</param>
+        /// <param name="algorithm">The algorithm to use. Must be directly supplied as a constant.</param>
+        /// <returns>Distance betweeen g1 and g2.</returns>
+        public static double SpatialDistanceSphere(
+            [CanBeNull] this DbFunctions _,
+            Geometry g1,
+            Geometry g2,
+            SpatialDistanceAlgorithm algorithm)
+        {
+            throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(SpatialDistanceSphere)));
+        }
+    }
+}

--- a/src/EFCore.MySql.NTS/Query/ExpressionTranslators/Internal/MySqlDbFunctionsExtensionsMethodTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/ExpressionTranslators/Internal/MySqlDbFunctionsExtensionsMethodTranslator.cs
@@ -1,0 +1,566 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using NetTopologySuite.Geometries;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class MySqlSpatialDbFunctionsExtensionsMethodTranslator : IMethodCallTranslator
+    {
+        private readonly IMySqlOptions _options;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
+
+        private static readonly MethodInfo _spatialDistancePlanarMethodInfo = typeof(MySqlSpatialDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlSpatialDbFunctionsExtensions.SpatialDistancePlanar), new[] {typeof(DbFunctions), typeof(Geometry), typeof(Geometry)});
+        private static readonly MethodInfo _spatialDistanceSphere = typeof(MySqlSpatialDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlSpatialDbFunctionsExtensions.SpatialDistanceSphere), new[] {typeof(DbFunctions), typeof(Geometry), typeof(Geometry), typeof(SpatialDistanceAlgorithm)});
+
+        public MySqlSpatialDbFunctionsExtensionsMethodTranslator(
+            ISqlExpressionFactory sqlExpressionFactory,
+            IMySqlOptions options)
+        {
+            _sqlExpressionFactory = (MySqlSqlExpressionFactory)sqlExpressionFactory;
+            _options = options;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+            if (Equals(method, _spatialDistancePlanarMethodInfo))
+            {
+                // MySQL 8 uses the Andoyer algorithm by default for `ST_Distance()`, if an SRID of 4326 has been
+                // associated with the geometry.
+                // Since this call explicitly asked for a planar distance calculation, we need to ensure that
+                // MySQL actually does that.
+                // MariaDB ignores SRIDs and always calculates the planar distance.
+                // CHECK: It could be faster to just manually apply the Pythagoras Theorem instead of changing the
+                //        SRID in the case where ST_SRID() does not support a second parameter yet (see
+                //        SetSrid()).
+                if (_options.ServerVersion.SupportsSpatialSupportFunctionAdditions &&
+                    _options.ServerVersion.SupportsSpatialDistanceFunctionImplementsAndoyer)
+                {
+                    return _sqlExpressionFactory.Case(
+                        new[]
+                        {
+                            new CaseWhenClause(
+                                _sqlExpressionFactory.Equal(
+                                    _sqlExpressionFactory.Function(
+                                        "ST_SRID",
+                                        new[] {arguments[1]},
+                                        typeof(int)),
+                                    _sqlExpressionFactory.Constant(0)),
+                                GetStDistanceFunctionCall(
+                                    arguments[1],
+                                    arguments[2],
+                                    method.ReturnType,
+                                    _sqlExpressionFactory.FindMapping(method.ReturnType),
+                                    _sqlExpressionFactory))
+                        },
+                        GetStDistanceFunctionCall(
+                            SetSrid(arguments[1], 0, _sqlExpressionFactory, _options),
+                            SetSrid(arguments[2], 0, _sqlExpressionFactory, _options),
+                            method.ReturnType,
+                            _sqlExpressionFactory.FindMapping(method.ReturnType),
+                            _sqlExpressionFactory));
+                }
+
+                return GetStDistanceFunctionCall(
+                    arguments[1],
+                    arguments[2],
+                    method.ReturnType,
+                    _sqlExpressionFactory.FindMapping(method.ReturnType),
+                    _sqlExpressionFactory);
+            }
+
+            if (Equals(method, _spatialDistanceSphere))
+            {
+                if (!(arguments[3] is SqlConstantExpression algorithm))
+                {
+                    throw new InvalidOperationException("The 'algorithm' parameter must be supplied as a constant.");
+                }
+
+                return GetStDistanceSphereFunctionCall(
+                    arguments[1],
+                    arguments[2],
+                    (SpatialDistanceAlgorithm)algorithm.Value,
+                    method.ReturnType,
+                    _sqlExpressionFactory.FindMapping(method.ReturnType),
+                    _sqlExpressionFactory,
+                    _options);
+            }
+
+            return null;
+        }
+
+        private static SqlFunctionExpression SetSrid(
+            SqlExpression geometry,
+            int srid,
+            ISqlExpressionFactory sqlExpressionFactory,
+            IMySqlOptions options)
+            => options.ServerVersion.SupportsSpatialSetSridFunction
+                ? sqlExpressionFactory.Function(
+                    "ST_SRID",
+                    new[]
+                    {
+                        geometry,
+                        sqlExpressionFactory.Constant(srid)
+                    },
+                    typeof(int))
+                : sqlExpressionFactory.Function(
+                    "ST_GeomFromWKB",
+                    new SqlExpression[]
+                    {
+                        sqlExpressionFactory.Function(
+                            "ST_AsBinary",
+                            new[] {geometry},
+                            typeof(byte[])),
+                        sqlExpressionFactory.Constant(srid)
+                    },
+                    geometry.Type);
+
+        public static SqlExpression GetStDistanceFunctionCall(
+            SqlExpression left,
+            SqlExpression right,
+            Type resultType,
+            RelationalTypeMapping resultTypeMapping,
+            ISqlExpressionFactory sqlExpressionFactory)
+        {
+            return sqlExpressionFactory.Function(
+                "ST_Distance",
+                new[] {left, right},
+                resultType,
+                resultTypeMapping);
+        }
+
+        public static SqlExpression GetStDistanceSphereFunctionCall(
+            SqlExpression left,
+            SqlExpression right,
+            SpatialDistanceAlgorithm algorithm,
+            Type resultType,
+            RelationalTypeMapping resultTypeMapping,
+            ISqlExpressionFactory sqlExpressionFactory,
+            IMySqlOptions options)
+        {
+            if (options.ServerVersion.SupportsSpatialDistanceSphereFunction)
+            {
+                if (algorithm == SpatialDistanceAlgorithm.Native)
+                {
+                    return sqlExpressionFactory.Function(
+                        "ST_Distance_Sphere",
+                        new[] {left, right},
+                        resultType,
+                        resultTypeMapping);
+                }
+
+                if (algorithm == SpatialDistanceAlgorithm.Andoyer &&
+                    options.ServerVersion.SupportsSpatialDistanceFunctionImplementsAndoyer)
+                {
+                    // The `ST_Distance()` in MySQL already uses the Andoyer algorithm, when SRID 4326 is associated
+                    // with the geometry.
+                    // CHECK: It might be faster to just run the custom implementation, if `ST_SRID()` does not support
+                    //        a second parameter yet (see SetSrid()).
+                    return sqlExpressionFactory.Case(
+                        new[]
+                        {
+                            new CaseWhenClause(
+                                sqlExpressionFactory.Equal(
+                                    sqlExpressionFactory.Function(
+                                        "ST_SRID",
+                                        new[] {left},
+                                        typeof(int)),
+                                    sqlExpressionFactory.Constant(4326)),
+                                GetStDistanceFunctionCall(
+                                    left,
+                                    right,
+                                    resultType,
+                                    resultTypeMapping,
+                                    sqlExpressionFactory))
+                        },
+                        GetStDistanceFunctionCall(
+                            SetSrid(left, 4326, sqlExpressionFactory, options),
+                            SetSrid(right, 4326, sqlExpressionFactory, options),
+                            resultType,
+                            resultTypeMapping,
+                            sqlExpressionFactory));
+                }
+
+                if (algorithm == SpatialDistanceAlgorithm.Haversine)
+                {
+                    // The Haversine algorithm assumes planar coordinates.
+                    return sqlExpressionFactory.Case(
+                        new[]
+                        {
+                            new CaseWhenClause(
+                                sqlExpressionFactory.Equal(
+                                    sqlExpressionFactory.Function(
+                                        "ST_SRID",
+                                        new[] {left},
+                                        typeof(int)),
+                                    sqlExpressionFactory.Constant(0)),
+                                GetHaversineDistance(
+                                    left,
+                                    right,
+                                    resultType,
+                                    sqlExpressionFactory))
+                        },
+                        GetHaversineDistance(
+                            SetSrid(left, 0, sqlExpressionFactory, options),
+                            SetSrid(right, 0, sqlExpressionFactory, options),
+                            resultType,
+                            sqlExpressionFactory));
+                }
+            }
+
+            if (algorithm == SpatialDistanceAlgorithm.Haversine)
+            {
+                return GetHaversineDistance(left, right, resultType, sqlExpressionFactory);
+            }
+
+            return GetAndoyerDistance(left, right, resultType, sqlExpressionFactory);
+        }
+
+        private static SqlExpression GetHaversineDistance(
+            SqlExpression left,
+            SqlExpression right,
+            Type resultType,
+            ISqlExpressionFactory sqlExpressionFactory)
+        {
+            // HAVERSINE = 6371000 * 2 * ASIN(
+            //     SQRT(
+            //         POWER(SIN((ST_Y(pt2) - ST_Y(pt1)) * pi()/180 / 2), 2) +
+            //         COS(ST_Y(pt1) * pi()/180) *
+            //         COS(ST_Y(pt2) * pi()/180) *
+            //         POWER(SIN((ST_X(pt2) - ST_X(pt1)) * pi()/180 / 2), 2)
+            //     )
+            // )
+
+            return sqlExpressionFactory.Multiply(
+                sqlExpressionFactory.Constant(6370986.0), // see https://postgis.net/docs/manual-1.4/ST_Distance_Sphere.html
+                sqlExpressionFactory.Multiply(
+                    sqlExpressionFactory.Constant(2.0),
+                    sqlExpressionFactory.Function(
+                        "ASIN",
+                        new[]
+                        {
+                            sqlExpressionFactory.Function(
+                                "SQRT",
+                                new[]
+                                {
+                                    sqlExpressionFactory.Add(
+                                        sqlExpressionFactory.Function(
+                                            "POWER",
+                                            new SqlExpression[]
+                                            {
+                                                sqlExpressionFactory.Function(
+                                                    "SIN",
+                                                    new[]
+                                                    {
+                                                        sqlExpressionFactory.Divide(
+                                                            sqlExpressionFactory.Divide(
+                                                                sqlExpressionFactory.Multiply(
+                                                                    sqlExpressionFactory.Subtract(
+                                                                        sqlExpressionFactory.Function(
+                                                                            "ST_Y",
+                                                                            new[] {right},
+                                                                            resultType),
+                                                                        sqlExpressionFactory.Function(
+                                                                            "ST_Y",
+                                                                            new[] {left},
+                                                                            resultType)),
+                                                                    sqlExpressionFactory.Function(
+                                                                        "PI",
+                                                                        Array.Empty<SqlExpression>(),
+                                                                        resultType)),
+                                                                sqlExpressionFactory.Constant(180.0)),
+                                                            sqlExpressionFactory.Constant(2.0))
+                                                    },
+                                                    resultType),
+                                                sqlExpressionFactory.Constant(2),
+                                            },
+                                            resultType),
+                                        sqlExpressionFactory.Multiply(
+                                            sqlExpressionFactory.Function(
+                                                "COS",
+                                                new[]
+                                                {
+                                                    sqlExpressionFactory.Divide(
+                                                        sqlExpressionFactory.Multiply(
+                                                            sqlExpressionFactory.Function(
+                                                                "ST_Y",
+                                                                new[] {left},
+                                                                resultType),
+                                                            sqlExpressionFactory.Function(
+                                                                "PI",
+                                                                Array.Empty<SqlExpression>(),
+                                                                resultType)),
+                                                        sqlExpressionFactory.Constant(180.0)),
+                                                },
+                                                resultType),
+                                            sqlExpressionFactory.Multiply(
+                                                sqlExpressionFactory.Function(
+                                                    "COS",
+                                                    new[]
+                                                    {
+                                                        sqlExpressionFactory.Divide(
+                                                            sqlExpressionFactory.Multiply(
+                                                                sqlExpressionFactory.Function(
+                                                                    "ST_Y",
+                                                                    new[] {right},
+                                                                    resultType),
+                                                                sqlExpressionFactory.Function(
+                                                                    "PI",
+                                                                    Array.Empty<SqlExpression>(),
+                                                                    resultType)),
+                                                            sqlExpressionFactory.Constant(180.0)),
+                                                    },
+                                                    resultType),
+                                                sqlExpressionFactory.Function(
+                                                    "POWER",
+                                                    new SqlExpression[]
+                                                    {
+                                                        sqlExpressionFactory.Function(
+                                                            "SIN",
+                                                            new[]
+                                                            {
+                                                                sqlExpressionFactory.Divide(
+                                                                    sqlExpressionFactory.Divide(
+                                                                        sqlExpressionFactory.Multiply(
+                                                                            sqlExpressionFactory.Subtract(
+                                                                                sqlExpressionFactory.Function(
+                                                                                    "ST_X",
+                                                                                    new[] {right},
+                                                                                    resultType),
+                                                                                sqlExpressionFactory.Function(
+                                                                                    "ST_X",
+                                                                                    new[] {left},
+                                                                                    resultType)),
+                                                                            sqlExpressionFactory.Function(
+                                                                                "PI",
+                                                                                Array.Empty<SqlExpression>(),
+                                                                                resultType)),
+                                                                        sqlExpressionFactory.Constant(180.0)),
+                                                                    sqlExpressionFactory.Constant(2.0))
+                                                            },
+                                                            resultType),
+                                                        sqlExpressionFactory.Constant(2),
+                                                    },
+                                                    resultType))))
+                                },
+                                resultType)
+                        },
+                        resultType)));
+        }
+
+        private static SqlExpression GetAndoyerDistance(
+            SqlExpression left,
+            SqlExpression right,
+            Type resultType,
+            ISqlExpressionFactory sqlExpressionFactory)
+        {
+            SqlExpression toDegrees(SqlExpression coord)
+                => sqlExpressionFactory.Divide(
+                    sqlExpressionFactory.Multiply(
+                        coord,
+                        sqlExpressionFactory.Function(
+                            "PI",
+                            Array.Empty<SqlExpression>(),
+                            resultType)),
+                    sqlExpressionFactory.Constant(180.0));
+
+            SqlExpression xCoord(SqlExpression point)
+                => sqlExpressionFactory.Function(
+                    "ST_X",
+                    new[] {point},
+                    resultType);
+
+            SqlExpression yCoord(SqlExpression point)
+                => sqlExpressionFactory.Function(
+                    "ST_Y",
+                    new[] {point},
+                    resultType);
+
+            var c0 = sqlExpressionFactory.Constant(0.0);
+            var c1 = sqlExpressionFactory.Constant(1.0);
+            var c2 = sqlExpressionFactory.Constant(2.0);
+            var c3 = sqlExpressionFactory.Constant(3.0);
+            var c2Int = sqlExpressionFactory.Constant(2);
+
+            var lon1 = toDegrees(xCoord(left));
+            var lat1 = toDegrees(yCoord(left));
+            var lon2 = toDegrees(xCoord(right));
+            var lat2 = toDegrees(yCoord(right));
+
+            var g = sqlExpressionFactory.Divide(
+                sqlExpressionFactory.Subtract(
+                    lat1,
+                    lat2),
+                c2);
+            var lambda = sqlExpressionFactory.Divide(
+                sqlExpressionFactory.Subtract(
+                    lon1,
+                    lon2),
+                c2);
+
+            var f = sqlExpressionFactory.Divide(
+                sqlExpressionFactory.Add(
+                    lat1,
+                    lat2),
+                c2);
+
+            var sinG2 = sqlExpressionFactory.Function(
+                "POWER",
+                new SqlExpression[]
+                {
+                    sqlExpressionFactory.Function(
+                        "SIN",
+                        new[] {g},
+                        resultType),
+                    c2Int
+                },
+                resultType);
+            var cosG2 = sqlExpressionFactory.Function(
+                "POWER",
+                new SqlExpression[]
+                {
+                    sqlExpressionFactory.Function(
+                        "COS",
+                        new[] {g},
+                        resultType),
+                    c2Int
+                },
+                resultType);
+            var sinF2 = sqlExpressionFactory.Function(
+                "POWER",
+                new SqlExpression[]
+                {
+                    sqlExpressionFactory.Function(
+                        "SIN",
+                        new[] {f},
+                        resultType),
+                    c2Int
+                },
+                resultType);
+            var cosF2 = sqlExpressionFactory.Function(
+                "POWER",
+                new SqlExpression[]
+                {
+                    sqlExpressionFactory.Function(
+                        "COS",
+                        new[] {f},
+                        resultType),
+                    c2Int
+                },
+                resultType);
+            var sinL2 = sqlExpressionFactory.Function(
+                "POWER",
+                new SqlExpression[]
+                {
+                    sqlExpressionFactory.Function(
+                        "SIN",
+                        new[] {lambda},
+                        resultType),
+                    c2Int
+                },
+                resultType);
+            var cosL2 = sqlExpressionFactory.Function(
+                "POWER",
+                new SqlExpression[]
+                {
+                    sqlExpressionFactory.Function(
+                        "COS",
+                        new[] {lambda},
+                        resultType),
+                    c2Int
+                },
+                resultType);
+
+            var s = sqlExpressionFactory.Add(
+                sqlExpressionFactory.Multiply(sinG2, cosL2),
+                sqlExpressionFactory.Multiply(cosF2, sinL2));
+            var c = sqlExpressionFactory.Add(
+                sqlExpressionFactory.Multiply(cosG2, cosL2),
+                sqlExpressionFactory.Multiply(sinF2, sinL2));
+
+            var radiusA = sqlExpressionFactory.Constant(6378137.0);
+            var radiusB = sqlExpressionFactory.Constant(6356752.3142451793);
+            var flattening = sqlExpressionFactory.Divide(
+                sqlExpressionFactory.Subtract(radiusA, radiusB),
+                radiusA);
+
+            var omega = sqlExpressionFactory.Function(
+                "ATAN",
+                new[]
+                {
+                    sqlExpressionFactory.Function(
+                        "SQRT",
+                        new[] {sqlExpressionFactory.Divide(s, c)},
+                        resultType)
+                },
+                resultType);
+            var r3 = sqlExpressionFactory.Divide(
+                sqlExpressionFactory.Multiply(
+                    c3,
+                    sqlExpressionFactory.Function(
+                        "SQRT",
+                        new[] {sqlExpressionFactory.Multiply(s, c)},
+                        resultType)),
+                omega);
+            var d = sqlExpressionFactory.Multiply(
+                sqlExpressionFactory.Multiply(c2, omega),
+                radiusA);
+            var h1 = sqlExpressionFactory.Divide(
+                sqlExpressionFactory.Subtract(r3, c1),
+                sqlExpressionFactory.Multiply(c2, c));
+            var h2 = sqlExpressionFactory.Divide(
+                sqlExpressionFactory.Add(r3, c1),
+                sqlExpressionFactory.Multiply(c2, s));
+
+            var andoyer = sqlExpressionFactory.Multiply(
+                d,
+                sqlExpressionFactory.Add(
+                    c1,
+                    sqlExpressionFactory.Multiply(
+                        flattening,
+                        sqlExpressionFactory.Subtract(
+                            sqlExpressionFactory.Multiply(
+                                sqlExpressionFactory.Multiply(
+                                    h1,
+                                    sinF2),
+                                cosG2),
+                            sqlExpressionFactory.Multiply(
+                                sqlExpressionFactory.Multiply(
+                                    h2,
+                                    cosF2),
+                                sinG2)))));
+
+            return sqlExpressionFactory.Case(
+                new[]
+                {
+                    new CaseWhenClause(
+                        sqlExpressionFactory.OrElse(
+                            sqlExpressionFactory.OrElse(
+                                sqlExpressionFactory.AndAlso(
+                                    sqlExpressionFactory.Equal(lambda, c0),
+                                    sqlExpressionFactory.Equal(g, c0)),
+                                sqlExpressionFactory.Equal(s, c0)),
+                            sqlExpressionFactory.Equal(c, c0)),
+                        c0),
+                },
+                andoyer);
+        }
+    }
+}

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlNetTopologySuiteMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlNetTopologySuiteMethodCallTranslatorPlugin.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -32,14 +35,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
         /// </summary>
         public MySqlNetTopologySuiteMethodCallTranslatorPlugin(
             IRelationalTypeMappingSource typeMappingSource,
-            ISqlExpressionFactory sqlExpressionFactory)
+            ISqlExpressionFactory sqlExpressionFactory,
+            IMySqlOptions options)
         {
             Translators = new IMethodCallTranslator[]
             {
-                new MySqlGeometryMethodTranslator(typeMappingSource, sqlExpressionFactory),
+                new MySqlGeometryMethodTranslator(typeMappingSource, sqlExpressionFactory, options),
                 new MySqlGeometryCollectionMethodTranslator(typeMappingSource, sqlExpressionFactory),
                 new MySqlLineStringMethodTranslator(typeMappingSource, sqlExpressionFactory),
-                new MySqlPolygonMethodTranslator(typeMappingSource, sqlExpressionFactory)
+                new MySqlPolygonMethodTranslator(typeMappingSource, sqlExpressionFactory),
+                new MySqlSpatialDbFunctionsExtensionsMethodTranslator(sqlExpressionFactory, options)
             };
         }
 

--- a/src/EFCore.MySql.NTS/Storage/Internal/MySqlGeographyWktWriter.cs
+++ b/src/EFCore.MySql.NTS/Storage/Internal/MySqlGeographyWktWriter.cs
@@ -1,0 +1,951 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NetTopologySuite.Utilities;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
+{
+    /// <summary>
+    /// MySQL specific implementation of WKTWriter.
+    /// It swaps the X/Y coordinates, because if geography data is used (SRID 4326), MySQL uses the order (lat, lon)
+    /// instead of (lon, lat).
+    /// </summary>
+    public class MySqlGeographyWktWriter
+    {
+        /// <summary>
+        /// Generates the WKT for a <c>Point</c> specified by a <see cref="Coordinate"/>.
+        /// </summary>
+        /// <param name="p0">The point coordinate.</param>
+        /// <returns>The WKT</returns>
+        public static string ToPoint(Coordinate p0)
+        {
+            // legacy note: JTS's version never checks Z or M, so the things that call this aren't
+            // expecting to see them.  the "actual" code to write points handles Z / M just fine.
+            return $"POINT ({Format(p0)})";
+        }
+
+        /// <summary>
+        /// Generates the WKT for a N-point <c>LineString</c> specified by a <see cref="CoordinateSequence"/>.
+        /// </summary>
+        /// <param name="seq">The sequence to write.</param>
+        /// <returns>The WKT</returns>
+        public static string ToLineString(CoordinateSequence seq)
+        {
+            // legacy note: JTS's version never checks Z or M, so the things that call this aren't
+            // expecting to see them.  the "actual" code to write lines handles Z / M just fine.
+            var buf = new StringBuilder();
+            buf.Append("LINESTRING");
+            if (seq.Count == 0)
+                buf.Append(" EMPTY");
+            else
+            {
+                buf.Append("(");
+                for (int i = 0; i < seq.Count; i++)
+                {
+                    if (i > 0)
+                        buf.Append(", ");
+                    buf.Append(Format(seq.GetX(i), seq.GetY(i)));
+                }
+                buf.Append(")");
+            }
+            return buf.ToString();
+        }
+
+        /**
+         * Generates the WKT for a <tt>LINESTRING</tt>
+         * specified by a {@link CoordinateSequence}.
+         *
+         * @param seq the sequence to write
+         *
+         * @return the WKT string
+         */
+        public static string ToLineString(Coordinate[] coord)
+        {
+            // legacy note: JTS's version never checks Z or M, so the things that call this aren't
+            // expecting to see them.  the "actual" code to write lines handles Z / M just fine.
+            var buf = new StringBuilder();
+            buf.Append("LINESTRING ");
+            if (coord.Length == 0)
+                buf.Append(" EMPTY");
+            else
+            {
+                buf.Append("(");
+                for (int i = 0; i < coord.Length; i++)
+                {
+                    if (i > 0)
+                        buf.Append(", ");
+                    buf.Append(Format(coord[i]));
+                }
+                buf.Append(")");
+            }
+            return buf.ToString();
+        }
+
+        /// <summary>
+        /// Generates the WKT for a <c>LineString</c> specified by two <see cref="Coordinate"/>s.
+        /// </summary>
+        /// <param name="p0">The first coordinate.</param>
+        /// <param name="p1">The second coordinate.</param>
+        /// <returns>The WKT</returns>
+        public static string ToLineString(Coordinate p0, Coordinate p1)
+        {
+            // legacy note: JTS's version never checks Z or M, so the things that call this aren't
+            // expecting to see them.  the "actual" code to write lines handles Z / M just fine.
+            return $"LINESTRING ({Format(p0)}, {Format(p1)})";
+        }
+
+        internal static string Format(Coordinate p)
+        {
+            return Format(p.X, p.Y);
+        }
+
+        internal static string Format(double x, double y)
+        {
+            return OrdinateFormat.Default.Format(x) + " " + OrdinateFormat.Default.Format(y);
+        }
+
+
+        private OrdinateFormat CreateOrdinateFormat(PrecisionModel precisionModel)
+        {
+            // the default number of decimal places is 16, which is sufficient
+            // to accomodate the maximum precision of a double.
+            int digits = precisionModel.MaximumSignificantDigits;
+            int decimalPlaces = Math.Max(0, digits); // negative values not allowed
+
+            return new OrdinateFormat(decimalPlaces);
+        }
+
+        /// <summary>
+        /// A filter implementation to test if a coordinate sequence actually has meaningful values
+        /// for an ordinate bit-pattern
+        /// </summary>
+        private class CheckOrdinatesFilter : ICoordinateSequenceFilter
+        {
+            private readonly Ordinates _checkOrdinateFlags;
+            private Ordinates _outputOrdinates;
+
+            private readonly bool _alwaysEmitZWithM;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CheckOrdinatesFilter"/> flag.
+            /// </summary>
+            /// <param name="checkOrdinateFlags">
+            /// The index for the ordinates to test.
+            /// </param>
+            /// <param name="alwaysEmitZWithM">
+            /// <see langword="true"/> if <see cref="Ordinates.M"/> implies
+            /// <see cref="Ordinates.Z"/>, <see langword="false"/> otherwise.
+            /// </param>
+            public CheckOrdinatesFilter(Ordinates checkOrdinateFlags, bool alwaysEmitZWithM)
+            {
+                _outputOrdinates = Ordinates.XY;
+                _checkOrdinateFlags = checkOrdinateFlags;
+                _alwaysEmitZWithM = alwaysEmitZWithM;
+            }
+
+            /// <inheritdoc />
+            public void Filter(CoordinateSequence seq, int i)
+            {
+                if (_checkOrdinateFlags.HasFlag(Ordinates.Z) && !_outputOrdinates.HasFlag(Ordinates.Z))
+                {
+                    if (!double.IsNaN(seq.GetZ(i)))
+                    {
+                        _outputOrdinates |= Ordinates.Z;
+                    }
+                }
+
+                if (_checkOrdinateFlags.HasFlag(Ordinates.M) && !_outputOrdinates.HasFlag(Ordinates.M))
+                {
+                    if (!double.IsNaN(seq.GetM(i)))
+                    {
+                        _outputOrdinates |= Ordinates.M;
+                        if (_alwaysEmitZWithM)
+                        {
+                            _outputOrdinates |= Ordinates.Z;
+                        }
+                    }
+                }
+            }
+
+            /// <inheritdoc />
+            public bool GeometryChanged => false;
+
+            /// <inheritdoc />
+            public bool Done => _outputOrdinates == _checkOrdinateFlags;
+
+            /// <summary>
+            /// Gets the evaluated ordinate bit-pattern of ordinates with valid values masked by
+            /// <see cref="_checkOrdinateFlags"/>.
+            /// </summary>
+            public Ordinates OutputOrdinates => _outputOrdinates;
+        }
+
+        private Ordinates _outputOrdinates;
+        private readonly int _outputDimension;
+
+        private PrecisionModel _precisionModel;
+        private bool _isFormatted;
+        private int _coordsPerLine = -1;
+        private string _indentTabStr;
+        //private bool _zIsMeasure;
+
+        // MSSQL overrides
+        private readonly bool _skipOrdinateToken;
+        private readonly bool _alwaysEmitZWithM;
+        private readonly string _missingOrdinateReplacementText = " NaN";
+
+        public MySqlGeographyWktWriter() : this(2, false) { }
+
+        public MySqlGeographyWktWriter(int outputDimension) : this(outputDimension, false) { }
+
+        private MySqlGeographyWktWriter(int outputDimension, bool mssql)
+        {
+            this.Tab = 2;
+            if (outputDimension < 2 || outputDimension > 4)
+                throw new ArgumentException("Output dimension must be in the range [2, 4]", "outputDimension");
+            _outputDimension = outputDimension;
+
+            switch (outputDimension)
+            {
+                case 2:
+                    _outputOrdinates = Ordinates.XY;
+                    break;
+
+                case 3:
+                    _outputOrdinates = Ordinates.XYZ;
+                    break;
+
+                case 4:
+                    _outputOrdinates = Ordinates.XYZM;
+                    break;
+            }
+
+            if (mssql)
+            {
+                _skipOrdinateToken = true;
+                _alwaysEmitZWithM = true;
+                _missingOrdinateReplacementText = " NULL";
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets whther the output woll be formatted
+        /// </summary>
+        public bool Formatted
+        {
+            get => _isFormatted;
+            set => _isFormatted = value;
+        }
+
+        /// <summary>
+        /// Gets/sets the maximum number of coordinates per line written in formatted output.
+        /// </summary>
+        /// <remarks>If the provided coordinate number is &lt; 0, coordinates will be written all on one line.</remarks>
+        public int MaxCoordinatesPerLine
+        {
+            get => _coordsPerLine;
+            set => _coordsPerLine = value;
+        }
+
+        /// <summary>Gets/sets the tab size to use for indenting.</summary>
+        /// <exception cref="ArgumentException">If the size is non-positive</exception>
+        public int Tab
+        {
+            get => _indentTabStr.Length;
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Tab count must be positive", "value");
+                _indentTabStr = new string(' ', value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Ordinates"/> to be written.  Possible members are:
+        /// <list type="bullet">
+        /// <item><description><see cref="Ordinates.X"/></description></item>
+        /// <item><description><see cref="Ordinates.Y"/></description></item>
+        /// <item><description><see cref="Ordinates.Z"/></description></item>
+        /// <item><description><see cref="Ordinates.M"/></description></item>
+        /// </list>
+        /// Values of <see cref="Ordinates.X"/> and <see cref="Ordinates.Y"/> are always assumed and
+        /// not particularly checked for.
+        /// </summary>
+        public Ordinates OutputOrdinates
+        {
+            get => _outputOrdinates;
+            set => _outputOrdinates = Ordinates.XY | (value & Ordinates.XYZM);
+        }
+
+        /// <summary>
+        /// Gets or sets a <see cref="PrecisionModel"/> that should be used on the ordinates written.
+        /// <para>
+        /// If none/<see langword="null"/> is assigned, the precision model of the
+        /// <see cref="Geometry.Factory"/> is used.
+        /// </para>
+        /// <para>
+        /// Note: The precision model is applied to all ordinate values, not just x and y.
+        /// </para>
+        /// </summary>
+        public PrecisionModel PrecisionModel
+        {
+            get => _precisionModel;
+            set => _precisionModel = value;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MySqlGeographyWktWriter"/> class suitable for MSSQL's non-
+        /// standard WKT format.
+        /// </summary>
+        /// <returns>
+        /// A new instance of the <see cref="MySqlGeographyWktWriter"/> class suitable for MSSQL's non-standard
+        /// WKT format.
+        /// </returns>
+        public static MySqlGeographyWktWriter ForMicrosoftSqlServer() => new MySqlGeographyWktWriter(4, true);
+
+        /// <summary>
+        /// Converts a <c>Geometry</c> to its Well-known Text representation.
+        /// </summary>
+        /// <param name="geometry">A <c>Geometry</c> to process.</param>
+        /// <returns>A Geometry Tagged Text string (see the OpenGIS Simple Features Specification).</returns>
+        public virtual string Write(Geometry geometry)
+        {
+            var sb = new StringBuilder();
+            var sw = new StringWriter(sb);
+
+            // determine the precision model
+            var pm = _precisionModel ?? geometry.Factory.PrecisionModel;
+
+            try
+            {
+                WriteFormatted(geometry, false, sw, pm);
+            }
+            catch (IOException)
+            {
+                Assert.ShouldNeverReachHere();
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Converts a <c>Geometry</c> to its Well-known Text representation.
+        /// </summary>
+        /// <param name="geometry">A <c>Geometry</c> to process.</param>
+        /// <param name="stream">A <c>Stream</c> to write into</param>
+        public void Write(Geometry geometry, Stream stream)
+        {
+            var sw = new StreamWriter(stream);
+
+            // determine the precision model
+            var pm = _precisionModel ?? geometry.Factory.PrecisionModel;
+
+            try
+            {
+                WriteFormatted(geometry, _isFormatted, sw, pm);
+            }
+            catch (IOException)
+            {
+                Assert.ShouldNeverReachHere();
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>Geometry</c> to its Well-known Text representation.
+        /// </summary>
+        /// <param name="geometry">A <c>Geometry</c> to process.</param>
+        /// <param name="writer"></param>
+        /// <returns>A "Geometry Tagged Text" string (see the OpenGIS Simple Features Specification)</returns>
+        public virtual void Write(Geometry geometry, TextWriter writer)
+        {
+            // determine the precision model
+            var pm = _precisionModel ?? geometry.Factory.PrecisionModel;
+
+            WriteFormatted(geometry, _isFormatted, writer, pm);
+        }
+
+        /// <summary>
+        /// Same as <c>write</c>, but with newlines and spaces to make the
+        /// well-known text more readable.
+        /// </summary>
+        /// <param name="geometry">A <c>Geometry</c> to process</param>
+        /// <returns>
+        /// A "Geometry Tagged Text" string (see the OpenGIS Simple
+        /// Features Specification), with newlines and spaces.
+        /// </returns>
+        public virtual string WriteFormatted(Geometry geometry)
+        {
+            var sw = new StringWriter();
+            try
+            {
+                WriteFormatted(geometry, true, sw, _precisionModel);
+            }
+            catch (IOException)
+            {
+                Assert.ShouldNeverReachHere();
+            }
+            return sw.ToString();
+        }
+
+        /// <summary>
+        /// Same as <c>write</c>, but with newlines and spaces to make the
+        /// well-known text more readable.
+        /// </summary>
+        /// <param name="geometry">A <c>Geometry</c> to process</param>
+        /// <param name="writer"></param>
+        /// <returns>
+        /// A Geometry Tagged Text string (see the OpenGIS Simple
+        /// Features Specification), with newlines and spaces.
+        /// </returns>
+        public virtual void WriteFormatted(Geometry geometry, TextWriter writer)
+        {
+            WriteFormatted(geometry, true, writer, _precisionModel);
+        }
+
+        /// <summary>
+        /// Converts a <c>Geometry</c> to its Well-known Text representation.
+        /// </summary>
+        /// <param name="geometry">A <c>Geometry</c> to process</param>
+        /// <param name="useFormatting">A flag indicating that the output should be formatted.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="precisionModel">The precision model to use.</param>
+        /// <returns>
+        /// A "Geometry Tagged Text" string (see the OpenGIS Simple
+        /// Features Specification).
+        /// </returns>
+        private void WriteFormatted(Geometry geometry, bool useFormatting, TextWriter writer, PrecisionModel precisionModel)
+        {
+            if (geometry == null)
+                throw new ArgumentNullException("geometry");
+
+            // ensure we have a precision model
+            precisionModel = precisionModel ?? geometry.PrecisionModel;
+
+            // create the formatter
+            bool useMaxPrecision = precisionModel.PrecisionModelType == PrecisionModels.Floating;
+            var ordinateFormat = CreateOrdinateFormat(precisionModel);
+            //string format = "0." + StringOfChar('#', ordinateFormat.NumberDecimalDigits);
+
+            // append the WKT
+            AppendGeometryTaggedText(geometry, useFormatting, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Geometry"/> to &lt;Geometry Tagged Text&gt; format, then appends
+        /// it to the writer.
+        /// </summary>
+        /// <param name="geometry">the <see cref="Geometry"/> to process.</param>
+        /// <param name="useFormatting">A flag indicating that the output should be formatted.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendGeometryTaggedText(Geometry geometry, bool useFormatting, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            // evaluate the ordinates actually present in the geometry
+            var cof = new CheckOrdinatesFilter(_outputOrdinates, _alwaysEmitZWithM);
+            geometry.Apply(cof);
+
+            // Append the WKT
+            AppendGeometryTaggedText(geometry, cof.OutputOrdinates, useFormatting, 0, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Geometry"/> to &lt;Geometry Tagged Text&gt; format, then appends
+        /// it to the writer.
+        /// </summary>
+        /// <param name="geometry">the <see cref="Geometry"/> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendGeometryTaggedText(Geometry geometry, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            Indent(useFormatting, level, writer);
+
+            switch (geometry)
+            {
+                case Point point:
+                    AppendPointTaggedText(point, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case LinearRing linearRing:
+                    AppendLinearRingTaggedText(linearRing, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case LineString lineString:
+                    AppendLineStringTaggedText(lineString, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case Polygon polygon:
+                    AppendPolygonTaggedText(polygon, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case MultiPoint multiPoint:
+                    AppendMultiPointTaggedText(multiPoint, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case MultiLineString multiLineString:
+                    AppendMultiLineStringTaggedText(multiLineString, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case MultiPolygon multiPolygon:
+                    AppendMultiPolygonTaggedText(multiPolygon, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                case GeometryCollection geometryCollection:
+                    AppendGeometryCollectionTaggedText(geometryCollection, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+                    break;
+
+                default:
+                    Assert.ShouldNeverReachHere("Unsupported Geometry implementation:" + geometry.GetType());
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>Coordinate</c> to Point Tagged Text format,
+        /// then appends it to the writer.
+        /// </summary>
+        /// <param name="point">The <c>Point</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendPointTaggedText(Point point, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write("POINT ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendSequenceText(point.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>LineString</c> to &lt;LineString Tagged Text
+        /// format, then appends it to the writer.
+        /// </summary>
+        /// <param name="lineString">The <c>LineString</c> to process.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendLineStringTaggedText(LineString lineString, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write("LINESTRING ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendSequenceText(lineString.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>LinearRing</c> to &lt;LinearRing Tagged Text
+        /// format, then appends it to the writer.
+        /// </summary>
+        /// <param name="linearRing">The <c>LinearRing</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendLinearRingTaggedText(LinearRing linearRing, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write("LINEARRING ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendSequenceText(linearRing.CoordinateSequence, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>Polygon</c> to Polygon Tagged Text format,
+        /// then appends it to the writer.
+        /// </summary>
+        /// <param name="polygon">The <c>Polygon</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendPolygonTaggedText(Polygon polygon, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write("POLYGON ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendPolygonText(polygon, outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>MultiPoint</c> to &lt;MultiPoint Tagged Text
+        /// format, then appends it to the writer.
+        /// </summary>
+        /// <param name="multipoint">The <c>MultiPoint</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendMultiPointTaggedText(MultiPoint multipoint, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write("MULTIPOINT ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendMultiPointText(multipoint, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>MultiLineString</c> to MultiLineString Tagged
+        /// Text format, then appends it to the writer.
+        /// </summary>
+        /// <param name="multiLineString">The <c>MultiLineString</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendMultiLineStringTaggedText(MultiLineString multiLineString, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write("MULTILINESTRING ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendMultiLineStringText(multiLineString, outputOrdinates, useFormatting, level, /*false, */writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>MultiPolygon</c> to MultiPolygon Tagged Text
+        /// format, then appends it to the writer.
+        /// </summary>
+        /// <param name="multiPolygon">The <c>MultiPolygon</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendMultiPolygonTaggedText(MultiPolygon multiPolygon, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write("MULTIPOLYGON ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendMultiPolygonText(multiPolygon, outputOrdinates, useFormatting, level, /*false, */writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Converts a <c>GeometryCollection</c> to GeometryCollection
+        /// Tagged Text format, then appends it to the writer.
+        /// </summary>
+        /// <param name="geometryCollection">The <c>GeometryCollection</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that the output should be formatted</param>
+        /// <param name="level">the indentation level</param>
+        /// <param name="writer">The output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendGeometryCollectionTaggedText(GeometryCollection geometryCollection, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            writer.Write("GEOMETRYCOLLECTION ");
+            AppendOrdinateText(outputOrdinates, writer);
+            AppendGeometryCollectionText(geometryCollection, outputOrdinates, useFormatting, level, writer, ordinateFormat);
+        }
+
+        /// <summary>
+        /// Appends the i'th coordinate from the sequence to the writer
+        /// <para>
+        /// If the <paramref name="seq"/> has coordinates that are <see cref="double.IsNaN">NaN</see>,
+        /// these are not written, even though <see cref="_outputDimension"/> suggests this.
+        /// </para>
+        /// </summary>
+        /// <param name="seq">the <see cref="CoordinateSequence"/> to process</param>
+        /// <param name="outputOrdinates">A bit pattern of output ordinates</param>
+        /// <param name="i">the index of the coordinate to write</param>
+        /// <param name="writer">writer the output writer to append to</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values</param>
+        /// <exception cref="IOException"></exception>
+        private void AppendCoordinate(CoordinateSequence seq, Ordinates outputOrdinates, int i, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            // Swaps the X/Y coordinates, because if geography data is used (SRID 4326), MySQL uses the order (lat, lon)
+            // instead of (lon, lat).
+            writer.Write(WriteNumber(seq.GetY(i), ordinateFormat) + " " +
+                         WriteNumber(seq.GetX(i), ordinateFormat));
+
+            if (outputOrdinates.HasFlag(Ordinates.Z))
+            {
+                double z = seq.GetZ(i);
+                if (!double.IsNaN(z))
+                {
+                    writer.Write(" ");
+                    writer.Write(WriteNumber(seq.GetZ(i), ordinateFormat));
+                }
+                else
+                {
+                    writer.Write(_missingOrdinateReplacementText);
+                }
+            }
+
+            if (outputOrdinates.HasFlag(Ordinates.M))
+            {
+                writer.Write(" ");
+                writer.Write(WriteNumber(seq.GetM(i), ordinateFormat));
+            }
+        }
+
+        /// <summary>
+        /// Converts a <see cref="double" /> to a <see cref="string" />.
+        /// </summary>
+        /// <param name="d">The <see cref="double" /> to convert.</param>
+        /// <param name="ordinateFormat">A</param>
+        /// <returns>
+        /// The <see cref="double" /> as a <see cref="string" />.
+        /// </returns>
+        private static string WriteNumber(double d, OrdinateFormat ordinateFormat)
+        {
+            return ordinateFormat.Format(d);
+        }
+
+        /// <summary>
+        /// Appends additional ordinate information. This function may
+        /// <list type="bullet">
+        /// <item>
+        /// <description>
+        /// append 'Z' if in <paramref name="outputOrdinates"/> the <see cref="Ordinates.Z"/> value is included.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// append 'M' if in <paramref name="outputOrdinates"/> the <see cref="Ordinates.M"/> value is included.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// append 'ZM' if in <paramref name="outputOrdinates"/> the <see cref="Ordinates.Z"/> and
+        /// <see cref="Ordinates.M"/> values are included.
+        /// </description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <exception cref="IOException">if an error occurs while using the writer.</exception>
+        private void AppendOrdinateText(Ordinates outputOrdinates, TextWriter writer)
+        {
+            if (_skipOrdinateToken)
+            {
+                return;
+            }
+
+            if (outputOrdinates.HasFlag(Ordinates.Z))
+            {
+                writer.Write('Z');
+            }
+
+            if (outputOrdinates.HasFlag(Ordinates.M))
+            {
+                writer.Write('M');
+            }
+        }
+
+        /// <summary>
+        /// Appends all members of a <see cref="CoordinateSequence"/> to the stream. Each
+        /// <see cref="Coordinate"/> is separated from another using a colon, the ordinates of a
+        /// <see cref="Coordinate"/> are separated by a space.
+        /// </summary>
+        /// <param name="seq">the <see cref="CoordinateSequence"/> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that.</param>
+        /// <param name="level">the indentation level.</param>
+        /// <param name="indentFirst">flag indicating that the first <see cref="Coordinate"/> of the sequence should be indented for better visibility.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendSequenceText(CoordinateSequence seq, Ordinates outputOrdinates, bool useFormatting, int level, bool indentFirst, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (seq.Count == 0)
+            {
+                writer.Write("EMPTY");
+            }
+            else
+            {
+                if (indentFirst) Indent(useFormatting, level, writer);
+                writer.Write("(");
+                for (int i = 0; i < seq.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        writer.Write(", ");
+                        if (_coordsPerLine > 0
+                            && i%_coordsPerLine == 0)
+                        {
+                            Indent(useFormatting, level + 1, writer);
+                        }
+                    }
+                    AppendCoordinate(seq, outputOrdinates, i, writer, ordinateFormat);
+                }
+                writer.Write(")");
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>Polygon</c> to Polygon Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="polygon">The <c>Polygon</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that.</param>
+        /// <param name="level">the indentation level.</param>
+        /// <param name="indentFirst">flag indicating that the first <see cref="Coordinate"/> of the sequence should be indented for better visibility.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendPolygonText(Polygon polygon, Ordinates outputOrdinates, bool useFormatting, int level, bool indentFirst, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (polygon.IsEmpty)
+                writer.Write("EMPTY");
+            else
+            {
+                if (indentFirst) Indent(useFormatting, level, writer);
+                writer.Write("(");
+                AppendSequenceText(polygon.ExteriorRing.CoordinateSequence, outputOrdinates,
+                    useFormatting, level, false, writer, ordinateFormat);
+                for (int i = 0; i < polygon.NumInteriorRings; i++)
+                {
+                    writer.Write(", ");
+                    AppendSequenceText(polygon.GetInteriorRingN(i).CoordinateSequence, outputOrdinates,
+                        useFormatting, level + 1, true, writer, ordinateFormat);
+                }
+                writer.Write(")");
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>MultiPoint</c> to &lt;MultiPoint Text format, then
+        /// appends it to the writer.
+        /// </summary>
+        /// <param name="multiPoint">The <c>MultiPoint</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that.</param>
+        /// <param name="level">the indentation level.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendMultiPointText(MultiPoint multiPoint, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (multiPoint.IsEmpty)
+                writer.Write("EMPTY");
+            else
+            {
+                writer.Write("(");
+                for (int i = 0; i < multiPoint.NumGeometries; i++)
+                {
+                    if (i > 0)
+                    {
+                        writer.Write(", ");
+                        IndentCoords(useFormatting, i, level + 1, writer);
+                    }
+                    AppendSequenceText(((Point)multiPoint.GetGeometryN(i)).CoordinateSequence,
+                        outputOrdinates, useFormatting, level, false, writer, ordinateFormat);
+                }
+                writer.Write(")");
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>MultiLineString</c> to &lt;MultiLineString Text
+        /// format, then appends it to the writer.
+        /// </summary>
+        /// <param name="multiLineString">The <c>MultiLineString</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that.</param>
+        /// <param name="level">the indentation level.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendMultiLineStringText(MultiLineString multiLineString, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (multiLineString.IsEmpty)
+                writer.Write("EMPTY");
+            else
+            {
+                int level2 = level;
+                bool doIndent = false;
+                writer.Write("(");
+                for (int i = 0; i < multiLineString.NumGeometries; i++)
+                {
+                    if (i > 0)
+                    {
+                        writer.Write(", ");
+                        level2 = level + 1;
+                        doIndent = true;
+                    }
+                    AppendSequenceText(((LineString) multiLineString.GetGeometryN(i)).CoordinateSequence,
+                        outputOrdinates, useFormatting, level2, doIndent, writer, ordinateFormat);
+                }
+                writer.Write(")");
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>MultiPolygon</c> to &lt;MultiPolygon Text format,
+        /// then appends it to the writer.
+        /// </summary>
+        /// <param name="multiPolygon">The <c>MultiPolygon</c> to process.</param>
+        /// <param name="outputOrdinates">A bit-pattern of ordinates to write.</param>
+        /// <param name="useFormatting">flag indicating that.</param>
+        /// <param name="level">the indentation level.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendMultiPolygonText(MultiPolygon multiPolygon, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (multiPolygon.IsEmpty)
+                writer.Write("EMPTY");
+            else
+            {
+                int level2 = level;
+                bool doIndent = false;
+                writer.Write("(");
+                for (int i = 0; i < multiPolygon.NumGeometries; i++)
+                {
+                    if (i > 0)
+                    {
+                        writer.Write(", ");
+                        level2 = level + 1;
+                        doIndent = true;
+                    }
+                    AppendPolygonText((Polygon) multiPolygon.GetGeometryN(i), outputOrdinates, useFormatting, level2, doIndent, writer, ordinateFormat);
+                }
+                writer.Write(")");
+            }
+        }
+
+        /// <summary>
+        /// Converts a <c>GeometryCollection</c> to GeometryCollectionText
+        /// format, then appends it to the writer.
+        /// </summary>
+        /// <param name="geometryCollection">The <c>GeometryCollection</c> to process.</param>
+        /// <param name="outputOrdinates"></param>
+        /// <param name="useFormatting">flag indicating that.</param>
+        /// <param name="level">the indentation level.</param>
+        /// <param name="writer">the output writer to append to.</param>
+        /// <param name="ordinateFormat">The format to use for writing ordinate values.</param>
+        private void AppendGeometryCollectionText(GeometryCollection geometryCollection, Ordinates outputOrdinates, bool useFormatting, int level, TextWriter writer, OrdinateFormat ordinateFormat)
+        {
+            if (geometryCollection.IsEmpty)
+                writer.Write("EMPTY");
+            else
+            {
+                int level2 = level;
+                writer.Write("(");
+                for (int i = 0; i < geometryCollection.NumGeometries; i++)
+                {
+                    if (i > 0)
+                    {
+                        writer.Write(", ");
+                        level2 = level + 1;
+                    }
+                    AppendGeometryTaggedText(geometryCollection.GetGeometryN(i), outputOrdinates, useFormatting, level2, writer, ordinateFormat);
+                }
+                writer.Write(")");
+            }
+        }
+
+        private void IndentCoords(bool useFormatting, int coordIndex, int level, TextWriter writer)
+        {
+            if (_coordsPerLine <= 0 || coordIndex % _coordsPerLine != 0)
+                return;
+            Indent(useFormatting, level, writer);
+        }
+
+        private void Indent(bool useFormatting, int level, TextWriter writer)
+        {
+            if (!useFormatting || level <= 0) return;
+            writer.Write("\n");
+            for (int i = 0; i < level; i++)
+                writer.Write(_indentTabStr);
+        }
+    }
+}

--- a/src/EFCore.MySql.NTS/Storage/Internal/MySqlGeometryTypeMapping.cs
+++ b/src/EFCore.MySql.NTS/Storage/Internal/MySqlGeometryTypeMapping.cs
@@ -76,20 +76,24 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         {
             var builder = new StringBuilder();
             var geometry = (Geometry)value;
-            var defaultSrid = geometry.SRID == 0;
+            var isDefaultSrid = geometry.SRID == 0;
+            var isGeography = geometry.SRID == 4326;
 
             if (CheckEmptyValue(geometry))
             {
-                defaultSrid = true;
+                isDefaultSrid = true;
             }
 
             builder
                 .Append("ST_GeomFromText")
                 .Append("('")
-                .Append(geometry.ToText())
+                .Append(
+                    isGeography
+                        ? new MySqlGeographyWktWriter().Write(geometry)
+                        : geometry.ToText())
                 .Append("'");
 
-            if (!defaultSrid)
+            if (!isDefaultSrid)
             {
                 builder
                     .Append(", ")

--- a/src/EFCore.MySql.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
+++ b/src/EFCore.MySql.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
@@ -11,6 +11,11 @@ using NetTopologySuite.IO;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.ValueConversion.Internal
 {
+    internal static class GeometryValueConverter
+    {
+        internal static readonly ConcurrentDictionary<uint, NtsGeometryServices> GeometryServiceses = new ConcurrentDictionary<uint, NtsGeometryServices>();
+    }
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -33,9 +38,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.ValueConversion.Internal
         {
         }
 
-        // ReSharper disable once StaticMemberInGenericType
-        private static readonly ConcurrentDictionary<uint, NtsGeometryServices> _geometryServiceses = new ConcurrentDictionary<uint, NtsGeometryServices>();
-
         private static MySqlGeometry ConvertToProviderCore(TGeometry v)
             => MySqlGeometry.FromWkb(v.SRID, v.ToBinary());
 
@@ -47,7 +49,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.ValueConversion.Internal
             var biEndianBinaryReader = new BiEndianBinaryReader(memoryStream);
             var srid = biEndianBinaryReader.ReadUInt32();
 
-            var geometryServices = _geometryServiceses.GetOrAdd(
+            var geometryServices = GeometryValueConverter.GeometryServiceses.GetOrAdd(
                 srid,
                 b => new NtsGeometryServices(
                     NtsGeometryServices.Instance.DefaultCoordinateSequenceFactory,

--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -73,8 +73,20 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         // public const string SpatialRelateFunctionMySqlSupportVersionString = SpatialFunctionAdditionsMySqlSupportVersionString;
         public const string SpatialRelateFunctionMariaDbSupportVersionString = SpatialFunctionAdditionsMariaDbSupportVersionString;
 
-        public const string SpatialIsValidFunctionMySqlSupportVersionString = "5.7.6-mysql";
-        // public const string SpatialIsValidFunctionMariaDbSupportVersionString = "?.?.?-mariadb";
+        public const string SpatialSupportFunctionAdditionsMySqlSupportVersionString = "5.7.6-mysql";
+        // public const string SpatialSupportFunctionAdditionsMariaDbSupportVersionString = "?.?.?-mariadb";
+
+        public const string SpatialIsValidFunctionMySqlSupportVersionString = SpatialSupportFunctionAdditionsMySqlSupportVersionString;
+        // public const string SpatialIsValidFunctionMariaDbSupportVersionString = SpatialSupportFunctionAdditionsMariaDbSupportVersionString;
+
+        public const string SpatialDistanceSphereFunctionMySqlSupportVersionString = SpatialSupportFunctionAdditionsMySqlSupportVersionString;
+        // public const string SpatialDistanceSphereFunctionMariaDbSupportVersionString = SpatialSupportFunctionAdditionsMariaDbSupportVersionString;
+
+        public const string SpatialSetSridFunctionMySqlSupportVersionString = "8.0.0-mysql";
+        // public const string SpatialSetSridFunctionMariaDbSupportVersionString = "?.?.?-mariadb";
+
+        public const string SpatialDistanceFunctionImplementsAndoyerMySqlSupportVersionString = "8.0.0-mysql";
+        // public const string SpatialDistanceFunctionImplementsAndoyerMariaDbSupportVersionString = "?.?.?-mariadb";
 
         // public const string ExceptInterceptMySqlSupportVersionString = "?.?.?-mysql";
         public const string ExceptInterceptMariaDbSupportVersionString = "10.3.0-mariadb";
@@ -111,7 +123,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public const string SpatialIsRingFunctionSupportKey = nameof(SpatialIsRingFunctionSupportKey);
         public const string SpatialPointOnSurfaceFunctionSupportKey = nameof(SpatialPointOnSurfaceFunctionSupportKey);
         public const string SpatialRelateFunctionSupportKey = nameof(SpatialRelateFunctionSupportKey);
+        public const string SpatialSupportFunctionAdditionsSupportKey = nameof(SpatialSupportFunctionAdditionsSupportKey);
         public const string SpatialIsValidFunctionSupportKey = nameof(SpatialIsValidFunctionSupportKey);
+        public const string SpatialDistanceSphereFunctionSupportKey = nameof(SpatialDistanceSphereFunctionSupportKey);
+        public const string SpatialSetSridFunctionSupportKey = nameof(SpatialSetSridFunctionSupportKey);
+        public const string SpatialDistanceFunctionImplementsAndoyerSupportKey = nameof(SpatialDistanceFunctionImplementsAndoyerSupportKey);
         public const string ExceptInterceptSupportKey = nameof(ExceptInterceptSupportKey);
         public const string ExceptInterceptPrecedenceSupportKey = nameof(ExceptInterceptPrecedenceSupportKey);
         public const string JsonDataTypeEmulationSupportKey = nameof(JsonDataTypeEmulationSupportKey);
@@ -141,7 +157,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             { SpatialIsRingFunctionSupportKey, new ServerVersionSupport(/*SpatialIsRingFunctionMySqlSupportVersionString, */SpatialIsRingFunctionMariaDbSupportVersionString)},
             { SpatialPointOnSurfaceFunctionSupportKey, new ServerVersionSupport(/*SpatialPointOnSurfaceFunctionMySqlSupportVersionString, */SpatialPointOnSurfaceFunctionMariaDbSupportVersionString)},
             { SpatialRelateFunctionSupportKey, new ServerVersionSupport(/*SpatialRelateFunctionMySqlSupportVersionString, */SpatialRelateFunctionMariaDbSupportVersionString)},
+            { SpatialSupportFunctionAdditionsSupportKey, new ServerVersionSupport(SpatialSupportFunctionAdditionsMySqlSupportVersionString/*, SpatialSupportFunctionAdditionsMariaDbSupportVersionString*/)},
             { SpatialIsValidFunctionSupportKey, new ServerVersionSupport(SpatialIsValidFunctionMySqlSupportVersionString/*, SpatialIsValidFunctionMariaDbSupportVersionString*/)},
+            { SpatialDistanceSphereFunctionSupportKey, new ServerVersionSupport(SpatialDistanceSphereFunctionMySqlSupportVersionString/*, SpatialDistanceSphereFunctionMariaDbSupportVersionString*/)},
+            { SpatialSetSridFunctionSupportKey, new ServerVersionSupport(SpatialSetSridFunctionMySqlSupportVersionString/*, SpatialSetSridFunctionMariaDbSupportVersionString*/)},
+            { SpatialDistanceFunctionImplementsAndoyerSupportKey, new ServerVersionSupport(SpatialDistanceFunctionImplementsAndoyerMySqlSupportVersionString/*, SpatialDistanceFunctionImplementsAndoyerMariaDbSupportVersionString*/)},
             { ExceptInterceptSupportKey, new ServerVersionSupport(/*ExceptInterceptMySqlSupportVersionString, */ExceptInterceptMariaDbSupportVersionString)},
             { ExceptInterceptPrecedenceSupportKey, new ServerVersionSupport(/*ExceptInterceptPrecedenceMySqlSupportVersionString, */ExceptInterceptPrecedenceMariaDbSupportVersionString)},
             { JsonDataTypeEmulationSupportKey, new ServerVersionSupport(/*JsonDataTypeEmulationMySqlSupportVersionString, */JsonDataTypeEmulationMariaDbSupportVersionString)},
@@ -171,7 +191,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public virtual bool SupportsSpatialIsRingFunction => SupportMap[SpatialIsRingFunctionSupportKey].IsSupported(this);
         public virtual bool SupportsSpatialPointOnSurfaceFunction => SupportMap[SpatialPointOnSurfaceFunctionSupportKey].IsSupported(this);
         public virtual bool SupportsSpatialRelateFunction => SupportMap[SpatialRelateFunctionSupportKey].IsSupported(this);
+        public virtual bool SupportsSpatialSupportFunctionAdditions => SupportMap[SpatialSupportFunctionAdditionsSupportKey].IsSupported(this);
         public virtual bool SupportsSpatialIsValidFunction => SupportMap[SpatialIsValidFunctionSupportKey].IsSupported(this);
+        public virtual bool SupportsSpatialDistanceSphereFunction => SupportMap[SpatialDistanceSphereFunctionSupportKey].IsSupported(this);
+        public virtual bool SupportsSpatialSetSridFunction => SupportMap[SpatialSetSridFunctionSupportKey].IsSupported(this);
+        public virtual bool SupportsSpatialDistanceFunctionImplementsAndoyer => SupportMap[SpatialSetSridFunctionSupportKey].IsSupported(this);
         public virtual bool SupportsExceptIntercept => SupportMap[ExceptInterceptSupportKey].IsSupported(this);
         public virtual bool SupportsExceptInterceptPrecedence => SupportMap[ExceptInterceptPrecedenceSupportKey].IsSupported(this);
         public virtual bool SupportsJsonDataTypeEmulation => SupportMap[JsonDataTypeEmulationSupportKey].IsSupported(this);

--- a/src/EFCore.MySql/Storage/ServerVersion.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.cs
@@ -11,7 +11,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
     {
         private static readonly Regex _versionRegex = new Regex(@"\d+\.\d+\.?(?:\d+)?");
 
-        public static ServerVersion Default = new ServerVersion(new Version(8, 0, 19), ServerType.MySql);
+        public static readonly ServerVersion Default = new ServerVersion(new Version(8, 0, 21), ServerType.MySql);
 
         public ServerVersion()
             : this(null)

--- a/test/EFCore.MySql.FunctionalTests/Query/SpatialGeographyQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SpatialGeographyQueryMySqlTest.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NetTopologySuite;
+using NetTopologySuite.Geometries;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
+{
+    public class SpatialGeographyQueryMySqlTest : QueryTestBase<SpatialGeographyQueryMySqlTest.SpatialGeographyQueryMySqlFixture>
+    {
+        public SpatialGeographyQueryMySqlTest(SpatialGeographyQueryMySqlFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual void Distance(bool isAsync)
+        {
+            const double expectedGreatCircleDistance = 8117916.968066435; // return of ST_Distance_Sphere() for SRID 4326
+
+            using var context = CreateContext();
+
+            var seattle = context.Cities.First(c => c.Name == "Seattle");
+            var cities = context.Cities
+                .Where(c => c.Name == "Berlin")
+                .Select(c => new {Distance = c.Location.Distance(seattle.Location)})
+                .ToList();
+
+            var deviation = Math.Abs(cities.Single().Distance - expectedGreatCircleDistance) / expectedGreatCircleDistance;
+            Assert.True(deviation < 0.01); // adjust for MariaDB
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual void IsWithinDistance(bool isAsync)
+        {
+            const double expectedGreatCircleDistance = 8117916.968066435 + 100_000; // +100 km
+
+            using var context = CreateContext();
+
+            var seattle = context.Cities.First(c => c.Name == "Seattle");
+            var cities = context.Cities
+                .Where(c => c.CityId != seattle.CityId &&
+                            c.Location.IsWithinDistance(seattle.Location, expectedGreatCircleDistance))
+                .ToList();
+
+            Assert.Equal(1, cities.Count);
+            Assert.Equal("Berlin", cities[0].Name);
+        }
+
+        private SpatialGeographyContext CreateContext() => Fixture.CreateContext();
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        public class SpatialGeographyContext : PoolableDbContext
+        {
+            public DbSet<City> Cities { get; set; }
+
+            public SpatialGeographyContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public static void Seed(SpatialGeographyContext context, GeometryFactory factory)
+            {
+                context.AddRange(SpatialGeographyData.CreateCities(factory));
+                context.SaveChanges();
+            }
+
+            public class City
+            {
+                public int CityId { get; set; }
+                public string Name { get; set; }
+                public Point Location { get; set; }
+            }
+        }
+
+        public class SpatialGeographyData : ISetSource
+        {
+            private readonly IReadOnlyList<SpatialGeographyContext.City> _cities;
+
+            public SpatialGeographyData(GeometryFactory factory)
+            {
+                _cities = CreateCities(factory);
+            }
+
+            public static IReadOnlyList<SpatialGeographyContext.City> CreateCities(GeometryFactory factory)
+            {
+                return new []
+                {
+                    new SpatialGeographyContext.City {CityId = 1, Name = "Berlin", Location = factory.CreatePoint(new Coordinate(13.404954, 52.520007))},
+                    new SpatialGeographyContext.City {CityId = 2, Name = "Seattle", Location = factory.CreatePoint(new Coordinate(-122.3320708, 47.6062095))},
+                    new SpatialGeographyContext.City {CityId = 3, Name = "Warsaw", Location = factory.CreatePoint(new Coordinate(21.012229, 52.229676))}
+                };
+            }
+
+            public virtual IQueryable<TEntity> Set<TEntity>()
+                where TEntity : class
+            {
+                if (typeof(TEntity) == typeof(SpatialGeographyContext.City))
+                {
+                    return (IQueryable<TEntity>)_cities.AsQueryable();
+                }
+
+                throw new InvalidOperationException("Unknown entity type: " + typeof(TEntity));
+            }
+        }
+
+        public class SpatialGeographyQueryMySqlFixture : SharedStoreFixtureBase<SpatialGeographyContext>, IQueryFixtureBase
+        {
+            private GeometryFactory _geometryFactory;
+
+            public new RelationalTestStore TestStore
+                => (RelationalTestStore)base.TestStore;
+
+            public TestSqlLoggerFactory TestSqlLoggerFactory
+                => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+
+            public QueryAsserterBase QueryAsserter { get; set; }
+
+            public virtual GeometryFactory GeometryFactory
+                => LazyInitializer.EnsureInitialized(
+                    ref _geometryFactory,
+                    () => NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326));
+
+            protected override string StoreName
+                => "SpatialGeographyQueryTest";
+
+            protected override bool ShouldLogCategory(string logCategory)
+                => logCategory == DbLoggerCategory.Query.Name;
+
+            protected override ITestStoreFactory TestStoreFactory
+                => MySqlTestStoreFactory.Instance;
+
+            protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+                => base.AddServices(serviceCollection)
+                    .AddEntityFrameworkMySqlNetTopologySuite();
+
+            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            {
+                var optionsBuilder = base.AddOptions(builder);
+                new MySqlDbContextOptionsBuilder(optionsBuilder)
+                    .UseNetTopologySuite();
+
+                return optionsBuilder;
+            }
+
+            public override SpatialGeographyContext CreateContext()
+            {
+                var context = base.CreateContext();
+                context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+
+                return context;
+            }
+
+            protected override void Seed(SpatialGeographyContext context)
+                => SpatialGeographyContext.Seed(context, GeometryFactory);
+        }
+    }
+}


### PR DESCRIPTION
* Fixes the issue that `ST_GeomFromText()` and `ST_GeomFromWKB()` functions expect a (lat, lon) order with SRID `4326`.
* Fixes a bug that read SRIDs incorrectly from the database.
* Fixes a bug where database read objects had no SRID set.
* Add `ST_Distance_Sphere()` support. Is is automatically used when `Geometry.Distance()` ist called on an object with SRID `4326`.
* Closes the gap to MariaDB and MySQL < 8, by providing custom sphere distance algorithm implementations (Haversine and Andoyer). This adds distance calculation support for MariaDB through Pomelo. The behavior should be consistent across all (supported) database servers.
* Add `EF.Functions` extensions (`SpatialDistancePlanar()` and `SpatialDistanceSphere()`), for distance calculations with an explicit algorithm.
* `Geometry.Distance()` is now translated in a way, that a spherical distance algorithm is used for SRID `4326` and a planar algorithm for SRID `0`.

Fixes #1163 