### PR TITLE
Fix boolean handling regression bug

### DIFF
--- a/src/EFCore.MySql/Internal/MySqlDefaultDataTypeMappings.cs
+++ b/src/EFCore.MySql/Internal/MySqlDefaultDataTypeMappings.cs
@@ -92,7 +92,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
 
     public enum MySqlBooleanType
     {
-        None = -1,
+        None = -1, // TODO: Remove in EF Core 5; see MySqlTypeMappingTest.Bool_with_MySqlBooleanType_None_maps_to_null()
         Default = 0,
         TinyInt1 = 1,
         Bit1 = 2

--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -20,7 +20,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
         {
             ConnectionSettings = new MySqlConnectionSettings();
             ServerVersion = new ServerVersion(null);
-            CharSetBehavior = CharSetBehavior.AppendToAllColumns;
+            CharSetBehavior = CharSetBehavior.AppendToAllColumns; // TODO: Change to `NeverAppend` for EF Core 5.
 
             // We do not use the MySQL versions's default, but explicitly use `utf8mb4`
             // if not changed by the user.
@@ -157,15 +157,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
         {
             defaultDataTypeMappings ??= DefaultDataTypeMappings;
 
-            if (connectionSettings.TreatTinyAsBoolean ||
+            // Explicitly set MySqlDefaultDataTypeMappings values take precedence over connection string options.
+            if (connectionSettings.TreatTinyAsBoolean.HasValue &&
                 defaultDataTypeMappings.ClrBoolean == MySqlBooleanType.Default)
             {
-                defaultDataTypeMappings = defaultDataTypeMappings.WithClrBoolean(MySqlBooleanType.TinyInt1);
-            }
-            else if (defaultDataTypeMappings.ClrBoolean != MySqlBooleanType.Bit1 &&
-                     defaultDataTypeMappings.ClrBoolean != MySqlBooleanType.None)
-            {
-                defaultDataTypeMappings = defaultDataTypeMappings.WithClrBoolean(MySqlBooleanType.Bit1);
+                defaultDataTypeMappings = defaultDataTypeMappings.WithClrBoolean(
+                    connectionSettings.TreatTinyAsBoolean.Value
+                        ? MySqlBooleanType.TinyInt1
+                        : MySqlBooleanType.Bit1);
             }
 
             if (defaultDataTypeMappings.ClrDateTime == MySqlDateTimeType.Default)

--- a/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlConnectionSettings.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using System.Data.Common;
+using System.Linq;
 using MySql.Data.MySqlClient;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
@@ -32,11 +34,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                 GuidFormat = csb.GuidFormat;
             }
 
-            TreatTinyAsBoolean = csb.TreatTinyAsBoolean;
+            // It would be nice to have access to a public and currently non-existing
+            // MySqlConnectionStringOption.TreatTinyAsBoolean.HasValue() method, so we can safely find out, whether
+            // TreatTinyAsBoolean has been explicitly set or not.
+            var treatTinyAsBooleanKeys = new[] {"Treat Tiny As Boolean", "TreatTinyAsBoolean"};
+            TreatTinyAsBoolean = treatTinyAsBooleanKeys.Any(k => csb.ContainsKey(k))
+                ? (bool?)csb.TreatTinyAsBoolean
+                : null;
         }
 
         public virtual MySqlGuidFormat GuidFormat { get; }
-        public virtual bool TreatTinyAsBoolean { get; }
+        public virtual bool? TreatTinyAsBoolean { get; }
 
         protected bool Equals(MySqlConnectionSettings other)
         {
@@ -65,11 +73,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         }
 
         public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((int)GuidFormat * 397) ^ TreatTinyAsBoolean.GetHashCode();
-            }
-        }
+            => HashCode.Combine(
+                GuidFormat,
+                TreatTinyAsBoolean);
     }
 }

--- a/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
@@ -31,5 +31,74 @@ namespace Pomelo.EntityFrameworkCore.MySql
             Assert.StartsWith("Server=second;", mySqlOptionsExtension.ConnectionString, StringComparison.OrdinalIgnoreCase);
             Assert.Equal(MySqlBooleanType.TinyInt1, mySqlOptionsExtension.DefaultDataTypeMappings.ClrBoolean);
         }
+
+        [Fact]
+        public void TreatTinyAsBoolean_true()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql("TreatTinyAsBoolean=True");
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(MySqlBooleanType.TinyInt1, mySqlOptions.DefaultDataTypeMappings.ClrBoolean);
+        }
+
+        [Fact]
+        public void TreatTinyAsBoolean_false()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql("TreatTinyAsBoolean=False");
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(MySqlBooleanType.Bit1, mySqlOptions.DefaultDataTypeMappings.ClrBoolean);
+        }
+
+        [Fact]
+        public void TreatTinyAsBoolean_unspecified()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql("Server=foo");
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(MySqlBooleanType.Default, mySqlOptions.DefaultDataTypeMappings.ClrBoolean);
+        }
+
+        [Fact]
+        public void Explicit_DefaultDataTypeMappings_take_precedence_over_TreatTinyAsBoolean_true()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "TreatTinyAsBoolean=True",
+                b => b.DefaultDataTypeMappings(m => m.WithClrBoolean(MySqlBooleanType.Bit1)));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(MySqlBooleanType.Bit1, mySqlOptions.DefaultDataTypeMappings.ClrBoolean);
+        }
+
+        [Fact]
+        public void Explicit_DefaultDataTypeMappings_take_precedence_over_TreatTinyAsBoolean_false()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "TreatTinyAsBoolean=False",
+                b => b.DefaultDataTypeMappings(m => m.WithClrBoolean(MySqlBooleanType.TinyInt1)));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(MySqlBooleanType.TinyInt1, mySqlOptions.DefaultDataTypeMappings.ClrBoolean);
+        }
     }
 }


### PR DESCRIPTION
This fixes regression bug introduced in cec4a4e, that resulted in a mapping of `bit(1)` to `System.UInt64`, even when `TreatTinyAsBoolean=False` had been specified.

Fixes #1187