### PR TITLE
Fix `MySqlSchemaBehavior.Ignore` behavior, that would throw

### DIFF
--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -16,6 +16,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
 {
     public class MySqlOptions : IMySqlOptions
     {
+        private static readonly MySqlSchemaNameTranslator _ignoreSchemaNameTranslator = (_, objectName) => objectName;
+
         public MySqlOptions()
         {
             ConnectionSettings = new MySqlConnectionSettings();
@@ -52,7 +54,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             ReplaceLineBreaksWithCharFunction = mySqlOptions.ReplaceLineBreaksWithCharFunction;
             DefaultDataTypeMappings = ApplyDefaultDataTypeMappings(mySqlOptions.DefaultDataTypeMappings, ConnectionSettings);
             SchemaNameTranslator = mySqlOptions.SchemaNameTranslator ?? (mySqlOptions.SchemaBehavior == MySqlSchemaBehavior.Ignore
-                ? new MySqlSchemaNameTranslator((_, objectName) => objectName)
+                ? _ignoreSchemaNameTranslator
                 : null);
             IndexOptimizedBooleanColumns = mySqlOptions.IndexOptimizedBooleanColumns;
             JsonChangeTrackingOptions = mySqlJsonOptions?.JsonChangeTrackingOptions ?? default;
@@ -128,7 +130,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
                         nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
             }
 
-            if (!Equals(SchemaNameTranslator, mySqlOptions.SchemaNameTranslator))
+            if (!Equals(
+                SchemaNameTranslator,
+                mySqlOptions.SchemaBehavior == MySqlSchemaBehavior.Ignore
+                    ? _ignoreSchemaNameTranslator
+                    : SchemaNameTranslator))
             {
                 throw new InvalidOperationException(
                     CoreStrings.SingletonOptionChanged(

--- a/src/EFCore.MySql/Storage/Internal/MySqlDatabaseCreator.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDatabaseCreator.cs
@@ -139,10 +139,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         private IRelationalCommand CreateHasTablesCommand()
             => _rawSqlCommandBuilder
-                .Build(@"
-                    SELECT CASE WHEN COUNT(*) = 0 THEN FALSE ELSE TRUE END
-                    FROM information_schema.tables
-                    WHERE table_type = 'BASE TABLE' AND table_schema = '" + _relationalConnection.DbConnection.Database + "'");
+                .Build(@"SELECT CASE WHEN COUNT(*) = 0 THEN FALSE ELSE TRUE END
+FROM information_schema.tables
+WHERE table_type = 'BASE TABLE' AND table_schema = '" + _relationalConnection.DbConnection.Database + "'");
 
         private IReadOnlyList<MigrationCommand> CreateCreateOperations()
             => Dependencies.MigrationsSqlGenerator.Generate(new[] { new MySqlCreateDatabaseOperation { Name = _relationalConnection.DbConnection.Database } });

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.MySql.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using NetTopologySuite.Geometries;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Xunit;
 
@@ -108,6 +110,93 @@ ALTER TABLE `Cars` ADD CONSTRAINT `FK_Cars_LicensePlates_LicensePlateNumber` FOR
 );
 ",
                 Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        [ConditionalFact]
+        public virtual void CreateTable_MySqlSchemaBehavior_Throw()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                    Generate(
+                        options => options.SchemaBehavior(MySqlSchemaBehavior.Throw),
+                        buildAction: null,
+                        resetSchema: false,
+                        new CreateTableOperation
+                        {
+                            Name = "IceCreamShops",
+                            Schema = "IceCreamInc",
+                            Columns =
+                            {
+                                new AddColumnOperation
+                                {
+                                    Name = "Name",
+                                    ClrType = typeof(string),
+                                    ColumnType = "varchar(255)",
+                                }
+                            }
+                        }));
+        }
+
+        [ConditionalFact]
+        public virtual void CreateTable_MySqlSchemaBehavior_Ignore()
+        {
+            Generate(
+                options => options.SchemaBehavior(MySqlSchemaBehavior.Ignore),
+                buildAction: null,
+                resetSchema: false,
+                new CreateTableOperation
+                {
+                    Name = "IceCreamShops",
+                    Schema = "IceCreamInc",
+                    Columns =
+                    {
+                        new AddColumnOperation
+                        {
+                            Name = "Name",
+                            ClrType = typeof(string),
+                            ColumnType = "varchar(255)",
+                        }
+                    }
+                });
+
+            Assert.Equal(
+                @"CREATE TABLE `IceCreamShops` (
+    `Name` varchar(255) NOT NULL
+);",
+                Sql.Trim(),
+                ignoreLineEndingDifferences: true);
+        }
+
+        [ConditionalFact]
+        public virtual void CreateTable_MySqlSchemaBehavior_Translate()
+        {
+            Generate(
+                options => options.SchemaBehavior(
+                    MySqlSchemaBehavior.Translate,
+                    (schemaName, objectName) => $"{schemaName}_{objectName}"),
+                buildAction: null,
+                resetSchema: false,
+                new CreateTableOperation
+                {
+                    Name = "IceCreamShops",
+                    Schema = "IceCreamInc",
+                    Columns =
+                    {
+                        new AddColumnOperation
+                        {
+                            Name = "Name",
+                            ClrType = typeof(string),
+                            ColumnType = "varchar(255)",
+                        }
+                    }
+                });
+
+            Assert.Equal(
+                @"CREATE TABLE `IceCreamInc_IceCreamShops` (
+    `Name` varchar(255) NOT NULL
+);",
+                Sql.Trim(),
                 ignoreLineEndingDifferences: true);
         }
 

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestHelpers.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestHelpers.cs
@@ -31,6 +31,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
         public IServiceProvider CreateContextServices(CharSetBehavior charSetBehavior, CharSet charSet)
             => ((IInfrastructure<IServiceProvider>)new DbContext(CreateOptions(charSetBehavior, charSet))).Instance;
 
+        public IServiceProvider CreateContextServices(Action<MySqlDbContextOptionsBuilder> builder)
+            => ((IInfrastructure<IServiceProvider>)new DbContext(CreateOptions(builder))).Instance;
+
         public ModelBuilder CreateConventionBuilder(IServiceProvider contextServices)
         {
             var conventionSet = contextServices.GetRequiredService<IConventionSetBuilder>()
@@ -40,21 +43,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
         }
 
         public DbContextOptions CreateOptions(ServerVersion serverVersion)
-        {
-            var optionsBuilder = new DbContextOptionsBuilder();
-            optionsBuilder.UseMySql("Database=DummyDatabase", b => b.ServerVersion(serverVersion));
-
-            return optionsBuilder.Options;
-        }
+            => CreateOptions(b => b.ServerVersion(serverVersion));
 
         public DbContextOptions CreateOptions(CharSetBehavior charSetBehavior, CharSet charSet)
-        {
-            var optionsBuilder = new DbContextOptionsBuilder();
-            optionsBuilder.UseMySql("Database=DummyDatabase", b => b
-                .CharSetBehavior(charSetBehavior)
-                .CharSet(charSet));
+            => CreateOptions(
+                b => b.CharSetBehavior(charSetBehavior)
+                    .CharSet(charSet));
 
-            return optionsBuilder.Options;
-        }
+        public DbContextOptions CreateOptions(Action<MySqlDbContextOptionsBuilder> builder)
+            => new DbContextOptionsBuilder()
+                .UseMySql("Database=DummyDatabase", builder)
+                .Options;
     }
 }


### PR DESCRIPTION
Fixes a bug in the handling of `MySqlSchemaBehavior.Ignore`, that would throw in `MySqlOptions` when used, and adds tests.