### PR TITLE
Add more JSON functions, improve JSON string support and perform cleanup

### DIFF
--- a/src/EFCore.MySql.Json.Microsoft/Extensions/MySqlJsonMicrosoftDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Extensions/MySqlJsonMicrosoftDbContextOptionsBuilderExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        [EditorBrowsable]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static MySqlDbContextOptionsBuilder UseMicrosoftJson(
             [NotNull] this MySqlDbContextOptionsBuilder optionsBuilder, MySqlJsonChangeTrackingOptions options)
         {

--- a/src/EFCore.MySql.Json.Newtonsoft/Extensions/MySqlJsonNewtonsoftDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Extensions/MySqlJsonNewtonsoftDbContextOptionsBuilderExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        [EditorBrowsable]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static MySqlDbContextOptionsBuilder UseNewtonsoftJson(
             [NotNull] this MySqlDbContextOptionsBuilder optionsBuilder, MySqlJsonChangeTrackingOptions options)
         {

--- a/src/EFCore.MySql.Json.Newtonsoft/Storage/Internal/MySqlJsonNewtonsoftTypeMappingSourcePlugin.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Storage/Internal/MySqlJsonNewtonsoftTypeMappingSourcePlugin.cs
@@ -56,7 +56,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Storage.Internal
                 return _jsonStringValueConverter.Value;
             }
 
-            return (ValueConverter)Activator.CreateInstance(typeof(MySqlJsonNewtonsoftPocoValueConverter<>).MakeGenericType(clrType));
+            return (ValueConverter)Activator.CreateInstance(
+                typeof(MySqlJsonNewtonsoftPocoValueConverter<>).MakeGenericType(clrType));
         }
 
         protected override ValueComparer GetValueComparer(Type clrType)

--- a/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
@@ -11,123 +11,141 @@ namespace Microsoft.EntityFrameworkCore
     public static class MySqlJsonDbFunctionsExtensions
     {
         /// <summary>
-        /// Checks if <paramref name="json"/> contains <paramref name="contained"/> as top-level entries.
+        /// Checks if <paramref name="json"/> contains <paramref name="candidate"/>.
         /// </summary>
         /// <param name="_">DbFunctions instance</param>
         /// <param name="json">
-        /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string property mapped to JSON,
-        /// or a user POCO mapped to JSON.
+        /// A JSON column or value. Can be a JSON DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
         /// </param>
-        /// <param name="contained">
-        /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
+        /// <param name="candidate">
+        /// A JSON column or value. Can be a JSON DOM object, a string, or a user POCO mapped to JSON.
         /// </param>
-        /// <remarks>
-        /// This operation is only supported with MySQL <c>json</c>, not <c>json</c>.
-        ///
-        /// See https://www.TODO.org/docs/current/functions-json.html.
-        /// </remarks>
         public static bool JsonContains(
             [CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] object candidate)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContains)));
 
         /// <summary>
-        /// Checks if <paramref name="json"/> contains <paramref name="contained"/> as top-level entries.
+        /// Checks if <paramref name="json"/> contains <paramref name="candidate"/> at a specific <paramref name="path"/>.
         /// </summary>
         /// <param name="_">DbFunctions instance</param>
         /// <param name="json">
-        /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string property mapped to JSON,
-        /// or a user POCO mapped to JSON.
+        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
         /// </param>
-        /// <param name="contained">
-        /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
+        /// <param name="candidate">
+        /// A JSON column or value. Can be a JSON DOM object, a string, or a user POCO mapped to JSON.
         /// </param>
-        /// <remarks>
-        /// This operation is only supported with MySQL <c>json</c>, not <c>json</c>.
-        ///
-        /// See https://www.TODO.org/docs/current/functions-json.html.
-        /// </remarks>
+        /// <param name="path">
+        /// A string containing a valid JSON path (staring with `$`).
+        /// </param>
         public static bool JsonContains(
             [CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] object candidate, [CanBeNull] string path)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContains)));
 
         /// <summary>
-        /// Checks if <paramref name="key"/> exists as a top-level key within <paramref name="json"/>.
+        /// Checks if <paramref name="path"/> exists within <paramref name="json"/>.
         /// </summary>
         /// <param name="_">DbFunctions instance</param>
         /// <param name="json">
-        /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
+        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
         /// </param>
-        /// <param name="key">A key to be checked inside <paramref name="json"/>.</param>
-        /// <remarks>
-        /// This operation is only supported with MySQL <c>json</c>, not <c>json</c>.
-        ///
-        /// See https://www.TODO.org/docs/current/functions-json.html.
-        /// </remarks>
+        /// <param name="path">A path to be checked inside <paramref name="json"/>.</param>
         public static bool JsonContainsPath([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string path)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContainsPath)));
 
         /// <summary>
-        /// Checks if any of the given <paramref name="keys"/> exist as top-level keys within <paramref name="json"/>.
+        /// Checks if any of the given <paramref name="paths"/> exist within <paramref name="json"/>.
         /// </summary>
         /// <param name="_">DbFunctions instance</param>
         /// <param name="json">
-        /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
+        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
         /// </param>
-        /// <param name="keys">A set of keys to be checked inside <paramref name="json"/>.</param>
-        /// <remarks>
-        /// This operation is only supported with MySQL <c>json</c>, not <c>json</c>.
-        ///
-        /// See https://www.TODO.org/docs/current/functions-json.html.
-        /// </remarks>
+        /// <param name="paths">A set of paths to be checked inside <paramref name="json"/>.</param>
         public static bool JsonContainsPathAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] params string[] paths)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContainsPathAny)));
 
         /// <summary>
-        /// Checks if all of the given <paramref name="keys"/> exist as top-level keys within <paramref name="json"/>.
+        /// Checks if all of the given <paramref name="paths"/> exist within <paramref name="json"/>.
         /// </summary>
         /// <param name="_">DbFunctions instance</param>
         /// <param name="json">
-        /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
+        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
         /// </param>
-        /// <param name="keys">A set of keys to be checked inside <paramref name="json"/>.</param>
-        /// <remarks>
-        /// This operation is only supported with MySQL <c>json</c>, not <c>json</c>.
-        ///
-        /// See https://www.TODO.org/docs/current/functions-json.html.
-        /// </remarks>
+        /// <param name="paths">A set of paths to be checked inside <paramref name="json"/>.</param>
         public static bool JsonContainsPathAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] params string[] paths)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContainsPathAll)));
 
         /// <summary>
         /// Returns the type of the outermost JSON value as a text string.
-        /// Possible types are object, array, string, number, boolean, and null.
         /// </summary>
         /// <param name="_">DbFunctions instance</param>
         /// <param name="json">
-        /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
+        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
         /// </param>
-        /// <remarks>
-        /// See https://www.TODO.org/docs/current/functions-json.html.
-        /// </remarks>
+        /// <returns> The JSON type as a text string. </returns>
+        /// <remarks> For possible return values see: https://dev.mysql.com/doc/refman/8.0/en/json-attribute-functions.html#function_json-type </remarks>
         public static string JsonType([CanBeNull] this DbFunctions _, [NotNull] object json)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonType)));
 
-        // JSON_SEARCH(json_doc, one_or_all, search_str[, escape_char[, path] ...])
+        /// <summary>
+        /// Checks if <paramref name="json"/> contains <paramref name="searchString"/>.
+        /// </summary>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="json">
+        /// A JSON column or value. Can be a JSON DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
+        /// </param>
+        /// <param name="searchString">
+        /// The string to search for.
+        /// </param>
         public static bool JsonSearchAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAny)));
 
+        /// <summary>
+        /// Checks if <paramref name="json"/> contains <paramref name="searchString"/> under <paramref name="path"/>.
+        /// </summary>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="json">
+        /// A JSON column or value. Can be a JSON DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
+        /// </param>
+        /// <param name="searchString">
+        /// The string to search for.
+        /// </param>
+        /// <param name="path">
+        /// A string containing a valid JSON path (staring with `$`).
+        /// </param>
         public static bool JsonSearchAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAny)));
 
+        /// <summary>
+        /// Checks if <paramref name="json"/> contains <paramref name="searchString"/> under <paramref name="path"/>.
+        /// </summary>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="json">
+        /// A JSON column or value. Can be a JSON DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
+        /// </param>
+        /// <param name="searchString">
+        /// The string to search for.
+        /// </param>
+        /// <param name="path">
+        /// A string containing a valid JSON path (staring with `$`).
+        /// </param>
+        /// <param name="escapeChar">
+        /// Can be `null`, an empty string or a one character wide string used for escaping characters in <paramref name="searchString"/>.
+        /// </param>
         public static bool JsonSearchAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path, string escapeChar)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAny)));
 
+        // These methods make no sense as long as they only return true or false, because they would return
+        // the same result as JsonSearchAny would.
+
+        [Obsolete("Use 'JsonSearchAny()' instead.")]
         public static bool JsonSearchAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAll)));
 
+        [Obsolete("Use 'JsonSearchAny()' instead.")]
         public static bool JsonSearchAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAll)));
 
+        [Obsolete("Use 'JsonSearchAny()' instead.")]
         public static bool JsonSearchAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path, string escapeChar)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAll)));
     }

--- a/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 
@@ -10,6 +13,200 @@ namespace Microsoft.EntityFrameworkCore
     /// </summary>
     public static class MySqlJsonDbFunctionsExtensions
     {
+        /// <summary>
+        /// Returns the type of the outermost JSON value as a text string.
+        /// </summary>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="json">
+        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
+        /// </param>
+        /// <returns> The JSON type as a text string. </returns>
+        /// <remarks> For possible return values see: https://dev.mysql.com/doc/refman/8.0/en/json-attribute-functions.html#function_json-type </remarks>
+        public static string JsonType([CanBeNull] this DbFunctions _, [NotNull] object json)
+            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonType)));
+
+        /// <summary>
+        /// Quotes a string as a JSON value by wrapping it with double quote characters and escaping interior quote and
+        /// other characters, then returning the result as a `utf8mb4` string. Returns `null` if the argument is `null`.
+        /// </summary>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="value">
+        /// The string value.
+        /// </param>
+        public static string JsonQuote(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] string value)
+        {
+            var quotedString = new StringBuilder(value.Length * 2 + 2);
+            var length = value.Length;
+
+            quotedString.Append('"');
+
+            for (var i = 0; i < length; i++)
+            {
+                quotedString.Append(
+                    value[i] switch
+                    {
+                        '"' => @"\""",
+                        '\b' => @"\b",
+                        '\f' => @"\f",
+                        '\n' => @"\n",
+                        '\r' => @"\r",
+                        '\t' => @"\t",
+                        '\\' => @"\\",
+                        _ => value[i]
+                    });
+            }
+
+            return quotedString
+                .Append('"')
+                .ToString();
+        }
+
+        /// <summary>
+        /// Unquotes JSON value and returns the result as a `utf8mb4` string. Returns `null` if the argument is `null`.
+        /// An error occurs if the value starts and ends with double quotes but is not a valid JSON string literal.
+        /// </summary>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="json">
+        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
+        /// </param>
+        public static string JsonUnquote(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] object json)
+        {
+            if (json is string jsonString)
+            {
+                var length = jsonString.Length;
+
+                if (length < 2 ||
+                    jsonString[0] != '"' ||
+                    jsonString[length - 1] != '"')
+                {
+                    return jsonString;
+                }
+
+                var unquotedString = new StringBuilder(length - 2);
+                var isEscapeSequence = false;
+                var unicodeCharNum = -1;
+                var unicodeChars = new char[4];
+
+                for (var i = 1; i < length - 1; i++)
+                {
+                    var c = jsonString[i];
+
+                    if (isEscapeSequence)
+                    {
+                        if (unicodeCharNum > -1)
+                        {
+                            if (c >= '0' && c <= '9' ||
+                                c >= 'A' && c <= 'F' ||
+                                c >= 'a' && c <= 'f')
+                            {
+                                unicodeChars[unicodeCharNum++] = c;
+
+                                if (unicodeCharNum >= 4)
+                                {
+                                    var utf8Value = ushort.Parse(new string(unicodeChars), NumberStyles.AllowHexSpecifier);
+                                    unquotedString.Append(
+                                        Encoding.UTF8.GetChars(
+                                            utf8Value <= 255
+                                                ? new[] {(byte)utf8Value}
+                                                : BitConverter.GetBytes(utf8Value)));
+                                    unicodeCharNum = -1;
+                                    isEscapeSequence = false;
+                                }
+                            }
+                            else
+                            {
+                                throw new ArgumentException("The JSON string is not well formed.");
+                            }
+                        }
+                        else if (c == '"')
+                        {
+                            unquotedString.Append('\"');
+                            isEscapeSequence = false;
+                        }
+                        else if (c == 'b')
+                        {
+                            unquotedString.Append('\b');
+                            isEscapeSequence = false;
+                        }
+                        else if (c == 'f')
+                        {
+                            unquotedString.Append('\f');
+                            isEscapeSequence = false;
+                        }
+                        else if (c == 'n')
+                        {
+                            unquotedString.Append('\n');
+                            isEscapeSequence = false;
+                        }
+                        else if (c == 'r')
+                        {
+                            unquotedString.Append('\r');
+                            isEscapeSequence = false;
+                        }
+                        else if (c == 't')
+                        {
+                            unquotedString.Append('\t');
+                            isEscapeSequence = false;
+                        }
+                        else if (c == '\\')
+                        {
+                            unquotedString.Append('\\');
+                            isEscapeSequence = false;
+                        }
+                        else if (c == 'u' &&
+                                 unicodeCharNum == -1)
+                        {
+                            unicodeCharNum = 0;
+                        }
+                        else
+                        {
+                            unquotedString.Append(c);
+                            isEscapeSequence = false;
+                        }
+                    }
+                    else if (c == '\\')
+                    {
+                        isEscapeSequence = true;
+                    }
+                    else
+                    {
+                        unquotedString.Append(c);
+                    }
+                }
+
+                if (isEscapeSequence)
+                {
+                    throw new ArgumentException("The JSON string is not well formed.");
+                }
+
+                return unquotedString.ToString();
+            }
+
+            return json.ToString();
+        }
+
+        /// <summary>
+        /// Returns data from a JSON document, selected from the parts of the document matched by the path arguments.
+        /// Returns `null` if any argument is `null` or no paths locate a value in the document. An error occurs if the
+        /// `json` argument is not a valid JSON document or any path argument is not a valid path expression.
+        /// </summary>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="json">
+        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
+        /// </param>
+        /// <param name="paths">
+        /// A set of paths to extract from <paramref name="json"/>.
+        /// </param>
+        public static T JsonExtract<T>(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] object json,
+            [NotNull] params string[] paths)
+            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonExtract)));
+
         /// <summary>
         /// Checks if <paramref name="json"/> contains <paramref name="candidate"/>.
         /// </summary>
@@ -73,18 +270,6 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="paths">A set of paths to be checked inside <paramref name="json"/>.</param>
         public static bool JsonContainsPathAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] params string[] paths)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContainsPathAll)));
-
-        /// <summary>
-        /// Returns the type of the outermost JSON value as a text string.
-        /// </summary>
-        /// <param name="_">DbFunctions instance</param>
-        /// <param name="json">
-        /// A JSON column or value. Can be a DOM object, a string property mapped to JSON, or a user POCO mapped to JSON.
-        /// </param>
-        /// <returns> The JSON type as a text string. </returns>
-        /// <remarks> For possible return values see: https://dev.mysql.com/doc/refman/8.0/en/json-attribute-functions.html#function_json-type </remarks>
-        public static string JsonType([CanBeNull] this DbFunctions _, [NotNull] object json)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonType)));
 
         /// <summary>
         /// Checks if <paramref name="json"/> contains <paramref name="searchString"/>.

--- a/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
@@ -13,6 +15,21 @@ namespace Microsoft.EntityFrameworkCore
     /// </summary>
     public static class MySqlJsonDbFunctionsExtensions
     {
+        /// <summary>
+        /// Explicitly converts <paramref name="value"/> to JSON.
+        /// </summary>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="value">
+        /// The string to convert to JSON.
+        /// </param>
+        /// <returns> The JSON value. </returns>
+        /// <remarks>
+        /// Translates <paramref name="value"/> to `CAST(value as json)` where appropriate on server implementations
+        /// that support the `json` store type.
+        /// </remarks>
+        public static MySqlJsonString AsJson([CanBeNull] this DbFunctions _, [NotNull] string value)
+            => value;
+
         /// <summary>
         /// Returns the type of the outermost JSON value as a text string.
         /// </summary>

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonDbFunctionsTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonDbFunctionsTranslator.cs
@@ -62,6 +62,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 
             var result = method.Name switch
             {
+                nameof(MySqlJsonDbFunctionsExtensions.AsJson)
+                    => _sqlExpressionFactory.ApplyTypeMapping(
+                        args[0],
+                        _sqlExpressionFactory.FindMapping(method.ReturnType, "json")),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonType)
                     => _sqlExpressionFactory.Function(
                         "JSON_TYPE",

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonDbFunctionsTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonDbFunctionsTranslator.cs
@@ -45,84 +45,112 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                 // This means they come wrapped in a convert node, which we need to remove.
                 // Convert nodes may also come from wrapping JsonTraversalExpressions generated through POCO traversal.
                 .Select(removeConvert)
+                // CHECK: Either just not doing this it all is fine, or not applying it to JsonQuote and JsonUnquote
+                // (as already implemented below) is needed. An alternative would be to move the check into the local
+                // json() function.
+                //
                 // If a function is invoked over a JSON traversal expression, that expression may come with
                 // returnText: true (i.e. operator ->> and not ->). Since the functions below require a json object and
                 // not text, we transform it.
-                .Select(a => a is MySqlJsonTraversalExpression traversal ? withReturnsText(traversal, false) : a)
+                // .Select(
+                //     a => a is MySqlJsonTraversalExpression traversal &&
+                //          method.Name != nameof(MySqlJsonDbFunctionsExtensions.JsonQuote) &&
+                //          method.Name != nameof(MySqlJsonDbFunctionsExtensions.JsonUnquote)
+                //         ? withReturnsText(traversal, false)
+                //         : a)
                 .ToArray();
-
-            if (!args.Any(a => a.TypeMapping is MySqlJsonTypeMapping || a is MySqlJsonTraversalExpression))
-            {
-                throw new InvalidOperationException("The EF JSON methods require a JSON parameter but none was found.");
-            }
 
             var result = method.Name switch
             {
                 nameof(MySqlJsonDbFunctionsExtensions.JsonType)
-                => _sqlExpressionFactory.Function(
-                    "JSON_TYPE",
-                    new[] {args[0]},
-                    typeof(string)),
+                    => _sqlExpressionFactory.Function(
+                        "JSON_TYPE",
+                        new[] {json(args[0])},
+                        typeof(string)),
+                nameof(MySqlJsonDbFunctionsExtensions.JsonQuote)
+                    => _sqlExpressionFactory.Function(
+                        "JSON_QUOTE",
+                        new[] {args[0]},
+                        method.ReturnType),
+                nameof(MySqlJsonDbFunctionsExtensions.JsonUnquote)
+                    => _sqlExpressionFactory.Function(
+                        "JSON_UNQUOTE",
+                        new[] {args[0]},
+                        method.ReturnType),
+                nameof(MySqlJsonDbFunctionsExtensions.JsonExtract)
+                    => _sqlExpressionFactory.Function(
+                        "JSON_EXTRACT",
+                        Array.Empty<SqlExpression>()
+                            .Append(json(args[0]))
+                            .Concat(deconstructParamsArray(args[1])),
+                        method.ReturnType,
+                        _sqlExpressionFactory.FindMapping(method.ReturnType, "json")),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonContains)
-                => _sqlExpressionFactory.Function(
-                    "JSON_CONTAINS",
-                    args.Length >= 3
-                        ? new[] {json(args[0]), args[1], args[2]}
-                        : new[] {json(args[0]), args[1]},
-                    typeof(bool)),
+                    => _sqlExpressionFactory.Function(
+                        "JSON_CONTAINS",
+                        args.Length >= 3
+                            ? new[] {json(args[0]), args[1], args[2]}
+                            : new[] {json(args[0]), args[1]},
+                        typeof(bool)),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonContainsPath)
-                => _sqlExpressionFactory.Function(
-                    "JSON_CONTAINS_PATH",
-                    new[] {json(args[0]), _sqlExpressionFactory.Constant("one"), args[1]},
-                    typeof(bool)),
+                    => _sqlExpressionFactory.Function(
+                        "JSON_CONTAINS_PATH",
+                        new[] {json(args[0]), _sqlExpressionFactory.Constant("one"), args[1]},
+                        typeof(bool)),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonContainsPathAny)
-                => _sqlExpressionFactory.Function(
-                    "JSON_CONTAINS_PATH",
-                    Array.Empty<SqlExpression>()
-                        .Append(json(args[0]))
-                        .Append(_sqlExpressionFactory.Constant("one"))
-                        .Concat(deconstructParamsArray(args[1])),
-                    typeof(bool)),
-                nameof(MySqlJsonDbFunctionsExtensions.JsonContainsPathAll)
-                => _sqlExpressionFactory.Function(
-                    "JSON_CONTAINS_PATH",
-                    Array.Empty<SqlExpression>()
-                        .Append(json(args[0]))
-                        .Append(_sqlExpressionFactory.Constant("all"))
-                        .Concat(deconstructParamsArray(args[1])),
-                    typeof(bool)),
-                nameof(MySqlJsonDbFunctionsExtensions.JsonSearchAny)
-                => _sqlExpressionFactory.IsNotNull(
-                    _sqlExpressionFactory.Function(
-                        "JSON_SEARCH",
+                    => _sqlExpressionFactory.Function(
+                        "JSON_CONTAINS_PATH",
                         Array.Empty<SqlExpression>()
                             .Append(json(args[0]))
                             .Append(_sqlExpressionFactory.Constant("one"))
-                            .Append(args[1])
-                            .AppendIfTrue(args.Length >= 3, () => args.Length >= 4
-                                ? args[3]
-                                : _sqlExpressionFactory.Constant(null, RelationalTypeMapping.NullMapping))
-                            .AppendIfTrue(args.Length >= 3, () => args[2]),
-                        typeof(bool))),
-                nameof(MySqlJsonDbFunctionsExtensions.JsonSearchAll)
-                => _sqlExpressionFactory.IsNotNull(
-                    _sqlExpressionFactory.Function(
-                        "JSON_SEARCH",
+                            .Concat(deconstructParamsArray(args[1])),
+                        typeof(bool)),
+                nameof(MySqlJsonDbFunctionsExtensions.JsonContainsPathAll)
+                    => _sqlExpressionFactory.Function(
+                        "JSON_CONTAINS_PATH",
                         Array.Empty<SqlExpression>()
                             .Append(json(args[0]))
                             .Append(_sqlExpressionFactory.Constant("all"))
-                            .Append(args[1])
-                            .AppendIfTrue(args.Length >= 3, () => args.Length >= 4
-                                ? args[3]
-                                : _sqlExpressionFactory.Constant(null, RelationalTypeMapping.NullMapping))
-                            .AppendIfTrue(args.Length >= 3, () => args[2]),
-                        typeof(bool))) as SqlExpression,
+                            .Concat(deconstructParamsArray(args[1])),
+                        typeof(bool)),
+                nameof(MySqlJsonDbFunctionsExtensions.JsonSearchAny)
+                    => _sqlExpressionFactory.IsNotNull(
+                        _sqlExpressionFactory.Function(
+                            "JSON_SEARCH",
+                            Array.Empty<SqlExpression>()
+                                .Append(json(args[0]))
+                                .Append(_sqlExpressionFactory.Constant("one"))
+                                .Append(args[1])
+                                .AppendIfTrue(args.Length >= 3, () => args.Length >= 4
+                                    ? args[3]
+                                    : _sqlExpressionFactory.Constant(null, RelationalTypeMapping.NullMapping))
+                                .AppendIfTrue(args.Length >= 3, () => args[2]),
+                            typeof(bool))),
+                nameof(MySqlJsonDbFunctionsExtensions.JsonSearchAll)
+                    => _sqlExpressionFactory.IsNotNull(
+                        _sqlExpressionFactory.Function(
+                            "JSON_SEARCH",
+                            Array.Empty<SqlExpression>()
+                                .Append(json(args[0]))
+                                .Append(_sqlExpressionFactory.Constant("all"))
+                                .Append(args[1])
+                                .AppendIfTrue(args.Length >= 3, () => args.Length >= 4
+                                    ? args[3]
+                                    : _sqlExpressionFactory.Constant(null, RelationalTypeMapping.NullMapping))
+                                .AppendIfTrue(args.Length >= 3, () => args[2]),
+                            typeof(bool))) as SqlExpression,
                 _ => null
             };
 
             return result;
 
-            SqlExpression json(SqlExpression e) => _sqlExpressionFactory.ApplyTypeMapping(e, _sqlExpressionFactory.FindMapping(e.Type, "json"));
+            SqlExpression json(SqlExpression e) => _sqlExpressionFactory.ApplyTypeMapping(ensureJson(e), _sqlExpressionFactory.FindMapping(e.Type, "json"));
+
+            static SqlExpression ensureJson(SqlExpression e)
+                => e.TypeMapping is MySqlJsonTypeMapping ||
+                   e is MySqlJsonTraversalExpression
+                    ? e
+                    : throw new InvalidOperationException("The JSON method requires a JSON parameter but none was found.");
 
             static SqlExpression removeConvert(SqlExpression e)
             {
@@ -135,12 +163,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                 return e;
             }
 
-            MySqlJsonTraversalExpression withReturnsText(MySqlJsonTraversalExpression traversal, bool returnsText)
-                => traversal.ReturnsText == returnsText
-                    ? traversal
-                    : returnsText
-                        ? traversal.Clone(returnsText, typeof(string), _stringTypeMapping)
-                        : traversal.Clone(returnsText, traversal.Type, traversal.Expression.TypeMapping);
+            // MySqlJsonTraversalExpression withReturnsText(MySqlJsonTraversalExpression traversal, bool returnsText)
+            //     => traversal.ReturnsText == returnsText
+            //         ? traversal
+            //         : returnsText
+            //             ? traversal.Clone(returnsText, typeof(string), _stringTypeMapping)
+            //             : traversal.Clone(returnsText, traversal.Type, traversal.Expression.TypeMapping);
 
             IEnumerable<SqlExpression> deconstructParamsArray(SqlExpression paramsArray)
             {

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlJsonParameterExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlJsonParameterExpressionVisitor.cs
@@ -27,24 +27,22 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
 
         protected virtual SqlExpression VisitParameter(SqlParameterExpression sqlParameterExpression)
         {
-            SqlExpression expression = sqlParameterExpression;
-
             if (sqlParameterExpression.TypeMapping is MySqlJsonTypeMapping)
             {
-                var typeMapping = _sqlExpressionFactory.FindMapping(expression.Type, "json");
+                var typeMapping = _sqlExpressionFactory.FindMapping(sqlParameterExpression.Type, "json");
 
                 // MySQL has a real JSON datatype, and string parameters need to be converted to it.
                 // MariaDB defines the JSON datatype just as a synonym for LONGTEXT.
                 if (!_options.ServerVersion.SupportsJsonDataTypeEmulation)
                 {
-                    expression = _sqlExpressionFactory.Convert(
+                    return _sqlExpressionFactory.Convert(
                         sqlParameterExpression,
-                        sqlParameterExpression.Type,
-                        typeMapping);
+                        typeMapping.ClrType, // will be typeof(string) when `sqlParameterExpression.Type`
+                        typeMapping);        // is typeof(MySqlJsonString)
                 }
             }
 
-            return expression;
+            return sqlParameterExpression;
         }
     }
 }

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
@@ -15,7 +13,6 @@ using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
 {
@@ -338,10 +335,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             // An exception is the JSON data type, when used in conjunction with a parameter (like `JsonDocument`).
             // JSON parameters like that will be serialized to string and supplied as a string parameter to MySQL
             // (at least this seems to be the case currently with MySqlConnector). To make assignments and comparisons
-            // between JSON columns and JSON parameters (supplied as string) work, the string needs to be explicitly
-            // converted to JSON.
-            if (!castMapping.Equals(sqlUnaryExpression.Operand.TypeMapping.StoreType, StringComparison.OrdinalIgnoreCase) ||
-                castMapping == "json")
+            // between JSON columns and JSON parameters (supplied as string) work on server implementations that support
+            // a JSON store type, the string needs to be explicitly converted to JSON.
+            if (castMapping == "json" && !_options.ServerVersion.SupportsJsonDataTypeEmulation ||
+                !castMapping.Equals(sqlUnaryExpression.Operand.TypeMapping.StoreType, StringComparison.OrdinalIgnoreCase))
             {
                 if (useDecimalToDoubleWorkaround)
                 {

--- a/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMappingSourcePlugin.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMappingSourcePlugin.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -26,6 +27,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         {
             var clrType = mappingInfo.ClrType;
             var storeTypeName = mappingInfo.StoreTypeName;
+
+            if (clrType == typeof(MySqlJsonString))
+            {
+                clrType = typeof(string);
+                storeTypeName = "json";
+            }
 
             if (storeTypeName != null)
             {

--- a/src/EFCore.MySql/Storage/MySqlJsonString.cs
+++ b/src/EFCore.MySql/Storage/MySqlJsonString.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// This class can be used to represent a string that contains valid JSON data. When used in database queries
+    /// against server implementations that support the `JSON` store type, a `CAST(mySqlJsonString as json)` clause will
+    /// be generated where necessary.
+    /// To mark a string as containing JSON data, just cast the string to `MySqlJsonString`.
+    /// </summary>
+    public sealed class MySqlJsonString : IConvertible
+    {
+        private readonly string _json;
+
+        private MySqlJsonString(string json)
+            => _json = json;
+
+        public static implicit operator string(MySqlJsonString jsonStringObject)
+            => jsonStringObject._json;
+
+        public static implicit operator MySqlJsonString(string stringObject)
+            => new MySqlJsonString(stringObject);
+
+        public static bool operator ==(MySqlJsonString left, MySqlJsonString right)
+            => left?.Equals(right) ?? ReferenceEquals(right, null);
+
+        public static bool operator !=(MySqlJsonString left, MySqlJsonString right)
+            => !(left == right);
+
+        public static bool operator ==(MySqlJsonString left, string right)
+            => left?.Equals(right) ?? ReferenceEquals(right, null);
+
+        public static bool operator !=(MySqlJsonString left, string right)
+            => !(left == right);
+
+        private bool Equals(MySqlJsonString other)
+            => _json == other._json;
+
+        private bool Equals(string other)
+            => _json == other;
+
+        public override bool Equals(object obj)
+            => ReferenceEquals(this, obj) ||
+               obj is MySqlJsonString other && Equals(other) ||
+               obj is string otherString && Equals(otherString);
+
+        public override int GetHashCode()
+            => HashCode.Combine(_json);
+
+        public TypeCode GetTypeCode()
+            => TypeCode.Object;
+
+        public bool ToBoolean(IFormatProvider provider)
+            => Convert.ToBoolean(_json, provider);
+
+        public byte ToByte(IFormatProvider provider)
+            => Convert.ToByte(_json, provider);
+
+        public char ToChar(IFormatProvider provider)
+            => Convert.ToChar(_json, provider);
+
+        public DateTime ToDateTime(IFormatProvider provider)
+            => Convert.ToDateTime(_json, provider);
+
+        public decimal ToDecimal(IFormatProvider provider)
+            => Convert.ToDecimal(_json, provider);
+
+        public double ToDouble(IFormatProvider provider)
+            => Convert.ToDouble(_json, provider);
+
+        public short ToInt16(IFormatProvider provider)
+            => Convert.ToInt16(_json, provider);
+
+        public int ToInt32(IFormatProvider provider)
+            => Convert.ToInt32(_json, provider);
+
+        public long ToInt64(IFormatProvider provider)
+            => Convert.ToInt64(_json, provider);
+
+        public sbyte ToSByte(IFormatProvider provider)
+            => Convert.ToSByte(_json, provider);
+
+        public float ToSingle(IFormatProvider provider)
+            => Convert.ToSingle(_json, provider);
+
+        public string ToString(IFormatProvider provider)
+            => Convert.ToString(_json, provider);
+
+        public object ToType(Type conversionType, IFormatProvider provider)
+            => Convert.ChangeType(_json, conversionType, provider);
+
+        public ushort ToUInt16(IFormatProvider provider)
+            => Convert.ToUInt16(_json, provider);
+
+        public uint ToUInt32(IFormatProvider provider)
+            => Convert.ToUInt32(_json, provider);
+
+        public ulong ToUInt64(IFormatProvider provider)
+            => Convert.ToUInt64(_json, provider);
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/BuiltInDataTypesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BuiltInDataTypesMySqlTest.cs
@@ -288,7 +288,7 @@ WHERE `m`.`TimeSpanAsTime` = @__timeSpan_0",
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.IntAsYear == param62));
 
                 var param63 = @"{""a"": ""b""}";
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsJson == param63));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsJson == (MySqlJsonString)param63));
             }
         }
 
@@ -483,7 +483,7 @@ WHERE `m`.`TimeSpanAsTime` = @__timeSpan_0",
 @p25='128'
 @p26='79'
 @p27='Your' (Nullable = false) (Size = 10) (DbType = StringFixedLength)
-@p28='{""a"": ""b""}' (Nullable = false)
+@p28='{""a"": ""b""}' (Nullable = false) (Size = 4000)
 @p29='arm' (Nullable = false) (Size = 4000)
 @p30='anyone!' (Nullable = false) (Size = 4000)
 @p31='strong' (Nullable = false) (Size = 10) (DbType = StringFixedLength)
@@ -652,7 +652,7 @@ WHERE `m`.`TimeSpanAsTime` = @__timeSpan_0",
 @p25='-128' (Nullable = true)
 @p26='79' (Nullable = true)
 @p27='C' (Size = 20) (DbType = StringFixedLength)
-@p28='{""a"": ""b""}'
+@p28='{""a"": ""b""}' (Size = 4000)
 @p29='anyone!' (Size = 4000)
 @p30='Your' (Size = 20) (DbType = StringFixedLength)
 @p31='Gumball Rules OK!' (Size = 4000)
@@ -816,7 +816,7 @@ WHERE `m`.`TimeSpanAsTime` = @__timeSpan_0",
 @p25=NULL (DbType = SByte)
 @p26=NULL (DbType = Int16)
 @p27=NULL (Size = 20) (DbType = StringFixedLength)
-@p28=NULL
+@p28=NULL (Size = 4000)
 @p29=NULL (Size = 4000)
 @p30=NULL (Size = 20) (DbType = StringFixedLength)
 @p31=NULL (Size = 4000)

--- a/test/EFCore.MySql.FunctionalTests/Query/DbFunctionsMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/DbFunctionsMySqlTest.MySql.cs
@@ -272,5 +272,39 @@ WHERE UNHEX(HEX(`o`.`CustomerID`)) = 'VINET'");
 
             Assert.Equal("VINET", unhex);
         }
+
+        [Fact]
+        public void JsonQuote_client_eval()
+        {
+            var quoted = EF.Functions.JsonQuote("first\\\"second\"\tthird");
+
+            Assert.Equal(@"""first\\\""second\""\tthird""", quoted);
+        }
+
+        [Fact]
+        public void JsonUnquote_client_eval()
+        {
+            var unquoted = EF.Functions.JsonUnquote(@"""first\\\""second\""\tthird""");
+
+            Assert.Equal("first\\\"second\"\tthird", unquoted);
+        }
+
+        [Fact]
+        public void JsonUnquote_client_eval_unicode()
+        {
+            var unquoted = EF.Functions.JsonUnquote(@"""a\u003da""");
+
+            Assert.Equal("a=a", unquoted);
+        }
+
+        [Fact]
+        public void JsonUnquote_client_eval_throws()
+        {
+            Assert.Equal(
+                "The JSON string is not well formed.",
+                Assert.Throws<ArgumentException>(
+                        () => EF.Functions.JsonUnquote(@"""a\u3da"""))
+                    .Message);
+        }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonMicrosoftDomQueryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonMicrosoftDomQueryTest.cs
@@ -79,7 +79,7 @@ FROM `JsonEntities` AS `j`
 WHERE `j`.`Id` = @__p_0
 LIMIT 1",
                 //
-                $@"{InsertJsonDocument(@"@__expected_0='{""ID"":""00000000-0000-0000-0000-000000000000"",""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23.1,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d"",""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")}
+                $@"{InsertJsonDocument(@"@__expected_0='{""ID"":""00000000-0000-0000-0000-000000000000"",""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23.1,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d"",""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Size = 4000)
 
 SELECT `j`.`Id`, `j`.`CustomerDocument`, `j`.`CustomerElement`
 FROM `JsonEntities` AS `j`
@@ -103,7 +103,7 @@ FROM `JsonEntities` AS `j`
 WHERE `j`.`Id` = @__p_0
 LIMIT 1",
                 //
-                $@"{InsertJsonDocument(@"@__expected_0='{""ID"":""00000000-0000-0000-0000-000000000000"",""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23.1,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d"",""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Nullable = false)
+                $@"{InsertJsonDocument(@"@__expected_0='{""ID"":""00000000-0000-0000-0000-000000000000"",""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23.1,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d"",""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Nullable = false) (Size = 4000)
 
 SELECT `j`.`Id`, `j`.`CustomerDocument`, `j`.`CustomerElement`
 FROM `JsonEntities` AS `j`
@@ -335,17 +335,29 @@ WHERE JSON_UNQUOTE(JSON_QUOTE(JSON_UNQUOTE(JSON_EXTRACT(`j`.`CustomerElement`, '
         {
             using var ctx = CreateContext();
 
-            var name = @"""Joe""";
             var count = ctx.JsonEntities.Count(e =>
-                EF.Functions.JsonExtract<string>(e.CustomerElement, "$.Name") == name);
+                EF.Functions.JsonExtract<string>(e.CustomerElement, "$.Name") == @"Joe");
 
             Assert.Equal(1, count);
             AssertSql(
-                $@"@__name_1='""Joe""'
-
-SELECT COUNT(*)
+                $@"SELECT COUNT(*)
 FROM `JsonEntities` AS `j`
-WHERE JSON_EXTRACT(`j`.`CustomerElement`, '$.Name') = {InsertJsonConvert("@__name_1")}");
+WHERE JSON_EXTRACT(`j`.`CustomerElement`, '$.Name') = 'Joe'");
+        }
+
+        [Fact]
+        public void JsonExtract_equals_operands_flipped()
+        {
+            using var ctx = CreateContext();
+
+            var count = ctx.JsonEntities.Count(e =>
+                @"Joe" == EF.Functions.JsonExtract<string>(e.CustomerElement, "$.Name"));
+
+            Assert.Equal(1, count);
+            AssertSql(
+                $@"SELECT COUNT(*)
+FROM `JsonEntities` AS `j`
+WHERE 'Joe' = JSON_EXTRACT(`j`.`CustomerElement`, '$.Name')");
         }
 
         [Fact]
@@ -376,7 +388,7 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(`j`.`CustomerElement`, '$.Name')) = @__name_1");
 
             Assert.Equal(1, count);
             AssertSql(
-                $@"@__element_1='{{""Name"":""Joe"",""Age"":25}}' (Nullable = false)
+                $@"@__element_1='{{""Name"":""Joe"",""Age"":25}}' (Nullable = false) (Size = 4000)
 
 SELECT COUNT(*)
 FROM `JsonEntities` AS `j`

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonMicrosoftDomQueryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonMicrosoftDomQueryTest.cs
@@ -420,7 +420,9 @@ LIMIT 2");
         public void JsonSearchAll()
         {
             using var ctx = CreateContext();
+#pragma warning disable 618
             var count = ctx.JsonEntities.Count(e => EF.Functions.JsonSearchAll(e.CustomerElement, "%o%"));
+#pragma warning restore 618
 
             Assert.Equal(3, count);
             AssertSql(
@@ -433,7 +435,9 @@ WHERE JSON_SEARCH(`j`.`CustomerElement`, 'all', '%o%') IS NOT NULL");
         public void JsonSearchAll_with_path()
         {
             using var ctx = CreateContext();
+#pragma warning disable 618
             var count = ctx.JsonEntities.Count(e => EF.Functions.JsonSearchAll(e.CustomerElement, "%o%", "$.Name"));
+#pragma warning restore 618
 
             Assert.Equal(2, count);
             AssertSql(

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonMicrosoftDomQueryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonMicrosoftDomQueryTest.cs
@@ -316,6 +316,57 @@ LIMIT 2");
         #region Functions
 
         [Fact]
+        public void JsonQuote_JsonUnquote()
+        {
+            using var ctx = CreateContext();
+
+            var count = ctx.JsonEntities.Count(e =>
+                EF.Functions.JsonUnquote(EF.Functions.JsonQuote(e.CustomerElement.GetProperty("Name").GetString())) == @"Joe");
+
+            Assert.Equal(1, count);
+            AssertSql(
+                $@"SELECT COUNT(*)
+FROM `JsonEntities` AS `j`
+WHERE JSON_UNQUOTE(JSON_QUOTE(JSON_UNQUOTE(JSON_EXTRACT(`j`.`CustomerElement`, '$.Name')))) = 'Joe'");
+        }
+
+        [Fact]
+        public void JsonExtract()
+        {
+            using var ctx = CreateContext();
+
+            var name = @"""Joe""";
+            var count = ctx.JsonEntities.Count(e =>
+                EF.Functions.JsonExtract<string>(e.CustomerElement, "$.Name") == name);
+
+            Assert.Equal(1, count);
+            AssertSql(
+                $@"@__name_1='""Joe""'
+
+SELECT COUNT(*)
+FROM `JsonEntities` AS `j`
+WHERE JSON_EXTRACT(`j`.`CustomerElement`, '$.Name') = {InsertJsonConvert("@__name_1")}");
+        }
+
+        [Fact]
+        public void JsonExtract_JsonUnquote()
+        {
+            using var ctx = CreateContext();
+
+            var name = @"Joe";
+            var count = ctx.JsonEntities.Count(e =>
+                EF.Functions.JsonUnquote(EF.Functions.JsonExtract<string>(e.CustomerElement, "$.Name")) == name);
+
+            Assert.Equal(1, count);
+            AssertSql(
+                $@"@__name_1='Joe' (Size = 4000)
+
+SELECT COUNT(*)
+FROM `JsonEntities` AS `j`
+WHERE JSON_UNQUOTE(JSON_EXTRACT(`j`.`CustomerElement`, '$.Name')) = @__name_1");
+        }
+
+        [Fact]
         public void JsonContains_with_json_element()
         {
             using var ctx = CreateContext();

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonMicrosoftPocoQueryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonMicrosoftPocoQueryTest.cs
@@ -27,7 +27,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 
             Assert.Equal(1, count);
             AssertSql(
-                $@"@__element_1='{{""Name"":""Joe"",""Age"":25}}' (Nullable = false)
+                $@"@__element_1='{{""Name"":""Joe"",""Age"":25}}' (Nullable = false) (Size = 4000)
 
 SELECT COUNT(*)
 FROM `JsonEntities` AS `j`

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonNewtonsoftDomQueryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonNewtonsoftDomQueryTest.cs
@@ -448,7 +448,9 @@ LIMIT 2");
         public void JsonSearchAll()
         {
             using var ctx = CreateContext();
+#pragma warning disable 618
             var count = ctx.JsonEntities.Count(e => EF.Functions.JsonSearchAll(e.CustomerJToken, "%o%"));
+#pragma warning restore 618
 
             Assert.Equal(3, count);
             AssertSql(
@@ -461,7 +463,9 @@ WHERE JSON_SEARCH(`j`.`CustomerJToken`, 'all', '%o%') IS NOT NULL");
         public void JsonSearchAll_with_path()
         {
             using var ctx = CreateContext();
+#pragma warning disable 618
             var count = ctx.JsonEntities.Count(e => EF.Functions.JsonSearchAll(e.CustomerJToken, "%o%", "$.Name"));
+#pragma warning restore 618
 
             Assert.Equal(2, count);
             AssertSql(

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonNewtonsoftDomQueryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonNewtonsoftDomQueryTest.cs
@@ -343,6 +343,57 @@ LIMIT 2");
 
          #region Functions
 
+         [Fact]
+         public void JsonQuote_JsonUnquote()
+         {
+             using var ctx = CreateContext();
+
+             var count = ctx.JsonEntities.Count(e =>
+                 EF.Functions.JsonUnquote(EF.Functions.JsonQuote(e.CustomerJToken["Name"].Value<string>())) == @"Joe");
+
+             Assert.Equal(1, count);
+             AssertSql(
+                 $@"SELECT COUNT(*)
+FROM `JsonEntities` AS `j`
+WHERE JSON_UNQUOTE(JSON_QUOTE(JSON_UNQUOTE(JSON_EXTRACT(`j`.`CustomerJToken`, '$.Name')))) = 'Joe'");
+         }
+
+         [Fact]
+         public void JsonExtract()
+         {
+             using var ctx = CreateContext();
+
+             var name = @"""Joe""";
+             var count = ctx.JsonEntities.Count(e =>
+                 EF.Functions.JsonExtract<string>(e.CustomerJToken, "$.Name") == name);
+
+             Assert.Equal(1, count);
+             AssertSql(
+                 $@"@__name_1='""Joe""'
+
+SELECT COUNT(*)
+FROM `JsonEntities` AS `j`
+WHERE JSON_EXTRACT(`j`.`CustomerJToken`, '$.Name') = {InsertJsonConvert("@__name_1")}");
+         }
+
+         [Fact]
+         public void JsonExtract_JsonUnquote()
+         {
+             using var ctx = CreateContext();
+
+             var name = @"Joe";
+             var count = ctx.JsonEntities.Count(e =>
+                 EF.Functions.JsonUnquote(EF.Functions.JsonExtract<string>(e.CustomerJToken, "$.Name")) == name);
+
+             Assert.Equal(1, count);
+             AssertSql(
+                 $@"@__name_1='Joe' (Size = 4000)
+
+SELECT COUNT(*)
+FROM `JsonEntities` AS `j`
+WHERE JSON_UNQUOTE(JSON_EXTRACT(`j`.`CustomerJToken`, '$.Name')) = @__name_1");
+         }
+
         [Fact]
         public void JsonContains_with_json_element()
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonNewtonsoftDomQueryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonNewtonsoftDomQueryTest.cs
@@ -79,7 +79,7 @@ FROM `JsonEntities` AS `j`
 WHERE `j`.`Id` = @__p_0
 LIMIT 1",
                 //
-                $@"{InsertJsonDocument(@"@__expected_0='{""ID"":""00000000-0000-0000-0000-000000000000"",""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23.1,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d"",""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")}
+                $@"{InsertJsonDocument(@"@__expected_0='{""ID"":""00000000-0000-0000-0000-000000000000"",""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23.1,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d"",""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Size = 4000)
 
 SELECT `j`.`Id`, `j`.`CustomerJObject`, `j`.`CustomerJToken`
 FROM `JsonEntities` AS `j`
@@ -103,7 +103,7 @@ FROM `JsonEntities` AS `j`
 WHERE `j`.`Id` = @__p_0
 LIMIT 1",
                 //
-                $@"{InsertJsonDocument(@"@__expected_0='{""ID"":""00000000-0000-0000-0000-000000000000"",""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23.1,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d"",""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")}
+                $@"{InsertJsonDocument(@"@__expected_0='{""ID"":""00000000-0000-0000-0000-000000000000"",""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23.1,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""SomeNullableInt"":20,""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d"",""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Size = 4000)
 
 SELECT `j`.`Id`, `j`.`CustomerJObject`, `j`.`CustomerJToken`
 FROM `JsonEntities` AS `j`
@@ -363,17 +363,29 @@ WHERE JSON_UNQUOTE(JSON_QUOTE(JSON_UNQUOTE(JSON_EXTRACT(`j`.`CustomerJToken`, '$
          {
              using var ctx = CreateContext();
 
-             var name = @"""Joe""";
              var count = ctx.JsonEntities.Count(e =>
-                 EF.Functions.JsonExtract<string>(e.CustomerJToken, "$.Name") == name);
+                 EF.Functions.JsonExtract<string>(e.CustomerJToken, "$.Name") == @"Joe");
 
              Assert.Equal(1, count);
              AssertSql(
-                 $@"@__name_1='""Joe""'
-
-SELECT COUNT(*)
+                 $@"SELECT COUNT(*)
 FROM `JsonEntities` AS `j`
-WHERE JSON_EXTRACT(`j`.`CustomerJToken`, '$.Name') = {InsertJsonConvert("@__name_1")}");
+WHERE JSON_EXTRACT(`j`.`CustomerJToken`, '$.Name') = 'Joe'");
+         }
+
+         [Fact]
+         public void JsonExtract_equals_operands_flipped()
+         {
+             using var ctx = CreateContext();
+
+             var count = ctx.JsonEntities.Count(e =>
+                 @"Joe" == EF.Functions.JsonExtract<string>(e.CustomerJToken, "$.Name"));
+
+             Assert.Equal(1, count);
+             AssertSql(
+                 $@"SELECT COUNT(*)
+FROM `JsonEntities` AS `j`
+WHERE 'Joe' = JSON_EXTRACT(`j`.`CustomerJToken`, '$.Name')");
          }
 
          [Fact]
@@ -404,7 +416,7 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(`j`.`CustomerJToken`, '$.Name')) = @__name_1");
 
             Assert.Equal(1, count);
             AssertSql(
-                $@"@__element_1='{{""Name"":""Joe"",""Age"":25}}'
+                $@"@__element_1='{{""Name"":""Joe"",""Age"":25}}' (Size = 4000)
 
 SELECT COUNT(*)
 FROM `JsonEntities` AS `j`

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonNewtonsoftPocoQueryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonNewtonsoftPocoQueryTest.cs
@@ -27,7 +27,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 
             Assert.Equal(1, count);
             AssertSql(
-                $@"@__element_1='{{""Name"":""Joe"",""Age"":25}}'
+                $@"@__element_1='{{""Name"":""Joe"",""Age"":25}}' (Size = 4000)
 
 SELECT COUNT(*)
 FROM `JsonEntities` AS `j`

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonPocoQueryTestBase.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonPocoQueryTestBase.cs
@@ -68,7 +68,7 @@ FROM `JsonEntities` AS `j`
 WHERE `j`.`Id` = @__p_0
 LIMIT 1",
                 //
-                $@"@__expected_0='{{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""is_vip"":false,""Statistics"":{{""Visits"":4,""Purchases"":3,""Nested"":{{""SomeProperty"":10,""SomeNullableInt"":20,""IntArray"":[3,4],""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""}}}},""Orders"":[{{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01T00:00:00""}},{{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10T00:00:00""}}]}}'
+                $@"@__expected_0='{{""Name"":""Joe"",""Age"":25,""ID"":""00000000-0000-0000-0000-000000000000"",""is_vip"":false,""Statistics"":{{""Visits"":4,""Purchases"":3,""Nested"":{{""SomeProperty"":10,""SomeNullableInt"":20,""IntArray"":[3,4],""SomeNullableGuid"":""d5f2685d-e5c4-47e5-97aa-d0266154eb2d""}}}},""Orders"":[{{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01T00:00:00""}},{{""Price"":23.1,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10T00:00:00""}}]}}' (Size = 4000)
 
 SELECT `j`.`Id`, `j`.`Customer`, `j`.`ToplevelArray`
 FROM `JsonEntities` AS `j`
@@ -327,17 +327,17 @@ WHERE JSON_UNQUOTE(JSON_QUOTE(JSON_UNQUOTE(JSON_EXTRACT(`j`.`Customer`, '$.Name'
         {
             using var ctx = CreateContext();
 
-            var name = @"""Joe""";
+            var name = @"Joe";
             var count = ctx.JsonEntities.Count(e =>
                 EF.Functions.JsonExtract<string>(e.Customer, "$.Name") == name);
 
             Assert.Equal(1, count);
             AssertSql(
-                $@"@__name_1='""Joe""'
+                $@"@__name_1='Joe' (Size = 4000)
 
 SELECT COUNT(*)
 FROM `JsonEntities` AS `j`
-WHERE JSON_EXTRACT(`j`.`Customer`, '$.Name') = {InsertJsonConvert("@__name_1")}");
+WHERE JSON_EXTRACT(`j`.`Customer`, '$.Name') = @__name_1");
         }
 
         [Fact]

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonStringQueryTestBase.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonStringQueryTestBase.cs
@@ -65,7 +65,7 @@ WHERE `j`.`CustomerJson` = '{""Name"":""Test customer"",""Age"":80,""IsVip"":fal
         {
             using var ctx = CreateContext();
             var expected = ctx.JsonEntities.Find(1).CustomerJson;
-            var actual = ctx.JsonEntities.Single(e => e.CustomerJson == expected).CustomerJson;
+            var actual = ctx.JsonEntities.Single(e => e.CustomerJson == EF.Functions.AsJson(expected)).CustomerJson;
 
             Assert.Equal(actual, expected);
             AssertSql(
@@ -76,11 +76,35 @@ FROM `JsonEntities` AS `j`
 WHERE `j`.`Id` = @__p_0
 LIMIT 1",
                 //
-                $@"{InsertJsonDocument(@"@__expected_0='{""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10},""Visits"":4,""Purchases"":3}}'", @"@__expected_0='{""Name"":""Joe"",""Age"":25,""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")}
+                $@"{InsertJsonDocument(@"@__AsJson_0='{""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10},""Visits"":4,""Purchases"":3}}'", @"@__AsJson_0='{""Name"":""Joe"",""Age"":25,""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Size = 4000)
 
 SELECT `j`.`Id`, `j`.`CustomerJson`
 FROM `JsonEntities` AS `j`
-WHERE `j`.`CustomerJson` = {InsertJsonConvert("@__expected_0")}
+WHERE {InsertJsonConvert("`j`.`CustomerJson`")} = {InsertJsonConvert("@__AsJson_0")}
+LIMIT 2");
+        }
+
+        [Fact]
+        public void Parameter_cast_MySqlJsonString()
+        {
+            using var ctx = CreateContext();
+            var expected = ctx.JsonEntities.Find(1).CustomerJson;
+            var actual = ctx.JsonEntities.Single(e => e.CustomerJson == (MySqlJsonString)expected).CustomerJson;
+
+            Assert.Equal(actual, expected);
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT `j`.`Id`, `j`.`CustomerJson`
+FROM `JsonEntities` AS `j`
+WHERE `j`.`Id` = @__p_0
+LIMIT 1",
+                //
+                $@"{InsertJsonDocument(@"@__p_0='{""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10},""Visits"":4,""Purchases"":3}}'", @"@__p_0='{""Name"":""Joe"",""Age"":25,""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Size = 4000)
+
+SELECT `j`.`Id`, `j`.`CustomerJson`
+FROM `JsonEntities` AS `j`
+WHERE {InsertJsonConvert("`j`.`CustomerJson`")} = {InsertJsonConvert("@__p_0")}
 LIMIT 2");
         }
 
@@ -91,17 +115,14 @@ LIMIT 2");
         {
             using var ctx = CreateContext();
 
-            var name = @"""Joe""";
             var count = ctx.JsonEntities.Count(e =>
-                EF.Functions.JsonExtract<string>(e.CustomerJson, "$.Name") == name);
+                EF.Functions.JsonExtract<string>(e.CustomerJson, "$.Name") == @"Joe");
 
             Assert.Equal(1, count);
             AssertSql(
-                $@"@__name_1='""Joe""'
-
-SELECT COUNT(*)
+                $@"SELECT COUNT(*)
 FROM `JsonEntities` AS `j`
-WHERE JSON_EXTRACT(`j`.`CustomerJson`, '$.Name') = {InsertJsonConvert("@__name_1")}");
+WHERE JSON_EXTRACT(`j`.`CustomerJson`, '$.Name') = 'Joe'");
         }
 
         [Fact]


### PR DESCRIPTION
Adds some general JSON methods that are useful for common scenarios, corrects visibility of advanced extension methods and marks `JsonSearchAll` as obsolete, because there is no difference in our implementation to `JsonSearchAny`.

Implements improved JSON string support, by introducing the `EF.Functions.AsJson()` method and the `MySqlJsonString` class. To declare some string value/parameter etc. explicitly as a JSON string, either call `EF.Functions.AsJson(@"{""a"": ""1""}")` or just explicitly cast the expression to `MySqlJsonString` as in `(MySqlJsonString)@"{""a"": ""1""}")`.

Adds parameter caching to `MySqlJsonTypeMapping` by inheriting from `MySqlStringTypeMapping`.