### PR TITLE
Update client evaluation handling of DbFunction extensions (EF.Functions) for EF Core 5.0

### DIFF
--- a/src/EFCore.MySql.NTS/Extensions/MySqlNetTopologySuiteServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql.NTS/Extensions/MySqlNetTopologySuiteServiceCollectionExtensions.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAddProviderSpecificServices(
                     x => x.TryAddSingletonEnumerable<IRelationalTypeMappingSourcePlugin, MySqlNetTopologySuiteTypeMappingSourcePlugin>()
                         .TryAddSingletonEnumerable<IMethodCallTranslatorPlugin, MySqlNetTopologySuiteMethodCallTranslatorPlugin>()
-                        .TryAddSingletonEnumerable<IMemberTranslatorPlugin, MySqlNetTopologySuiteMemberTranslatorPlugin>());
+                        .TryAddSingletonEnumerable<IMemberTranslatorPlugin, MySqlNetTopologySuiteMemberTranslatorPlugin>()
+                        .TryAddSingletonEnumerable<IMySqlEvaluatableExpressionFilter, MySqlNetTopologySuiteEvaluatableExpressionFilter>());
 
             return serviceCollection;
         }

--- a/src/EFCore.MySql.NTS/Extensions/MySqlSpatialDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql.NTS/Extensions/MySqlSpatialDbFunctionsExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using NetTopologySuite.Geometries;
-using Pomelo.EntityFrameworkCore.MySql.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -48,9 +48,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             Geometry g1,
             Geometry g2)
-        {
-            throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(SpatialDistancePlanar)));
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(SpatialDistancePlanar)));
 
         /// <summary>
         ///     Returns the mimimum spherical distance between Point or MultiPoint arguments on a sphere in meters,
@@ -67,8 +65,6 @@ namespace Microsoft.EntityFrameworkCore
             Geometry g1,
             Geometry g2,
             SpatialDistanceAlgorithm algorithm)
-        {
-            throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(SpatialDistanceSphere)));
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(SpatialDistanceSphere)));
     }
 }

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlNetTopologySuiteEvaluatableExpressionFilter.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlNetTopologySuiteEvaluatableExpressionFilter.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
+{
+    public class MySqlNetTopologySuiteEvaluatableExpressionFilter : IMySqlEvaluatableExpressionFilter
+    {
+        public bool? IsEvaluatableExpression(Expression expression, IModel model)
+        {
+            if (expression is MethodCallExpression methodCallExpression &&
+                methodCallExpression.Method.DeclaringType == typeof(MySqlSpatialDbFunctionsExtensions))
+            {
+                return false;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
-using System.Globalization;
-using System.Text;
 using JetBrains.Annotations;
-using Pomelo.EntityFrameworkCore.MySql.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -28,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime startDate,
             DateTime endDate)
-            => endDate.Year - startDate.Year;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffYear)));
 
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
@@ -42,9 +40,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime? startDate,
             DateTime? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffYear(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffYear)));
 
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
@@ -58,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset startDate,
             DateTimeOffset endDate)
-            => DateDiffYear(_, startDate.UtcDateTime, endDate.UtcDateTime);
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffYear)));
 
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
@@ -72,9 +68,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset? startDate,
             DateTimeOffset? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffYear(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffYear)));
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
@@ -88,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime startDate,
             DateTime endDate)
-            => 12 * (endDate.Year - startDate.Year) + endDate.Month - startDate.Month;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMonth)));
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
@@ -102,9 +96,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime? startDate,
             DateTime? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffMonth(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMonth)));
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
@@ -118,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset startDate,
             DateTimeOffset endDate)
-            => DateDiffMonth(_, startDate.UtcDateTime, endDate.UtcDateTime);
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMonth)));
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
@@ -132,9 +124,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset? startDate,
             DateTimeOffset? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffMonth(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMonth)));
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
@@ -148,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime startDate,
             DateTime endDate)
-            => (endDate.Date - startDate.Date).Days;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffDay)));
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
@@ -162,9 +152,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime? startDate,
             DateTime? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffDay(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffDay)));
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
@@ -178,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset startDate,
             DateTimeOffset endDate)
-            => DateDiffDay(_, startDate.UtcDateTime, endDate.UtcDateTime);
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffDay)));
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
@@ -192,9 +180,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset? startDate,
             DateTimeOffset? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffDay(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffDay)));
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
@@ -208,12 +194,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime startDate,
             DateTime endDate)
-        {
-            checked
-            {
-                return DateDiffDay(_, startDate, endDate) * 24 + endDate.Hour - startDate.Hour;
-            }
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffHour)));
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
@@ -227,9 +208,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime? startDate,
             DateTime? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffHour(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffHour)));
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
@@ -243,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset startDate,
             DateTimeOffset endDate)
-            => DateDiffHour(_, startDate.UtcDateTime, endDate.UtcDateTime);
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffHour)));
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
@@ -257,9 +236,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset? startDate,
             DateTimeOffset? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffHour(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffHour)));
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
@@ -273,12 +250,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime startDate,
             DateTime endDate)
-        {
-            checked
-            {
-                return DateDiffHour(_, startDate, endDate) * 60 + endDate.Minute - startDate.Minute;
-            }
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMinute)));
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
@@ -292,9 +264,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime? startDate,
             DateTime? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffMinute(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMinute)));
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
@@ -308,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset startDate,
             DateTimeOffset endDate)
-            => DateDiffMinute(_, startDate.UtcDateTime, endDate.UtcDateTime);
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMinute)));
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
@@ -322,9 +292,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset? startDate,
             DateTimeOffset? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffMinute(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMinute)));
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
@@ -338,12 +306,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime startDate,
             DateTime endDate)
-        {
-            checked
-            {
-                return DateDiffMinute(_, startDate, endDate) * 60 + endDate.Second - startDate.Second;
-            }
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffSecond)));
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
@@ -357,9 +320,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime? startDate,
             DateTime? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffSecond(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffSecond)));
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
@@ -373,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset startDate,
             DateTimeOffset endDate)
-            => DateDiffSecond(_, startDate.UtcDateTime, endDate.UtcDateTime);
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffSecond)));
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
@@ -387,9 +348,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset? startDate,
             DateTimeOffset? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffSecond(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffSecond)));
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
@@ -403,12 +362,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime startDate,
             DateTime endDate)
-        {
-            checked
-            {
-                return (int)((endDate.Ticks - startDate.Ticks) / 10);
-            }
-        }
+         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMicrosecond)));
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
@@ -422,9 +376,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTime? startDate,
             DateTime? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffMicrosecond(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMicrosecond)));
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
@@ -438,7 +390,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset startDate,
             DateTimeOffset endDate)
-            => DateDiffMicrosecond(_, startDate.UtcDateTime, endDate.UtcDateTime);
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMicrosecond)));
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
@@ -452,9 +404,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             DateTimeOffset? startDate,
             DateTimeOffset? endDate)
-            => (startDate.HasValue && endDate.HasValue)
-                ? (int?)DateDiffMicrosecond(_, startDate.Value, endDate.Value)
-                : null;
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMicrosecond)));
 
         /// <summary>
         ///     <para>
@@ -476,7 +426,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             [CanBeNull] T matchExpression,
             [CanBeNull] string pattern)
-            => LikeCore(matchExpression, pattern, null);
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Like)));
 
         /// <summary>
         ///     <para>
@@ -503,23 +453,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] T matchExpression,
             [CanBeNull] string pattern,
             [CanBeNull] string escapeCharacter)
-            => LikeCore(matchExpression, pattern, escapeCharacter);
-
-        private static bool LikeCore<T>(T matchExpression, string pattern, string escapeCharacter)
-        {
-            if (matchExpression is IConvertible convertible)
-            {
-                return EF.Functions.Like(convertible.ToString(CultureInfo.InvariantCulture), pattern, escapeCharacter);
-            }
-
-            if (matchExpression is byte[] byteArray)
-            {
-                var value = BitConverter.ToString(byteArray);
-                return EF.Functions.Like(value.Replace("-", string.Empty), pattern, escapeCharacter);
-            }
-
-            return false;
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Like)));
 
         /// <summary>
         ///     <para>
@@ -546,7 +480,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] T matchExpression,
             [CanBeNull] string pattern,
             MySqlMatchSearchMode searchMode)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(Match)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Match)));
 
         /// <summary>
         ///     <para>
@@ -567,60 +501,7 @@ namespace Microsoft.EntityFrameworkCore
         public static string Hex<T>(
             [CanBeNull] this DbFunctions _,
             [CanBeNull] T value)
-        {
-            if (value == null)
-            {
-                return null;
-            }
-
-            var bytes = value as byte[];
-
-            if (value is string stringValue)
-            {
-                if (stringValue == string.Empty)
-                {
-                    return string.Empty;
-                }
-
-                bytes = Encoding.UTF8.GetBytes(stringValue);
-            }
-
-            if (bytes != null)
-            {
-                if (bytes.Length <= 0)
-                {
-                    return string.Empty;
-                }
-
-                var sb = new StringBuilder(bytes.Length * 2);
-                var lastCharIndex = bytes.Length - 1;
-
-                for (var i = 0; i < lastCharIndex; i++)
-                {
-                    sb.Append(bytes[i].ToString("X2"));
-                }
-
-                // MySQL does not return a leading zero.
-                sb.Append(bytes[lastCharIndex].ToString("X"));
-
-                return sb.ToString();
-            }
-
-            var type = typeof(T).UnwrapNullableType();
-
-            if ((type.IsInteger() ||
-                 type == typeof(decimal) ||
-                 type == typeof(double) ||
-                 type == typeof(float)) &&
-                value is IConvertible convertible)
-            {
-                return convertible
-                    .ToInt64(CultureInfo.InvariantCulture)
-                    .ToString("X");
-            }
-
-            throw new InvalidOperationException(MySqlStrings.ExpressionTypeMismatch);
-        }
+         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Hex)));
 
         /// <summary>
         /// For a string argument `value`, Unhex() interprets each pair of characters in the argument as a hexadecimal
@@ -632,37 +513,6 @@ namespace Microsoft.EntityFrameworkCore
         public static string Unhex(
             [CanBeNull] this DbFunctions _,
             [CanBeNull] string value)
-        {
-            if (value == null)
-            {
-                return null;
-            }
-
-            if (value == string.Empty)
-            {
-                return string.Empty;
-            }
-
-            var byteCount = (value.Length + 1) / 2;
-            var sb = new StringBuilder(byteCount);
-
-            try
-            {
-                // The string might not contain a leading zero.
-                var firstByteLength = value.Length % 2 == 1 ? 1 : 2;
-                sb.Append(Convert.ToChar(Convert.ToByte(value.Substring(0, firstByteLength), 16)));
-
-                for (var i = 1; i < byteCount; i++)
-                {
-                    sb.Append(Convert.ToChar(Convert.ToByte(value.Substring(i * 2, 2), 16)));
-                }
-            }
-            catch (FormatException)
-            {
-                return null;
-            }
-
-            return sb.ToString();
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Hex)));
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
-using System.Globalization;
-using System.Text;
 using JetBrains.Annotations;
-using Pomelo.EntityFrameworkCore.MySql.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -40,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The JSON type as a text string. </returns>
         /// <remarks> For possible return values see: https://dev.mysql.com/doc/refman/8.0/en/json-attribute-functions.html#function_json-type </remarks>
         public static string JsonType([CanBeNull] this DbFunctions _, [NotNull] object json)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonType)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonType)));
 
         /// <summary>
         /// Quotes a string as a JSON value by wrapping it with double quote characters and escaping interior quote and
@@ -53,32 +51,7 @@ namespace Microsoft.EntityFrameworkCore
         public static string JsonQuote(
             [CanBeNull] this DbFunctions _,
             [NotNull] string value)
-        {
-            var quotedString = new StringBuilder(value.Length * 2 + 2);
-            var length = value.Length;
-
-            quotedString.Append('"');
-
-            for (var i = 0; i < length; i++)
-            {
-                quotedString.Append(
-                    value[i] switch
-                    {
-                        '"' => @"\""",
-                        '\b' => @"\b",
-                        '\f' => @"\f",
-                        '\n' => @"\n",
-                        '\r' => @"\r",
-                        '\t' => @"\t",
-                        '\\' => @"\\",
-                        _ => value[i]
-                    });
-            }
-
-            return quotedString
-                .Append('"')
-                .ToString();
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonQuote)));
 
         /// <summary>
         /// Unquotes JSON value and returns the result as a `utf8mb4` string. Returns `null` if the argument is `null`.
@@ -91,120 +64,7 @@ namespace Microsoft.EntityFrameworkCore
         public static string JsonUnquote(
             [CanBeNull] this DbFunctions _,
             [NotNull] object json)
-        {
-            if (json is string jsonString)
-            {
-                var length = jsonString.Length;
-
-                if (length < 2 ||
-                    jsonString[0] != '"' ||
-                    jsonString[length - 1] != '"')
-                {
-                    return jsonString;
-                }
-
-                var unquotedString = new StringBuilder(length - 2);
-                var isEscapeSequence = false;
-                var unicodeCharNum = -1;
-                var unicodeChars = new char[4];
-
-                for (var i = 1; i < length - 1; i++)
-                {
-                    var c = jsonString[i];
-
-                    if (isEscapeSequence)
-                    {
-                        if (unicodeCharNum > -1)
-                        {
-                            if (c >= '0' && c <= '9' ||
-                                c >= 'A' && c <= 'F' ||
-                                c >= 'a' && c <= 'f')
-                            {
-                                unicodeChars[unicodeCharNum++] = c;
-
-                                if (unicodeCharNum >= 4)
-                                {
-                                    var utf8Value = ushort.Parse(new string(unicodeChars), NumberStyles.AllowHexSpecifier);
-                                    unquotedString.Append(
-                                        Encoding.UTF8.GetChars(
-                                            utf8Value <= 255
-                                                ? new[] {(byte)utf8Value}
-                                                : BitConverter.GetBytes(utf8Value)));
-                                    unicodeCharNum = -1;
-                                    isEscapeSequence = false;
-                                }
-                            }
-                            else
-                            {
-                                throw new ArgumentException("The JSON string is not well formed.");
-                            }
-                        }
-                        else if (c == '"')
-                        {
-                            unquotedString.Append('\"');
-                            isEscapeSequence = false;
-                        }
-                        else if (c == 'b')
-                        {
-                            unquotedString.Append('\b');
-                            isEscapeSequence = false;
-                        }
-                        else if (c == 'f')
-                        {
-                            unquotedString.Append('\f');
-                            isEscapeSequence = false;
-                        }
-                        else if (c == 'n')
-                        {
-                            unquotedString.Append('\n');
-                            isEscapeSequence = false;
-                        }
-                        else if (c == 'r')
-                        {
-                            unquotedString.Append('\r');
-                            isEscapeSequence = false;
-                        }
-                        else if (c == 't')
-                        {
-                            unquotedString.Append('\t');
-                            isEscapeSequence = false;
-                        }
-                        else if (c == '\\')
-                        {
-                            unquotedString.Append('\\');
-                            isEscapeSequence = false;
-                        }
-                        else if (c == 'u' &&
-                                 unicodeCharNum == -1)
-                        {
-                            unicodeCharNum = 0;
-                        }
-                        else
-                        {
-                            unquotedString.Append(c);
-                            isEscapeSequence = false;
-                        }
-                    }
-                    else if (c == '\\')
-                    {
-                        isEscapeSequence = true;
-                    }
-                    else
-                    {
-                        unquotedString.Append(c);
-                    }
-                }
-
-                if (isEscapeSequence)
-                {
-                    throw new ArgumentException("The JSON string is not well formed.");
-                }
-
-                return unquotedString.ToString();
-            }
-
-            return json.ToString();
-        }
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonUnquote)));
 
         /// <summary>
         /// Returns data from a JSON document, selected from the parts of the document matched by the path arguments.
@@ -222,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             [NotNull] object json,
             [NotNull] params string[] paths)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonExtract)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonExtract)));
 
         /// <summary>
         /// Checks if <paramref name="json"/> contains <paramref name="candidate"/>.
@@ -236,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </param>
         public static bool JsonContains(
             [CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] object candidate)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContains)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonContains)));
 
         /// <summary>
         /// Checks if <paramref name="json"/> contains <paramref name="candidate"/> at a specific <paramref name="path"/>.
@@ -253,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </param>
         public static bool JsonContains(
             [CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] object candidate, [CanBeNull] string path)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContains)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonContains)));
 
         /// <summary>
         /// Checks if <paramref name="path"/> exists within <paramref name="json"/>.
@@ -264,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </param>
         /// <param name="path">A path to be checked inside <paramref name="json"/>.</param>
         public static bool JsonContainsPath([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string path)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContainsPath)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonContainsPath)));
 
         /// <summary>
         /// Checks if any of the given <paramref name="paths"/> exist within <paramref name="json"/>.
@@ -275,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </param>
         /// <param name="paths">A set of paths to be checked inside <paramref name="json"/>.</param>
         public static bool JsonContainsPathAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] params string[] paths)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContainsPathAny)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonContainsPathAny)));
 
         /// <summary>
         /// Checks if all of the given <paramref name="paths"/> exist within <paramref name="json"/>.
@@ -286,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </param>
         /// <param name="paths">A set of paths to be checked inside <paramref name="json"/>.</param>
         public static bool JsonContainsPathAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] params string[] paths)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonContainsPathAll)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonContainsPathAll)));
 
         /// <summary>
         /// Checks if <paramref name="json"/> contains <paramref name="searchString"/>.
@@ -299,7 +159,7 @@ namespace Microsoft.EntityFrameworkCore
         /// The string to search for.
         /// </param>
         public static bool JsonSearchAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAny)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonSearchAny)));
 
         /// <summary>
         /// Checks if <paramref name="json"/> contains <paramref name="searchString"/> under <paramref name="path"/>.
@@ -315,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore
         /// A string containing a valid JSON path (staring with `$`).
         /// </param>
         public static bool JsonSearchAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAny)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonSearchAny)));
 
         /// <summary>
         /// Checks if <paramref name="json"/> contains <paramref name="searchString"/> under <paramref name="path"/>.
@@ -334,6 +194,6 @@ namespace Microsoft.EntityFrameworkCore
         /// Can be `null`, an empty string or a one character wide string used for escaping characters in <paramref name="searchString"/>.
         /// </param>
         public static bool JsonSearchAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path, string escapeChar)
-            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAny)));
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonSearchAny)));
     }
 }

--- a/src/EFCore.MySql/Query/Internal/IMySqlEvaluatableExpressionFilter.cs
+++ b/src/EFCore.MySql/Query/Internal/IMySqlEvaluatableExpressionFilter.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
+{
+    public interface IMySqlEvaluatableExpressionFilter
+    {
+        /// <summary>
+        ///     Checks whether the given expression can be evaluated.
+        /// </summary>
+        /// <param name="expression"> The expression. </param>
+        /// <param name="model"> The model. </param>
+        /// <returns>
+        /// <see langword="true" /> if the expression can be evaluated, <see langword="false" /> if it can't and <see langword="null" /> if
+        /// it doesn't handle the given expression.
+        /// </returns>
+        bool? IsEvaluatableExpression([NotNull] Expression expression, [NotNull] IModel model);
+    }
+}

--- a/src/EFCore.MySql/Query/Internal/MySqlEvaluatableExpressionFilter.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlEvaluatableExpressionFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -11,17 +12,37 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlEvaluatableExpressionFilter : RelationalEvaluatableExpressionFilter
     {
-        public MySqlEvaluatableExpressionFilter([NotNull] EvaluatableExpressionFilterDependencies dependencies, [NotNull] RelationalEvaluatableExpressionFilterDependencies relationalDependencies)
+        private readonly IEnumerable<IMySqlEvaluatableExpressionFilter> _mySqlEvaluatableExpressionFilters;
+
+        public MySqlEvaluatableExpressionFilter(
+            [NotNull] EvaluatableExpressionFilterDependencies dependencies,
+            [NotNull] RelationalEvaluatableExpressionFilterDependencies relationalDependencies,
+            [NotNull] IEnumerable<IMySqlEvaluatableExpressionFilter> mySqlEvaluatableExpressionFilters)
             : base(dependencies, relationalDependencies)
         {
+            _mySqlEvaluatableExpressionFilters = mySqlEvaluatableExpressionFilters;
         }
 
         public override bool IsEvaluatableExpression(Expression expression, IModel model)
         {
-            if (expression is MethodCallExpression methodCallExpression
-                && methodCallExpression.Method.DeclaringType == typeof(MySqlDbFunctionsExtensions))
+            foreach (var evaluatableExpressionFilter in _mySqlEvaluatableExpressionFilters)
             {
-                return false;
+                var evaluatable = evaluatableExpressionFilter.IsEvaluatableExpression(expression, model);
+                if (evaluatable.HasValue)
+                {
+                    return evaluatable.Value;
+                }
+            }
+
+            if (expression is MethodCallExpression methodCallExpression)
+            {
+                var declaringType = methodCallExpression.Method.DeclaringType;
+
+                if (declaringType == typeof(MySqlDbFunctionsExtensions) ||
+                    declaringType == typeof(MySqlJsonDbFunctionsExtensions))
+                {
+                    return false;
+                }
             }
 
             return base.IsEvaluatableExpression(expression, model);

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonStringQueryTestBase.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonStringQueryTestBase.cs
@@ -77,11 +77,11 @@ FROM `JsonEntities` AS `j`
 WHERE `j`.`Id` = @__p_0
 LIMIT 1",
                 //
-                $@"{InsertJsonDocument(@"@__AsJson_0='{""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10},""Visits"":4,""Purchases"":3}}'", @"@__AsJson_0='{""Name"":""Joe"",""Age"":25,""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Size = 4000)
+                $@"{InsertJsonDocument(@"@__expected_1='{""Age"":25,""Name"":""Joe"",""IsVip"":false,""Orders"":[{""Price"":99.5,""ShippingDate"":""2019-10-01"",""ShippingAddress"":""Some address 1""},{""Price"":23,""ShippingDate"":""2019-10-10"",""ShippingAddress"":""Some address 2""}],""Statistics"":{""Nested"":{""IntArray"":[3,4],""SomeProperty"":10},""Visits"":4,""Purchases"":3}}'", @"@__expected_1='{""Name"":""Joe"",""Age"":25,""IsVip"":false,""Statistics"":{""Visits"":4,""Purchases"":3,""Nested"":{""SomeProperty"":10,""IntArray"":[3,4]}},""Orders"":[{""Price"":99.5,""ShippingAddress"":""Some address 1"",""ShippingDate"":""2019-10-01""},{""Price"":23,""ShippingAddress"":""Some address 2"",""ShippingDate"":""2019-10-10""}]}'")} (Size = 4000)
 
 SELECT `j`.`Id`, `j`.`CustomerJson`
 FROM `JsonEntities` AS `j`
-WHERE {InsertJsonConvert("`j`.`CustomerJson`")} = {InsertJsonConvert("@__AsJson_0")}
+WHERE {InsertJsonConvert("`j`.`CustomerJson`")} = {InsertJsonConvert("@__expected_1")}
 LIMIT 2");
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindDbFunctionsQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindDbFunctionsQueryMySqlTest.MySql.cs
@@ -1,10 +1,6 @@
 using System;
-using System.Globalization;
 using System.Linq;
-using System.Threading;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query;
-using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
@@ -228,14 +224,6 @@ WHERE HEX(`o`.`CustomerID`) = '56494E4554'");
         }
 
         [ConditionalFact]
-        public virtual void Hex_client_eval()
-        {
-            var hex = EF.Functions.Hex("VINET");
-
-            Assert.Equal("56494E4554", hex);
-        }
-
-        [ConditionalFact]
         public virtual void Unhex()
         {
             using (var context = CreateContext())
@@ -250,48 +238,6 @@ WHERE HEX(`o`.`CustomerID`) = '56494E4554'");
 FROM `Orders` AS `o`
 WHERE UNHEX(HEX(`o`.`CustomerID`)) = 'VINET'");
             }
-        }
-
-        [ConditionalFact]
-        public virtual void Unhex_client_eval()
-        {
-            var unhex = EF.Functions.Unhex("56494E4554");
-
-            Assert.Equal("VINET", unhex);
-        }
-
-        [Fact]
-        public void JsonQuote_client_eval()
-        {
-            var quoted = EF.Functions.JsonQuote("first\\\"second\"\tthird");
-
-            Assert.Equal(@"""first\\\""second\""\tthird""", quoted);
-        }
-
-        [Fact]
-        public void JsonUnquote_client_eval()
-        {
-            var unquoted = EF.Functions.JsonUnquote(@"""first\\\""second\""\tthird""");
-
-            Assert.Equal("first\\\"second\"\tthird", unquoted);
-        }
-
-        [Fact]
-        public void JsonUnquote_client_eval_unicode()
-        {
-            var unquoted = EF.Functions.JsonUnquote(@"""a\u003da""");
-
-            Assert.Equal("a=a", unquoted);
-        }
-
-        [Fact]
-        public void JsonUnquote_client_eval_throws()
-        {
-            Assert.Equal(
-                "The JSON string is not well formed.",
-                Assert.Throws<ArgumentException>(
-                        () => EF.Functions.JsonUnquote(@"""a\u3da"""))
-                    .Message);
         }
     }
 }


### PR DESCRIPTION
Make sure, that `DbFunctions` extensions always throw when called (client-eval) instead of translated.
We will apply this only to 5.0.

Fixes #1208