### PR TITLE
Check and reimplement nullability and argument null propagation for all SQL functions

### DIFF
--- a/src/EFCore.MySql.Json.Microsoft/Extensions/MySqlJsonMicrosoftServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Extensions/MySqlJsonMicrosoftServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 
 // ReSharper disable once CheckNamespace

--- a/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftDomTranslator.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftDomTranslator.cs
@@ -13,9 +13,8 @@ using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
-namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.ExpressionTranslators.Internal
+namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.Internal
 {
     public class MySqlJsonMicrosoftDomTranslator : IMemberTranslator, IMethodCallTranslator
     {
@@ -155,12 +154,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.ExpressionTransl
 
             if (method == _getArrayLength)
             {
-                return _sqlExpressionFactory.Function(
+                // Could return NULL if the path is not found, but we would be alright to throw then.
+                return _sqlExpressionFactory.NullableFunction(
                     "JSON_LENGTH",
                     new[] { instance },
-                    nullable: true,
-                    argumentsPropagateNullability: Statics.TrueArrays[1],
-                    typeof(int));
+                    typeof(int),
+                    false);
             }
 
             if (method.Name.StartsWith("TryGet") && arguments.Count == 0)

--- a/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftMemberTranslatorPlugin.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftMemberTranslatorPlugin.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
-using Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 

--- a/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftMethodCallTranslatorPlugin.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
-using Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 

--- a/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftPocoTranslator.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftPocoTranslator.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 
-namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.ExpressionTranslators.Internal
+namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.Internal
 {
     public class MySqlJsonMicrosoftPocoTranslator : MySqlJsonPocoTranslator
     {

--- a/src/EFCore.MySql.Json.Newtonsoft/Extensions/MySqlJsonNewtonsoftServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Extensions/MySqlJsonNewtonsoftServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 
 // ReSharper disable once CheckNamespace

--- a/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftDomTranslator.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftDomTranslator.cs
@@ -14,7 +14,7 @@ using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
-namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.ExpressionTranslators.Internal
+namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.Internal
 {
     public class MySqlJsonNewtonsoftDomTranslator : IMemberTranslator, IMethodCallTranslator
     {

--- a/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftMemberTranslatorPlugin.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftMemberTranslatorPlugin.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
-using Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 

--- a/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftMethodCallTranslatorPlugin.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
-using Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 

--- a/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftPocoTranslator.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftPocoTranslator.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 
-namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.ExpressionTranslators.Internal
+namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.Internal
 {
     public class MySqlJsonNewtonsoftPocoTranslator : MySqlJsonPocoTranslator
     {

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlGeometryCollectionMemberTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlGeometryCollectionMemberTranslator.cs
@@ -8,16 +8,15 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using NetTopologySuite.Geometries;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlGeometryCollectionMemberTranslator : IMemberTranslator
     {
         private static readonly MemberInfo _count = typeof(GeometryCollection).GetRuntimeProperty(nameof(GeometryCollection.Count));
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
-        public MySqlGeometryCollectionMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlGeometryCollectionMemberTranslator(MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
         }
@@ -26,12 +25,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
         {
             if (Equals(member, _count))
             {
-                return _sqlExpressionFactory.Function(
+                // Returns NULL for an empty geometry argument.
+                return _sqlExpressionFactory.NullableFunction(
                     "ST_NumGeometries",
                     new [] {instance},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[1],
-                    returnType);
+                    returnType,
+                    false);
             }
 
             return null;

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlGeometryMemberTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlGeometryMemberTranslator.cs
@@ -11,43 +11,42 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.Geometries;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlGeometryMemberTranslator : IMemberTranslator
     {
-        private static readonly IDictionary<MemberInfo, string> _memberToFunctionName = new Dictionary<MemberInfo, string>
+        private static readonly IDictionary<MemberInfo, (string Name, bool OnlyNullByArgs)> _memberToFunctionName = new Dictionary<MemberInfo, (string Name, bool OnlyNullByArgs)>
         {
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Area)), "ST_Area" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Dimension)), "ST_Dimension" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.GeometryType)), "ST_GeometryType" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.IsEmpty)), "ST_IsEmpty" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.IsValid)), "ST_IsValid" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Length)), "ST_Length" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.NumGeometries)), "ST_NumGeometries" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.NumPoints)), "ST_NumPoints" }
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Area)), ("ST_Area", false) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Dimension)), ("ST_Dimension", true) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.GeometryType)), ("ST_GeometryType", true) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.IsEmpty)), ("ST_IsEmpty", true) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.IsValid)), ("ST_IsValid", true) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Length)), ("ST_Length", false) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.NumGeometries)), ("ST_NumGeometries", false) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.NumPoints)), ("ST_NumPoints", false) }
         };
 
-        private static readonly IDictionary<MemberInfo, string> _geometryMemberToFunctionName = new Dictionary<MemberInfo, string>
+        private static readonly IDictionary<MemberInfo, (string Name, bool OnlyNullByArgs)> _geometryMemberToFunctionName = new Dictionary<MemberInfo, (string Name, bool OnlyNullByArgs)>
         {
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Boundary)), "ST_Boundary" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Centroid)), "ST_Centroid" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Envelope)), "ST_Envelope" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.InteriorPoint)), "ST_PointOnSurface" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.IsSimple)), "ST_IsSimple" },
-            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.PointOnSurface)), "ST_PointOnSurface" }
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Boundary)), ("ST_Boundary", false) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Centroid)), ("ST_Centroid", false) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.Envelope)), ("ST_Envelope", true) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.InteriorPoint)), ("ST_PointOnSurface", false) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.IsSimple)), ("ST_IsSimple", true) },
+            { typeof(Geometry).GetRuntimeProperty(nameof(Geometry.PointOnSurface)), ("ST_PointOnSurface", false) }
         };
 
         private static readonly MemberInfo _ogcGeometryType = typeof(Geometry).GetRuntimeProperty(nameof(Geometry.OgcGeometryType));
         private static readonly MemberInfo _srid = typeof(Geometry).GetRuntimeProperty(nameof(Geometry.SRID));
 
         private readonly IRelationalTypeMappingSource _typeMappingSource;
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
         public MySqlGeometryMemberTranslator(
             IRelationalTypeMappingSource typeMappingSource,
-            ISqlExpressionFactory sqlExpressionFactory)
+            MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _typeMappingSource = typeMappingSource;
             _sqlExpressionFactory = sqlExpressionFactory;
@@ -57,23 +56,22 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
         {
             if (typeof(Geometry).IsAssignableFrom(member.DeclaringType))
             {
-                Debug.Assert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
+                Debug.Assert(instance.TypeMapping != null, $"Instance must have {nameof(SqlExpression.TypeMapping)} assigned.");
                 var storeType = instance.TypeMapping.StoreType;
 
-                if (_memberToFunctionName.TryGetValue(member, out var functionName) ||
-                    _geometryMemberToFunctionName.TryGetValue(member, out functionName))
+                if (_memberToFunctionName.TryGetValue(member, out var mapping) ||
+                    _geometryMemberToFunctionName.TryGetValue(member, out mapping))
                 {
                     var resultTypeMapping = typeof(Geometry).IsAssignableFrom(returnType)
                         ? _typeMappingSource.FindMapping(returnType, storeType)
                         : _typeMappingSource.FindMapping(returnType);
 
-                    SqlExpression sqlExpression = _sqlExpressionFactory.Function(
-                        functionName,
+                    SqlExpression sqlExpression = _sqlExpressionFactory.NullableFunction(
+                        mapping.Name,
                         new [] {instance},
-                        nullable: true,
-                        argumentsPropagateNullability: TrueArrays[1],
                         returnType,
-                        resultTypeMapping);
+                        resultTypeMapping,
+                        mapping.OnlyNullByArgs);
 
                     // ST_IsRing and others returns TRUE for a NULL value in MariaDB, which is inconsistent with NTS' implementation.
                     // We return the following instead:
@@ -129,11 +127,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                     };
 
                     return _sqlExpressionFactory.Case(
-                        _sqlExpressionFactory.Function(
+                        _sqlExpressionFactory.NullableFunction(
                             "ST_GeometryType",
                             new [] {instance},
-                            nullable: true,
-                            argumentsPropagateNullability: TrueArrays[1],
                             typeof(string)),
                         whenClauses.ToArray(),
                         null);
@@ -141,11 +137,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 
                 if (Equals(member, _srid))
                 {
-                    return _sqlExpressionFactory.Function(
+                    return _sqlExpressionFactory.NullableFunction(
                         "ST_SRID",
                         new [] {instance},
-                        nullable: true,
-                        argumentsPropagateNullability: TrueArrays[1],
                         returnType);
                 }
             }

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlGeometryMethodTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlGeometryMethodTranslator.cs
@@ -14,37 +14,36 @@ using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.Geometries;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlGeometryMethodTranslator : IMethodCallTranslator
     {
-        private static readonly IDictionary<MethodInfo, string> _methodToFunctionName = new Dictionary<MethodInfo, string>
+        private static readonly IDictionary<MethodInfo, (string Name, bool OnlyNullByArgs)> _methodToFunctionName = new Dictionary<MethodInfo, (string Name, bool OnlyNullByArgs)>
         {
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.AsBinary), Type.EmptyTypes), "ST_AsBinary" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.AsText), Type.EmptyTypes), "ST_AsText" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Buffer), new[] { typeof(double) }), "ST_Buffer" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Contains), new[] { typeof(Geometry) }), "ST_Contains" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.ConvexHull), Type.EmptyTypes), "ST_ConvexHull" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Difference), new[] { typeof(Geometry) }), "ST_Difference" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Disjoint), new[] { typeof(Geometry) }), "ST_Disjoint" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.EqualsTopologically), new[] { typeof(Geometry) }), "ST_Equals" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Intersection), new[] { typeof(Geometry) }), "ST_Intersection" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Intersects), new[] { typeof(Geometry) }), "ST_Intersects" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Overlaps), new[] { typeof(Geometry) }), "ST_Overlaps" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.SymmetricDifference), new[] { typeof(Geometry) }), "ST_SymDifference" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.ToBinary), Type.EmptyTypes), "ST_AsBinary" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.ToText), Type.EmptyTypes), "ST_AsText" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Union), new[] { typeof(Geometry) }), "ST_Union" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Within), new[] { typeof(Geometry) }), "ST_Within" }
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.AsBinary), Type.EmptyTypes), ("ST_AsBinary", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.AsText), Type.EmptyTypes), ("ST_AsText", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Buffer), new[] { typeof(double) }), ("ST_Buffer", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Contains), new[] { typeof(Geometry) }), ("ST_Contains", false ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.ConvexHull), Type.EmptyTypes), ("ST_ConvexHull", false ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Difference), new[] { typeof(Geometry) }), ("ST_Difference", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Disjoint), new[] { typeof(Geometry) }), ("ST_Disjoint", false ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.EqualsTopologically), new[] { typeof(Geometry) }), ("ST_Equals", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Intersection), new[] { typeof(Geometry) }), ("ST_Intersection", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Intersects), new[] { typeof(Geometry) }), ("ST_Intersects", false ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Overlaps), new[] { typeof(Geometry) }), ("ST_Overlaps", false ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.SymmetricDifference), new[] { typeof(Geometry) }), ("ST_SymDifference", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.ToBinary), Type.EmptyTypes), ("ST_AsBinary", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.ToText), Type.EmptyTypes), ("ST_AsText", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Union), new[] { typeof(Geometry) }), ("ST_Union", true ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Within), new[] { typeof(Geometry) }), ("ST_Within", false ) }
         };
 
-        private static readonly IDictionary<MethodInfo, string> _geometryMethodToFunctionName = new Dictionary<MethodInfo, string>
+        private static readonly IDictionary<MethodInfo, (string Name, bool OnlyNullByArgs)> _geometryMethodToFunctionName = new Dictionary<MethodInfo, (string Name, bool OnlyNullByArgs)>
         {
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Crosses), new[] { typeof(Geometry) }), "ST_Crosses" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Relate), new[] { typeof(Geometry), typeof(string) }), "ST_Relate" },
-            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Touches), new[] { typeof(Geometry) }), "ST_Touches" }
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Crosses), new[] { typeof(Geometry) }), ("ST_Crosses", false ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Relate), new[] { typeof(Geometry), typeof(string) }), ("ST_Relate", false ) },
+            { typeof(Geometry).GetRuntimeMethod(nameof(Geometry.Touches), new[] { typeof(Geometry) }), ("ST_Touches", false ) }
         };
 
         private static readonly MethodInfo _getGeometryN = typeof(Geometry).GetRuntimeMethod(
@@ -58,12 +57,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             new[] { typeof(Geometry) });
 
         private readonly IRelationalTypeMappingSource _typeMappingSource;
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
         private readonly IMySqlOptions _options;
 
         public MySqlGeometryMethodTranslator(
             IRelationalTypeMappingSource typeMappingSource,
-            ISqlExpressionFactory sqlExpressionFactory,
+            MySqlSqlExpressionFactory sqlExpressionFactory,
             IMySqlOptions options)
         {
             _typeMappingSource = typeMappingSource;
@@ -82,8 +81,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 Debug.Assert(typeMapping != null, "At least one argument must have typeMapping.");
                 var storeType = typeMapping.StoreType;
 
-                if (_methodToFunctionName.TryGetValue(method, out var functionName) ||
-                    _geometryMethodToFunctionName.TryGetValue(method, out functionName))
+                if (_methodToFunctionName.TryGetValue(method, out var mapping) ||
+                    _geometryMethodToFunctionName.TryGetValue(method, out mapping))
                 {
                     instance = _sqlExpressionFactory.ApplyTypeMapping(
                         instance,
@@ -108,18 +107,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                         ? _typeMappingSource.FindMapping(method.ReturnType, storeType)
                         : _typeMappingSource.FindMapping(method.ReturnType);
 
-                    return _sqlExpressionFactory.Function(
-                        functionName,
+                    return _sqlExpressionFactory.NullableFunction(
+                        mapping.Name,
                         typeMappedArguments,
-                        nullable: true,
-                        argumentsPropagateNullability: Enumerable.Repeat(true, typeMappedArguments.Count),
                         method.ReturnType,
-                        resultTypeMapping);
+                        resultTypeMapping,
+                        mapping.OnlyNullByArgs);
                 }
 
                 if (Equals(method, _getGeometryN))
                 {
-                    return _sqlExpressionFactory.Function(
+                    return _sqlExpressionFactory.NullableFunction(
                         "ST_GeometryN",
                         new[]
                         {
@@ -128,10 +126,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                                 arguments[0],
                                 _sqlExpressionFactory.Constant(1))
                         },
-                        nullable: true,
-                        argumentsPropagateNullability: TrueArrays[2],
                         method.ReturnType,
-                        _typeMappingSource.FindMapping(method.ReturnType, storeType));
+                        _typeMappingSource.FindMapping(method.ReturnType, storeType),
+                        false);
                 }
 
                 if (Equals(method, _distance))
@@ -171,13 +168,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 {
                     new CaseWhenClause(
                         _sqlExpressionFactory.Equal(
-                            _sqlExpressionFactory.Function(
+                            _sqlExpressionFactory.NullableFunction(
                                 "ST_SRID",
                                 new[] {left},
-                                nullable: true,
-                                argumentsPropagateNullability: TrueArrays[1],
-                                typeof(int),
-                                _typeMappingSource.FindMapping(typeof(int))),
+                                typeof(int)),
                             _sqlExpressionFactory.Constant(4326)),
                         MySqlSpatialDbFunctionsExtensionsMethodTranslator.GetStDistanceSphereFunctionCall(
                             left,

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlLineStringMethodTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlLineStringMethodTranslator.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.Geometries;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -19,11 +18,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             nameof(LineString.GetPointN), new[] { typeof(int) });
 
         private readonly IRelationalTypeMappingSource _typeMappingSource;
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
         public MySqlLineStringMethodTranslator(
             IRelationalTypeMappingSource typeMappingSource,
-            ISqlExpressionFactory sqlExpressionFactory)
+            MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _typeMappingSource = typeMappingSource;
             _sqlExpressionFactory = sqlExpressionFactory;
@@ -33,7 +32,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
         {
             if (Equals(method, _getPointN))
             {
-                return _sqlExpressionFactory.Function(
+                return _sqlExpressionFactory.NullableFunction(
                     "ST_PointN",
                     new[]
                     {
@@ -42,10 +41,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                             arguments[0],
                             _sqlExpressionFactory.Constant(1))
                     },
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[2],
                     method.ReturnType,
-                    _typeMappingSource.FindMapping(method.ReturnType, instance.TypeMapping.StoreType));
+                    _typeMappingSource.FindMapping(method.ReturnType, instance.TypeMapping.StoreType),
+                    false);
             }
 
             return null;

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlMultiLineStringMemberTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlMultiLineStringMemberTranslator.cs
@@ -9,16 +9,15 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.Geometries;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlMultiLineStringMemberTranslator : IMemberTranslator
     {
         private static readonly MemberInfo _isClosed = typeof(MultiLineString).GetRuntimeProperty(nameof(MultiLineString.IsClosed));
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
-        public MySqlMultiLineStringMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlMultiLineStringMemberTranslator(MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
         }
@@ -27,12 +26,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
         {
             if (Equals(member, _isClosed))
             {
-                SqlExpression sqlExpression = _sqlExpressionFactory.Function(
+                SqlExpression sqlExpression = _sqlExpressionFactory.NullableFunction(
                     "ST_IsClosed",
                     new [] {instance},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[1],
-                    returnType);
+                    returnType,
+                    false);
 
                 // ST_IsRing and others returns TRUE for a NULL value in MariaDB, which is inconsistent with NTS' implementation.
                 // We return the following instead:

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlNetTopologySuiteMemberTranslatorPlugin.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlNetTopologySuiteMemberTranslatorPlugin.cs
@@ -21,14 +21,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             ISqlExpressionFactory sqlExpressionFactory,
             IMySqlOptions options)
         {
+            var mySqlSqlExpressionFactory = (MySqlSqlExpressionFactory)sqlExpressionFactory;
+
             Translators = new IMemberTranslator[]
             {
-                new MySqlGeometryMemberTranslator(typeMappingSource, sqlExpressionFactory),
-                new MySqlGeometryCollectionMemberTranslator(sqlExpressionFactory),
-                new MySqlLineStringMemberTranslator(typeMappingSource, sqlExpressionFactory, options),
-                new MySqlMultiLineStringMemberTranslator(sqlExpressionFactory),
-                new MySqlPointMemberTranslator(sqlExpressionFactory),
-                new MySqlPolygonMemberTranslator(typeMappingSource, sqlExpressionFactory)
+                new MySqlGeometryMemberTranslator(typeMappingSource, mySqlSqlExpressionFactory),
+                new MySqlGeometryCollectionMemberTranslator(mySqlSqlExpressionFactory),
+                new MySqlLineStringMemberTranslator(typeMappingSource, mySqlSqlExpressionFactory, options),
+                new MySqlMultiLineStringMemberTranslator(mySqlSqlExpressionFactory),
+                new MySqlPointMemberTranslator(mySqlSqlExpressionFactory),
+                new MySqlPolygonMemberTranslator(typeMappingSource, mySqlSqlExpressionFactory)
             };
         }
 

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlNetTopologySuiteMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlNetTopologySuiteMethodCallTranslatorPlugin.cs
@@ -22,13 +22,15 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             ISqlExpressionFactory sqlExpressionFactory,
             IMySqlOptions options)
         {
+            var mySqlSqlExpressionFactory = (MySqlSqlExpressionFactory)sqlExpressionFactory;
+
             Translators = new IMethodCallTranslator[]
             {
-                new MySqlGeometryMethodTranslator(typeMappingSource, sqlExpressionFactory, options),
-                new MySqlGeometryCollectionMethodTranslator(typeMappingSource, sqlExpressionFactory),
-                new MySqlLineStringMethodTranslator(typeMappingSource, sqlExpressionFactory),
-                new MySqlPolygonMethodTranslator(typeMappingSource, sqlExpressionFactory),
-                new MySqlSpatialDbFunctionsExtensionsMethodTranslator(typeMappingSource, sqlExpressionFactory, options)
+                new MySqlGeometryMethodTranslator(typeMappingSource, mySqlSqlExpressionFactory, options),
+                new MySqlGeometryCollectionMethodTranslator(typeMappingSource, mySqlSqlExpressionFactory),
+                new MySqlLineStringMethodTranslator(typeMappingSource, mySqlSqlExpressionFactory),
+                new MySqlPolygonMethodTranslator(typeMappingSource, mySqlSqlExpressionFactory),
+                new MySqlSpatialDbFunctionsExtensionsMethodTranslator(typeMappingSource, mySqlSqlExpressionFactory, options)
             };
         }
 

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlPointMemberTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlPointMemberTranslator.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using NetTopologySuite.Geometries;
-using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -21,9 +20,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             { typeof(Point).GetRuntimeProperty(nameof(Point.Y)), "ST_Y" },
         };
 
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
-        public MySqlPointMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlPointMemberTranslator(MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
         }
@@ -34,11 +33,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             {
                 if (_geometryMemberToFunctionName.TryGetValue(member, out var functionName))
                 {
-                    return _sqlExpressionFactory.Function(
+                    return _sqlExpressionFactory.NullableFunction(
                         functionName,
                         new[] { instance },
-                        nullable: true,
-                        argumentsPropagateNullability: Statics.TrueArrays[1],
                         returnType);
                 }
             }

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlPolygonMethodTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlPolygonMethodTranslator.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.Geometries;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -19,11 +18,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             nameof(Polygon.GetInteriorRingN), new[] { typeof(int) });
 
         private readonly IRelationalTypeMappingSource _typeMappingSource;
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
         public MySqlPolygonMethodTranslator(
             IRelationalTypeMappingSource typeMappingSource,
-            ISqlExpressionFactory sqlExpressionFactory)
+            MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _typeMappingSource = typeMappingSource;
             _sqlExpressionFactory = sqlExpressionFactory;
@@ -35,7 +34,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             {
                 var storeType = instance.TypeMapping.StoreType;
 
-                return _sqlExpressionFactory.Function(
+                return _sqlExpressionFactory.NullableFunction(
                     "ST_InteriorRingN",
                     new[]
                     {
@@ -44,10 +43,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                             arguments[0],
                             _sqlExpressionFactory.Constant(1))
                     },
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[2],
                     method.ReturnType,
-                    _typeMappingSource.FindMapping(method.ReturnType, storeType));
+                    _typeMappingSource.FindMapping(method.ReturnType, storeType),
+                    false);
             }
 
             return null;

--- a/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlJsonDbFunctionsExtensions.cs
@@ -136,16 +136,5 @@ namespace Microsoft.EntityFrameworkCore
         /// </param>
         public static bool JsonSearchAny([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path, string escapeChar)
             => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAny)));
-
-        // These methods make no sense as long as they only return true or false, because they would return
-        // the same result as JsonSearchAny would.
-        // public static bool JsonSearchAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString)
-        //     => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAll)));
-        //
-        // public static bool JsonSearchAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path)
-        //     => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAll)));
-        //
-        // public static bool JsonSearchAll([CanBeNull] this DbFunctions _, [NotNull] object json, [NotNull] string searchString, string path, string escapeChar)
-        //     => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(JsonSearchAll)));
     }
 }

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlByteArrayMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlByteArrayMethodTranslator.cs
@@ -10,19 +10,20 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 {
     public class MySqlByteArrayMethodTranslator : IMethodCallTranslator
     {
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
         private static readonly MethodInfo _containsMethod = typeof(Enumerable)
             .GetTypeInfo()
             .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
             .Single(m => m.Name == nameof(Enumerable.Contains) && m.GetParameters().Length == 2);
 
-        public MySqlByteArrayMethodTranslator([NotNull] ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlByteArrayMethodTranslator([NotNull] MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
         }
@@ -49,11 +50,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                     : _sqlExpressionFactory.Convert(arguments[1], typeof(byte[]), sourceTypeMapping);
 
                 return _sqlExpressionFactory.GreaterThan(
-                    _sqlExpressionFactory.Function(
+                    _sqlExpressionFactory.NullableFunction(
                         "LOCATE",
                         new[] { value, source },
-                        nullable: true,
-                        argumentsPropagateNullability: new[] { true, true },
                         typeof(int)),
                     _sqlExpressionFactory.Constant(0));
             }

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlDbFunctionsExtensionsMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlDbFunctionsExtensionsMethodTranslator.cs
@@ -10,9 +10,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
-using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 {
@@ -22,7 +20,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
     /// </summary>
     public class MySqlDbFunctionsExtensionsMethodTranslator : IMethodCallTranslator
     {
-        private readonly IMySqlOptions _options;
         private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
         private static readonly Type[] _supportedLikeTypes = {
@@ -111,12 +108,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 
         private static readonly MethodInfo _unhexMethodInfo = typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.Unhex), new[] {typeof(DbFunctions), typeof(string)});
 
-        public MySqlDbFunctionsExtensionsMethodTranslator(
-            ISqlExpressionFactory sqlExpressionFactory,
-            IMySqlOptions options)
+        public MySqlDbFunctionsExtensionsMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = (MySqlSqlExpressionFactory)sqlExpressionFactory;
-            _options = options;
         }
 
         /// <summary>
@@ -183,22 +177,19 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 
             if (_hexMethodInfos.Any(m => Equals(method, m)))
             {
-                return _sqlExpressionFactory.Function(
+                return _sqlExpressionFactory.NullableFunction(
                     "HEX",
                     new[] {arguments[1]},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[1],
                     typeof(string));
             }
 
-            if (method == _unhexMethodInfo)
+            if (Equals(method, _unhexMethodInfo))
             {
-                return _sqlExpressionFactory.Function(
+                return _sqlExpressionFactory.NullableFunction(
                     "UNHEX",
                     new[] {arguments[1]},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[1],
-                    typeof(string));
+                    typeof(string),
+                    false);
             }
 
             return null;

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonDbFunctionsTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonDbFunctionsTranslator.cs
@@ -15,7 +15,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 {
@@ -64,55 +63,41 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             var result = method.Name switch
             {
                 nameof(MySqlJsonDbFunctionsExtensions.JsonType)
-                => _sqlExpressionFactory.Function(
+                => _sqlExpressionFactory.NullableFunction(
                     "JSON_TYPE",
                     new[] {args[0]},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[1],
                     typeof(string)),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonContains)
-                => _sqlExpressionFactory.Function(
+                => _sqlExpressionFactory.NullableFunction(
                     "JSON_CONTAINS",
                     args.Length >= 3
                         ? new[] {Json(args[0]), args[1], args[2]}
                         : new[] {Json(args[0]), args[1]},
-                    nullable: true,
-                    argumentsPropagateNullability: args.Length >= 3
-                        ? TrueArrays[3]
-                        : TrueArrays[2],
                     typeof(bool)),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonContainsPath)
-                => _sqlExpressionFactory.Function(
+                => _sqlExpressionFactory.NullableFunction(
                     "JSON_CONTAINS_PATH",
                     new[] {Json(args[0]), _sqlExpressionFactory.Constant("one"), args[1]},
-                    nullable: true,
-                    argumentsPropagateNullability: new []{true, false, true},
                     typeof(bool)),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonContainsPathAny)
-                => _sqlExpressionFactory.Function(
+                => _sqlExpressionFactory.NullableFunction(
                     "JSON_CONTAINS_PATH",
                     Array.Empty<SqlExpression>()
                         .Append(Json(args[0]))
                         .Append(_sqlExpressionFactory.Constant("one"))
                         .Concat(DeconstructParamsArray(args[1])),
-                    nullable: true,
-                    argumentsPropagateNullability: new []{true, false}
-                        .Concat(Enumerable.Repeat(true, DeconstructParamsArray(args[1]).Count())),
                     typeof(bool)),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonContainsPathAll)
-                => _sqlExpressionFactory.Function(
+                => _sqlExpressionFactory.NullableFunction(
                     "JSON_CONTAINS_PATH",
                     Array.Empty<SqlExpression>()
                         .Append(Json(args[0]))
                         .Append(_sqlExpressionFactory.Constant("all"))
                         .Concat(DeconstructParamsArray(args[1])),
-                    nullable: true,
-                    argumentsPropagateNullability: new []{true, false}
-                        .Concat(Enumerable.Repeat(true, DeconstructParamsArray(args[1]).Count())),
                     typeof(bool)),
                 nameof(MySqlJsonDbFunctionsExtensions.JsonSearchAny)
                 => (SqlExpression)_sqlExpressionFactory.IsNotNull(
-                    _sqlExpressionFactory.Function(
+                    _sqlExpressionFactory.NullableFunction(
                         "JSON_SEARCH",
                         Array.Empty<SqlExpression>()
                             .Append(Json(args[0]))
@@ -122,28 +107,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                                 ? args[3]
                                 : _sqlExpressionFactory.Constant(null, RelationalTypeMapping.NullMapping))
                             .AppendIfTrue(args.Length >= 3, () => args[2]),
-                        nullable: true,
-                        argumentsPropagateNullability: new[]{true, false, true}
-                            .AppendIfTrue(args.Length >= 3, () => false)
-                            .AppendIfTrue(args.Length >= 3, () => true),
-                        typeof(bool))),
-                // nameof(MySqlJsonDbFunctionsExtensions.JsonSearchAll)
-                // => _sqlExpressionFactory.IsNotNull(
-                //     _sqlExpressionFactory.Function(
-                //         "JSON_SEARCH",
-                //         Array.Empty<SqlExpression>()
-                //             .Append(Json(args[0]))
-                //             .Append(_sqlExpressionFactory.Constant("all"))
-                //             .Append(args[1])
-                //             .AppendIfTrue(args.Length >= 3, () => args.Length >= 4
-                //                 ? args[3]
-                //                 : _sqlExpressionFactory.Constant(null, RelationalTypeMapping.NullMapping))
-                //             .AppendIfTrue(args.Length >= 3, () => args[2]),
-                //         nullable: true,
-                //         argumentsPropagateNullability: new[]{true, false, true}
-                //             .AppendIfTrue(args.Length >= 3, () => false)
-                //             .AppendIfTrue(args.Length >= 3, () => true),
-                //         typeof(bool))) as SqlExpression,
+                        typeof(bool),
+                        null,
+                        false)), // JSON_SEARCH can return null even if all arguments are not null
                 _ => null
             };
 

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonPocoTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonPocoTranslator.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 {
@@ -96,13 +95,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
         public virtual SqlExpression TranslateArrayLength([NotNull] SqlExpression expression)
             => expression is MySqlJsonTraversalExpression ||
                expression is ColumnExpression columnExpression && columnExpression.TypeMapping is MySqlJsonTypeMapping
-                ? _sqlExpressionFactory.Function(
+                ? _sqlExpressionFactory.NullableFunction(
                     "JSON_LENGTH",
                     new[] {expression},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[1],
                     typeof(int),
-                    _intTypeMapping)
+                    _intTypeMapping,
+                    false)
                 : null;
 
         private SqlExpression ConvertFromJsonExtract(SqlExpression expression, Type returnType)

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
@@ -12,7 +12,6 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 {
@@ -389,13 +388,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 
             // The prefix is non-constant, we use LEFT to extract the substring and compare.
             return _sqlExpressionFactory.Equal(
-                _sqlExpressionFactory.Function(
+                _sqlExpressionFactory.NullableFunction(
                     startsWith
                         ? "LEFT"
                         : "RIGHT",
                     new[] {targetTransform(target), CharLength(prefixSuffix)},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[2],
                     typeof(string),
                     stringTypeMapping),
                 prefixSuffixTransform(prefixSuffix));
@@ -426,6 +423,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                             patternTransform(_sqlExpressionFactory.Constant('%' + EscapeLikePattern(constantPatternString) + '%')));
                 }
 
+                // TODO: EF Core 5
                 // https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/996#issuecomment-607876040
                 // Can return NULL in .NET 5 after https://github.com/dotnet/efcore/issues/20498 has been fixed.
                 // `something LIKE NULL` always returns `NULL`. We will return `false`, to indicate, that no match
@@ -440,11 +438,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             // LOCATE('foo', 'barfoobar') > 0
             // Using an empty pattern `LOCATE('', 'barfoobar')` returns 1.
             return _sqlExpressionFactory.GreaterThan(
-                _sqlExpressionFactory.Function(
+                _sqlExpressionFactory.NullableFunction(
                     "LOCATE",
                     new[] {patternTransform(pattern), targetTransform(target)},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[2],
                     typeof(int)),
                 _sqlExpressionFactory.Constant(0));
         }
@@ -511,11 +507,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             // LOCATE('foo', 'barfoobar') - 1
             // Using an empty pattern `LOCATE('', 'barfoobar') - 1` returns 0.
             return _sqlExpressionFactory.Subtract(
-                _sqlExpressionFactory.Function(
+                _sqlExpressionFactory.NullableFunction(
                     "LOCATE",
                     new[] {patternTransform(pattern), targetTransform(target)},
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[2],
                     typeof(int)),
                 _sqlExpressionFactory.Constant(1));
         }
@@ -556,16 +550,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             };
 
         private SqlExpression LCase(SqlExpression value)
-            => _sqlExpressionFactory.Function(
+            => _sqlExpressionFactory.NullableFunction(
                 "LCASE",
-                new[]
-                {
-                    value
-                },
-                nullable: true,
-                argumentsPropagateNullability: TrueArrays[1],
-                value.Type,
-                null);
+                new[] {value},
+                value.Type);
 
         private SqlExpression Utf8Bin(SqlExpression value)
             => _sqlExpressionFactory.Collate(
@@ -575,16 +563,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             );
 
         private SqlExpression CharLength(SqlExpression value)
-            => _sqlExpressionFactory.Function(
+            => _sqlExpressionFactory.NullableFunction(
                 "CHAR_LENGTH",
-                new[]
-                {
-                    value
-                },
-                nullable: true,
-                argumentsPropagateNullability: TrueArrays[1],
-                typeof(int),
-                null);
+                new[] {value},
+                typeof(int));
 
         private const char LikeEscapeChar = '\\';
 

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlSqlTranslatingExpressionVisitor.cs
@@ -11,7 +11,6 @@ using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
 {
@@ -44,11 +43,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
                 if (sqlOperand.Type == typeof(byte[]) &&
                     (sqlOperand.TypeMapping == null || sqlOperand.TypeMapping is MySqlByteArrayTypeMapping))
                 {
-                    return _sqlExpressionFactory.Function(
+                    return _sqlExpressionFactory.NullableFunction(
                         "LENGTH",
                         new[] {sqlOperand},
-                        nullable: true,
-                        argumentsPropagateNullability: TrueArrays[1],
                         typeof(int));
                 }
 

--- a/src/EFCore.MySql/Query/Internal/MySqlDateDiffFunctionsTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlDateDiffFunctionsTranslator.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -190,9 +189,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                     "MICROSECOND"
                 }
             };
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
-        public MySqlDateDiffFunctionsTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlDateDiffFunctionsTranslator(MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
         }
@@ -212,7 +211,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 startDate = _sqlExpressionFactory.ApplyTypeMapping(startDate, typeMapping);
                 endDate = _sqlExpressionFactory.ApplyTypeMapping(endDate, typeMapping);
 
-                return _sqlExpressionFactory.Function(
+                return _sqlExpressionFactory.NullableFunction(
                     "TIMESTAMPDIFF",
                     new[]
                     {
@@ -220,9 +219,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                         startDate,
                         endDate
                     },
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[3],
-                    typeof(int));
+                    typeof(int),
+                    typeMapping: null,
+                    onlyNullWhenAnyNullPropagatingArgumentIsNull: true,
+                    argumentsPropagateNullability: new []{false, true, true});
             }
 
             return null;

--- a/src/EFCore.MySql/Query/Internal/MySqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlDateTimeMemberTranslator.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -47,7 +46,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 
                 if (_datePartMapping.TryGetValue(memberName, out var datePart))
                 {
-                    var extract = _sqlExpressionFactory.Function(
+                    var extract = _sqlExpressionFactory.NullableFunction(
                         "EXTRACT",
                         new[]
                         {
@@ -58,9 +57,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                                 },
                                 typeof(string))
                         },
-                        nullable: true,
-                        argumentsPropagateNullability: TrueArrays[1],
-                        returnType);
+                        returnType,
+                        false);
 
                     if (datePart.Divisor != 1)
                     {
@@ -75,53 +73,45 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 switch (memberName)
                 {
                     case nameof(DateTime.DayOfYear):
-                        return _sqlExpressionFactory.Function(
+                        return _sqlExpressionFactory.NullableFunction(
                         "DAYOFYEAR",
                         new[] { instance },
-                        nullable: true,
-                        argumentsPropagateNullability: TrueArrays[1],
-                        returnType);
+                        returnType,
+                        false);
 
                     case nameof(DateTime.Date):
-                        return _sqlExpressionFactory.Function(
+                        return _sqlExpressionFactory.NullableFunction(
                             "CONVERT",
                             new[]{
                                 instance,
                                 _sqlExpressionFactory.Fragment("date")
                             },
-                            nullable: true,
-                            argumentsPropagateNullability: TrueArrays[2],
-                            returnType);
+                            returnType,
+                            false);
 
                     case nameof(DateTime.TimeOfDay):
                         return _sqlExpressionFactory.Convert(instance, returnType);
 
                     case nameof(DateTime.Now):
-                        return _sqlExpressionFactory.Function(
+                        return _sqlExpressionFactory.NonNullableFunction(
                             declaringType == typeof(DateTimeOffset)
                                 ? "UTC_TIMESTAMP"
                                 : "CURRENT_TIMESTAMP",
                             Array.Empty<SqlExpression>(),
-                            nullable: false,
-                            argumentsPropagateNullability: FalseArrays[0],
                             returnType);
 
                     case nameof(DateTime.UtcNow):
-                        return _sqlExpressionFactory.Function(
+                        return _sqlExpressionFactory.NonNullableFunction(
                             "UTC_TIMESTAMP",
                             Array.Empty<SqlExpression>(),
-                            nullable: false,
-                            argumentsPropagateNullability: FalseArrays[0],
                             returnType);
 
                     case nameof(DateTime.Today):
-                        return _sqlExpressionFactory.Function(
+                        return _sqlExpressionFactory.NonNullableFunction(
                             declaringType == typeof(DateTimeOffset)
                                 ? "UTC_DATE"
                                 : "CURDATE",
                             Array.Empty<SqlExpression>(),
-                            nullable: false,
-                            argumentsPropagateNullability: FalseArrays[0],
                             returnType);
                 }
             }

--- a/src/EFCore.MySql/Query/Internal/MySqlDateTimeMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlDateTimeMethodTranslator.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -51,22 +50,23 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                        && ((double)sqlConstant.Value >= int.MaxValue
                            || (double)sqlConstant.Value <= int.MinValue)
                     ? null
-                    : _sqlExpressionFactory.Function(
+                    : _sqlExpressionFactory.NullableFunction(
                         "DATE_ADD",
                         new[]
                         {
                             instance,
-                            _sqlExpressionFactory.ComplexFunctionArgument(new SqlExpression[]
-                            {
-                                _sqlExpressionFactory.Fragment("INTERVAL"),
-                                _sqlExpressionFactory.Convert(arguments[0], typeof(int)),
-                                _sqlExpressionFactory.Fragment(datePart)
-                            }, typeof(string))
+                            _sqlExpressionFactory.ComplexFunctionArgument(
+                                new SqlExpression[]
+                                {
+                                    _sqlExpressionFactory.Fragment("INTERVAL"),
+                                    _sqlExpressionFactory.Convert(arguments[0], typeof(int)),
+                                    _sqlExpressionFactory.Fragment(datePart)
+                                }, typeof(string))
                         },
-                        nullable: true,
-                        argumentsPropagateNullability: TrueArrays[2],
                         instance.Type,
-                        instance.TypeMapping);
+                        instance.TypeMapping,
+                        true,
+                        new[] {true, false});
             }
 
             return null;

--- a/src/EFCore.MySql/Query/Internal/MySqlMathMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlMathMethodTranslator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -14,61 +13,61 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlMathMethodTranslator : IMethodCallTranslator
     {
-        private static readonly Dictionary<MethodInfo, string> _supportedMethodTranslations = new Dictionary<MethodInfo, string>
+        private static readonly IDictionary<MethodInfo, (string Name, bool OnlyNullByArgs)> _methodToFunctionName = new Dictionary<MethodInfo, (string Name, bool OnlyNullByArgs)>
         {
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(decimal) }), "ABS" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(double) }), "ABS" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(float) }), "ABS" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(int) }), "ABS" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(long) }), "ABS" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(short) }), "ABS" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Acos), new[] { typeof(double) }), "ACOS" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Asin), new[] { typeof(double) }), "ASIN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Atan), new[] { typeof(double) }), "ATAN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Atan2), new[] { typeof(double), typeof(double) }), "ATAN2" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(decimal) }), "CEILING" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(double) }), "CEILING" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Cos), new[] { typeof(double) }), "COS" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Exp), new[] { typeof(double) }), "EXP" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Floor), new[] { typeof(decimal) }), "FLOOR" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Floor), new[] { typeof(double) }), "FLOOR" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Log), new[] { typeof(double) }), "LOG" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Log), new[] { typeof(double), typeof(double) }), "LOG" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Log10), new[] { typeof(double) }), "LOG10" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(decimal), typeof(decimal) }), "GREATEST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(double), typeof(double) }), "GREATEST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(float), typeof(float) }), "GREATEST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(int), typeof(int) }), "GREATEST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(long), typeof(long) }), "GREATEST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(short), typeof(short) }), "GREATEST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(decimal), typeof(decimal) }), "LEAST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(double), typeof(double) }), "LEAST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(float), typeof(float) }), "LEAST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(int), typeof(int) }), "LEAST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(long), typeof(long) }), "LEAST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(short), typeof(short) }), "LEAST" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) }), "POWER" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(double) }), "ROUND" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(double), typeof(int) }), "ROUND" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal) }), "ROUND" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal), typeof(int) }), "ROUND" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(decimal) }), "SIGN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(double) }), "SIGN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(float) }), "SIGN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(int) }), "SIGN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(long) }), "SIGN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(sbyte) }), "SIGN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(short) }), "SIGN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sin), new[] { typeof(double) }), "SIN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Sqrt), new[] { typeof(double) }), "SQRT" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Tan), new[] { typeof(double) }), "TAN" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Truncate), new[] { typeof(double) }), "TRUNCATE" },
-            { typeof(Math).GetRuntimeMethod(nameof(Math.Truncate), new[] { typeof(decimal) }), "TRUNCATE" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(decimal) }), ("ABS", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(double) }), ("ABS", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(float) }), ("ABS", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(int) }), ("ABS", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(long) }), ("ABS", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(short) }), ("ABS", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Acos), new[] { typeof(double) }), ("ACOS", false) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Asin), new[] { typeof(double) }), ("ASIN", false) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Atan), new[] { typeof(double) }), ("ATAN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Atan2), new[] { typeof(double), typeof(double) }), ("ATAN2", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(decimal) }), ("CEILING", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(double) }), ("CEILING", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Cos), new[] { typeof(double) }), ("COS", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Exp), new[] { typeof(double) }), ("EXP", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Floor), new[] { typeof(decimal) }), ("FLOOR", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Floor), new[] { typeof(double) }), ("FLOOR", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Log), new[] { typeof(double) }), ("LOG", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Log), new[] { typeof(double), typeof(double) }), ("LOG", false) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Log10), new[] { typeof(double) }), ("LOG10", false) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(decimal), typeof(decimal) }), ("GREATEST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(double), typeof(double) }), ("GREATEST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(float), typeof(float) }), ("GREATEST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(int), typeof(int) }), ("GREATEST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(long), typeof(long) }), ("GREATEST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(short), typeof(short) }), ("GREATEST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(decimal), typeof(decimal) }), ("LEAST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(double), typeof(double) }), ("LEAST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(float), typeof(float) }), ("LEAST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(int), typeof(int) }), ("LEAST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(long), typeof(long) }), ("LEAST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(short), typeof(short) }), ("LEAST", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) }), ("POWER", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(double) }), ("ROUND", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(double), typeof(int) }), ("ROUND", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal) }), ("ROUND", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal), typeof(int) }), ("ROUND", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(decimal) }), ("SIGN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(double) }), ("SIGN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(float) }), ("SIGN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(int) }), ("SIGN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(long) }), ("SIGN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(sbyte) }), ("SIGN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(short) }), ("SIGN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sin), new[] { typeof(double) }), ("SIN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sqrt), new[] { typeof(double) }), ("SQRT", false) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Tan), new[] { typeof(double) }), ("TAN", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Truncate), new[] { typeof(double) }), ("TRUNCATE", true) },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Truncate), new[] { typeof(decimal) }), ("TRUNCATE", true) },
         };
 
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
-        public MySqlMathMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlMathMethodTranslator(MySqlSqlExpressionFactory sqlExpressionFactory)
             => _sqlExpressionFactory = sqlExpressionFactory;
 
         /// <inheritdoc />
@@ -78,11 +77,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             IReadOnlyList<SqlExpression> arguments,
             IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
-            if (_supportedMethodTranslations.TryGetValue(method, out var sqlFunctionName))
+            if (_methodToFunctionName.TryGetValue(method, out var mapping))
             {
                 var targetArgumentsCount = arguments.Count;
 
-                if (sqlFunctionName == "TRUNCATE")
+                if (mapping.Name == "TRUNCATE")
                 {
                     targetArgumentsCount = 2;
                 }
@@ -102,12 +101,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                     }
                 }
 
-                return _sqlExpressionFactory.Function(
-                    sqlFunctionName,
+                return _sqlExpressionFactory.NullableFunction(
+                    mapping.Name,
                     newArguments,
-                    nullable: true,
-                    argumentsPropagateNullability: Enumerable.Repeat(true, newArguments.Length),
-                    method.ReturnType);
+                    method.ReturnType,
+                    mapping.OnlyNullByArgs);
             }
 
             return null;

--- a/src/EFCore.MySql/Query/Internal/MySqlMethodCallTranslatorProvider.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlMethodCallTranslatorProvider.cs
@@ -4,7 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
-using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
@@ -13,8 +12,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
     {
         public MySqlMethodCallTranslatorProvider(
             [NotNull] RelationalMethodCallTranslatorProviderDependencies dependencies,
-            [NotNull] IRelationalTypeMappingSource typeMappingSource,
-            [NotNull] IMySqlOptions options)
+            [NotNull] IRelationalTypeMappingSource typeMappingSource)
             : base(dependencies)
         {
             var sqlExpressionFactory = (MySqlSqlExpressionFactory)dependencies.SqlExpressionFactory;
@@ -25,7 +23,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 new MySqlConvertTranslator(sqlExpressionFactory),
                 new MySqlDateTimeMethodTranslator(sqlExpressionFactory),
                 new MySqlDateDiffFunctionsTranslator(sqlExpressionFactory),
-                new MySqlDbFunctionsExtensionsMethodTranslator(sqlExpressionFactory, options),
+                new MySqlDbFunctionsExtensionsMethodTranslator(sqlExpressionFactory),
                 new MySqlJsonDbFunctionsTranslator(sqlExpressionFactory, typeMappingSource),
                 new MySqlMathMethodTranslator(sqlExpressionFactory),
                 new MySqlNewGuidTranslator(sqlExpressionFactory),

--- a/src/EFCore.MySql/Query/Internal/MySqlNewGuidTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlNewGuidTranslator.cs
@@ -8,16 +8,15 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlNewGuidTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo _methodInfo = typeof(Guid).GetRuntimeMethod(nameof(Guid.NewGuid), Array.Empty<Type>());
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
-        public MySqlNewGuidTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlNewGuidTranslator(MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
         }
@@ -29,11 +28,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             return _methodInfo.Equals(method)
-                ? _sqlExpressionFactory.Function(
+                ? _sqlExpressionFactory.NonNullableFunction(
                     "UUID",
                     Array.Empty<SqlExpression>(),
-                    nullable: false,
-                    argumentsPropagateNullability: FalseArrays[0],
                     method.ReturnType)
                 : null;
         }

--- a/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
@@ -9,7 +9,9 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -50,6 +52,112 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 scale);
 
         #region Expression factory methods
+
+        /// <summary>
+        /// Use for any function that could return `NULL` for *any* reason.
+        /// </summary>
+        /// <param name="name">The SQL name of the function.</param>
+        /// <param name="arguments">The arguments of the function.</param>
+        /// <param name="returnType">The CLR return type of the function.</param>
+        /// <param name="onlyNullWhenAnyNullPropagatingArgumentIsNull">
+        /// Set to `false` if the function can return `NULL` even if all of the arguments are not `NULL`. This will disable null-related
+        /// optimizations by EF Core.
+        /// </param>
+        /// <remarks>See https://github.com/dotnet/efcore/issues/23042</remarks>
+        /// <returns>The function expression.</returns>
+        public virtual SqlFunctionExpression NullableFunction(
+            string name,
+            IEnumerable<SqlExpression> arguments,
+            Type returnType,
+            bool onlyNullWhenAnyNullPropagatingArgumentIsNull)
+            => NullableFunction(name, arguments, returnType, null, onlyNullWhenAnyNullPropagatingArgumentIsNull);
+
+        /// <summary>
+        /// Use for any function that could return `NULL` for *any* reason.
+        /// </summary>
+        /// <param name="name">The SQL name of the function.</param>
+        /// <param name="arguments">The arguments of the function.</param>
+        /// <param name="returnType">The CLR return type of the function.</param>
+        /// <param name="typeMapping">The optional type mapping of the function.</param>
+        /// <param name="onlyNullWhenAnyNullPropagatingArgumentIsNull">
+        ///     Set to `false` if the function can return `NULL` even if all of the arguments are not `NULL`. This will disable null-related
+        ///     optimizations by EF Core.
+        /// </param>
+        /// <param name="argumentsPropagateNullability">
+        ///     The optional nullability array of the function.
+        ///     If omited and <paramref name="onlyNullWhenAnyNullPropagatingArgumentIsNull"/> is
+        ///     `true` (the default), all parameters will propagate nullability (meaning if any parameter is `NULL`, the function will
+        ///     automatically return `NULL` as well).
+        ///     If <paramref name="onlyNullWhenAnyNullPropagatingArgumentIsNull"/> is explicitly set to `false`, the
+        ///     null propagating capabilities of the arguments don't matter at all anymore, because the function will never be optimized by
+        ///     EF Core in the first place.
+        /// </param>
+        /// <remarks>See https://github.com/dotnet/efcore/issues/23042</remarks>
+        /// <returns>The function expression.</returns>
+        public virtual SqlFunctionExpression NullableFunction(
+            string name,
+            IEnumerable<SqlExpression> arguments,
+            Type returnType,
+            RelationalTypeMapping typeMapping = null,
+            bool onlyNullWhenAnyNullPropagatingArgumentIsNull = true,
+            IEnumerable<bool> argumentsPropagateNullability = null)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotNull(arguments, nameof(arguments));
+            Check.NotNull(returnType, nameof(returnType));
+
+            var typeMappedArguments = new List<SqlExpression>();
+
+            foreach (var argument in arguments)
+            {
+                typeMappedArguments.Add(ApplyDefaultTypeMapping(argument));
+            }
+
+            return new SqlFunctionExpression(
+                name,
+                typeMappedArguments,
+                true,
+                onlyNullWhenAnyNullPropagatingArgumentIsNull
+                    ? (argumentsPropagateNullability ?? Statics.GetTrueValues(typeMappedArguments.Count))
+                    : Statics.GetFalseValues(typeMappedArguments.Count),
+                returnType,
+                typeMapping);
+        }
+
+        /// <summary>
+        /// Use for any function that will never return `NULL`.
+        /// </summary>
+        /// <param name="name">The SQL name of the function.</param>
+        /// <param name="arguments">The arguments of the function.</param>
+        /// <param name="returnType">The CLR return type of the function.</param>
+        /// <param name="typeMapping">The optional type mapping of the function.</param>
+        /// <remarks>See https://github.com/dotnet/efcore/issues/23042</remarks>
+        /// <returns>The function expression.</returns>
+        public virtual SqlFunctionExpression NonNullableFunction(
+            string name,
+            IEnumerable<SqlExpression> arguments,
+            Type returnType,
+            RelationalTypeMapping typeMapping = null)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotNull(arguments, nameof(arguments));
+            Check.NotNull(returnType, nameof(returnType));
+
+            var typeMappedArguments = new List<SqlExpression>();
+
+            foreach (var argument in arguments)
+            {
+                typeMappedArguments.Add(ApplyDefaultTypeMapping(argument));
+            }
+
+            return new SqlFunctionExpression(
+                name,
+                typeMappedArguments,
+                false,
+                Statics.GetFalseValues(typeMappedArguments.Count),
+                returnType,
+                typeMapping);
+        }
 
         public MySqlComplexFunctionArgumentExpression ComplexFunctionArgument(
             IEnumerable<SqlExpression> argumentParts,

--- a/src/EFCore.MySql/Query/Internal/MySqlStringMemberTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlStringMemberTranslator.cs
@@ -7,15 +7,14 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using static Pomelo.EntityFrameworkCore.MySql.Utilities.Statics;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlStringMemberTranslator : IMemberTranslator
     {
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
-        public MySqlStringMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlStringMemberTranslator(MySqlSqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
         }
@@ -29,11 +28,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             if (member.Name == nameof(string.Length)
                 && instance?.Type == typeof(string))
             {
-                return _sqlExpressionFactory.Function(
+                return _sqlExpressionFactory.NullableFunction(
                     "CHAR_LENGTH",
                     new[] { instance },
-                    nullable: true,
-                    argumentsPropagateNullability: TrueArrays[1],
                     returnType);
             }
 

--- a/src/EFCore.MySql/Query/Internal/MySqlTimeSpanMemberTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlTimeSpanMemberTranslator.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -24,9 +23,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             };
         private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
-        public MySqlTimeSpanMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlTimeSpanMemberTranslator(MySqlSqlExpressionFactory sqlExpressionFactory)
         {
-            _sqlExpressionFactory = (MySqlSqlExpressionFactory)sqlExpressionFactory;
+            _sqlExpressionFactory = sqlExpressionFactory;
         }
 
         public virtual SqlExpression Translate(
@@ -41,7 +40,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             if (declaringType == typeof(TimeSpan) &&
                 _datePartMapping.TryGetValue(memberName, out var datePart))
             {
-                var extract = _sqlExpressionFactory.Function(
+                var extract = _sqlExpressionFactory.NullableFunction(
                     "EXTRACT",
                     new[]
                     {
@@ -52,9 +51,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                             },
                             typeof(string))
                     },
-                    nullable: true,
-                    argumentsPropagateNullability: Statics.TrueArrays[1],
-                    returnType);
+                    returnType,
+                    false);
 
                 if (datePart.Divisor != 1)
                 {

--- a/src/Shared/Statics.cs
+++ b/src/Shared/Statics.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Utilities
 {
@@ -15,14 +17,48 @@ namespace Pomelo.EntityFrameworkCore.MySql.Utilities
             new[] { true, true, true },
             new[] { true, true, true, true },
             new[] { true, true, true, true, true },
-            new[] { true, true, true, true, true, true }
+            new[] { true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true },
+            new[] { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true },
         };
 
         internal static readonly bool[][] FalseArrays =
         {
             Array.Empty<bool>(),
             new[] { false },
-            new[] { false, false }
+            new[] { false, false },
+            new[] { false, false, false },
+            new[] { false, false, false, false },
+            new[] { false, false, false, false, false },
+            new[] { false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false, false, false, false, false, false, false, false },
+            new[] { false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false },
         };
+
+        internal static IEnumerable<bool> GetTrueValues(int dimensions)
+            => dimensions <= 16
+                ? TrueArrays[dimensions]
+                : Enumerable.Repeat(true, dimensions);
+
+        internal static IEnumerable<bool> GetFalseValues(int dimensions)
+            => dimensions <= 16
+                ? FalseArrays[dimensions]
+                : Enumerable.Repeat(true, dimensions);
     }
 }


### PR DESCRIPTION
While I revisited all SQL function translations and their argument null propagation, I seized the opportunity to document them all in an Excel sheet, so we can add them to the wiki later, so users can lookup which properties/method calls are being translated to SQL. I'll attach it here, so it cannot get lost:

[Translations_20201031_01.xlsx](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/files/5471892/Translations_20201031_01.xlsx)