### PR TITLE
Increase `max_connections` allowed for MySQL/MariaDB in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ variables:
   mysql_legacy_sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
   # Currently no ONLY_FULL_GROUP_BY, see #1167:
   mariadb_sql_mode: STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+  max_connections: 255
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   dotnet_version: 5.0.100-preview.8.20417.9
@@ -88,7 +89,7 @@ jobs:
         exit 1
       fi
 
-      docker exec mysql mysql -h localhost -P 3306 -u root -pPassword12! -e "SET GLOBAL sql_mode = '$SQL_MODE';"
+      docker exec mysql mysql -h localhost -P 3306 -u root -pPassword12! -e "SET GLOBAL sql_mode = '$SQL_MODE'; SET GLOBAL max_connections = $(max_connections);"
     displayName: Setup Database
   - bash: |
       docker exec mysql mysql -h localhost -P 3306 -u root -pPassword12! -e "SHOW VARIABLES;';"
@@ -212,7 +213,7 @@ jobs:
       .\build.cmd
     displayName: Setup and Build Solution
   - pwsh: |
-      mysql -h localhost -u root -pPassword12! -e "SET GLOBAL sql_mode = '$(sql_mode)';"
+      mysql -h localhost -u root -pPassword12! -e "SET GLOBAL sql_mode = '$(sql_mode)'; SET GLOBAL max_connections = $(max_connections);"
     displayName: Setup Database
     ignoreLASTEXITCODE: true
   - pwsh: |

--- a/src/EFCore.MySql/Storage/Internal/MySqlTransientExceptionDetector.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTransientExceptionDetector.cs
@@ -10,7 +10,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     /// <summary>
     ///     Detects the exceptions caused by MySQL transient failures.
     /// </summary>
-    public class MySqlTransientExceptionDetector
+    public static class MySqlTransientExceptionDetector
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/TestMySqlRetryingExecutionStrategy.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/TestMySqlRetryingExecutionStrategy.cs
@@ -9,6 +9,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
     {
         private const bool ErrorNumberDebugMode = false;
 
+        // TODO: Check for correct MySQL error codes.
         private static readonly int[] _additionalErrorNumbers =
         {
             -1, // Physical connection is not usable


### PR DESCRIPTION
Fixes a non-deterministic issue, where the `max_connections` limit for a server implementation can be reached while running the functional tests.