### PR TITLE
Skip Windows tests only under certain conditions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
         databaseServerType: 'mysql'
         databaseServerVersion: '8.0.21'
         sqlMode: $(mysqlCurrentSqlMode)
-        skipTests: $(isPullRequest)
+        skipTests: $[and(variables['isPullRequest'], not(or(contains(variables['Build.SourceBranchName'], 'windows'), contains(variables['Build.SourceVersionMessage'], 'windows'))))]
       MySQL 8.0 (Linux):
         vmImageName: 'ubuntu-latest'
         databaseServerType: 'mysql'


### PR DESCRIPTION
We skip Windows tests if neither the branch name nor the commit message contains 'windows' and CI is run on an open PR (so not the final merge of the PR into a branch).

This will cut CI runtime by half.