### PR TITLE
Fix TimeSpan value translation of milliseconds

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlTimeSpanTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTimeSpanTypeMapping.cs
@@ -62,8 +62,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         {
             // Custom TimeSpan formats do not handle the fraction point character as gracefully as System.DateTime does.
             var literal = base.GenerateNonNullSqlLiteral(value);
-            return literal.EndsWith(".0")
-                ? "'" + literal.Substring(0, literal.Length - 2) + "'"
+            return literal.EndsWith(".")
+                ? "'" + literal.Substring(0, literal.Length - 1) + "'"
                 : "'" + literal + "'";
         }
 
@@ -80,7 +80,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         {
             var validPrecision = Math.Min(Math.Max(precision.GetValueOrDefault(), 0), 6);
             var precisionFormat = validPrecision > 0
-                ? @"\.f" + new string('F', validPrecision - 1)
+                ? @"\." + new string('F', validPrecision)
                 : null;
             return @"hh\:mm\:ss" + precisionFormat;
         }


### PR DESCRIPTION
A TimeSpan of `12:34:56.007` was incorrectly translated as `12:34:56.0007` before.