### PR TITLE
Add support for `ToQueryString()`

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IHistoryRepository, MySqlHistoryRepository>()
                 .TryAdd<ICompiledQueryCacheKeyGenerator, MySqlCompiledQueryCacheKeyGenerator>()
                 .TryAdd<IExecutionStrategyFactory, MySqlExecutionStrategyFactory>()
+                .TryAdd<IRelationalQueryStringFactory, MySqlQueryStringFactory>()
                 .TryAdd<IMigrator, MySqlMigrator>()
                 .TryAdd<IMethodCallTranslatorProvider, MySqlMethodCallTranslatorProvider>()
                 .TryAdd<IMemberTranslatorProvider, MySqlMemberTranslatorProvider>()

--- a/src/EFCore.MySql/Query/Internal/MySqlCommandParser.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlCommandParser.cs
@@ -1,0 +1,379 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
+{
+    public class MySqlCommandParser
+    {
+        public string SqlFragment { get; }
+        public char[] States { get; }
+
+        public MySqlCommandParser(string sqlFragment)
+        {
+            SqlFragment = sqlFragment ?? throw new ArgumentNullException(nameof(sqlFragment));
+            States = new char[sqlFragment.Length];
+
+            Parse();
+        }
+
+        public IReadOnlyList<int> GetStateIndices(char state, int start = 0, int length = -1)
+        {
+            if (start < 0 ||
+                start >= States.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(start));
+            }
+
+            if (length < 0 ||
+                length > 0 && start + length > States.Length)
+            {
+                length = States.Length - start;
+            }
+
+            var stateIndices = new List<int>();
+            char? lastState = null;
+
+            for (var i = start; i < length; i++)
+            {
+                var currentState = States[i];
+
+                if (currentState == state &&
+                    currentState != lastState)
+                {
+                    stateIndices.Add(i);
+                }
+
+                lastState = currentState;
+            }
+
+            return stateIndices.AsReadOnly();
+        }
+
+        public IReadOnlyList<int> GetStateIndices(char[] states, int start = 0, int length = -1)
+        {
+            if (states == null)
+            {
+                throw new ArgumentNullException(nameof(states));
+            }
+
+            if (states.Length <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(states));
+            }
+
+            if (start < 0 ||
+                start >= States.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(start));
+            }
+
+            if (length < 0 ||
+                length > 0 && start + length > States.Length)
+            {
+                length = States.Length - start;
+            }
+
+            var stateIndices = new List<int>();
+            char? lastState = null;
+
+            for (var i = start; i < length; i++)
+            {
+                var currentState = States[i];
+
+                if (currentState != lastState &&
+                    states.Contains(currentState))
+                {
+                    stateIndices.Add(i);
+                }
+
+                lastState = currentState;
+            }
+
+            return stateIndices.AsReadOnly();
+        }
+
+        protected virtual void Parse()
+        {
+            // We use '\0' as the default state and char.
+            var state = '\0';
+            var lastChar = '\0';
+            var secondTolastChar = '\0';
+
+            // State machine to parse MySQL SQL.
+            for (var i = 0; i < SqlFragment.Length; i++)
+            {
+                var c = SqlFragment[i];
+                var skipProcessing = false;
+
+                if (state == '\'')
+                {
+                    // We are currently inside a string, or closed the string in the last iteration but didn't
+                    // know that at the time, because it still could have been the beginning of an escape sequence.
+
+                    if (c == '\'')
+                    {
+                        // We either end the string, begin an escape sequence or end an escape sequence.
+                        if (lastChar == '\'')
+                        {
+                            // This is the end of an escape sequence.
+                            // We continue being in a string.
+                            lastChar = '\0';
+                        }
+                        else
+                        {
+                            // This is either the beginning of an escape sequence, or the end of the string.
+                            // We will know in the next iteration.
+                            lastChar = '\'';
+                        }
+                    }
+                    else if (lastChar == '\'')
+                    {
+                        // The last iteration was the end of a string.
+                        // Reset the current state and continue processing the current char.
+                        state = '\0';
+                        lastChar = '\0';
+                        States[i - 1] = state;
+                    }
+                }
+
+                if (state == '"')
+                {
+                    // We are currently inside a string, or closed the string in the last iteration but didn't
+                    // know that at the time, because it still could have been the beginning of an escape sequence.
+
+                    if (c == '"')
+                    {
+                        // We either end the string, begin an escape sequence or end an escape sequence.
+                        if (lastChar == '"')
+                        {
+                            // This is the end of an escape sequence.
+                            // We continue being in a string.
+                            lastChar = '\0';
+                        }
+                        else
+                        {
+                            // This is either the beginning of an escape sequence, or the end of the string.
+                            // We will know the in the next iteration.
+                            lastChar = '"';
+                        }
+                    }
+                    else if (lastChar == '"')
+                    {
+                        // The last iteration was the end of a string.
+                        // Reset the current state and continue processing the current char.
+                        state = '\0';
+                        lastChar = '\0';
+                        States[i - 1] = state;
+                    }
+                }
+
+                if (state == '`')
+                {
+                    // We are currently inside an identifier, or closed the identifier in the last iteration but didn't
+                    // know that at the time, because it still could have been the beginning of an escape sequence.
+
+                    if (c == '`')
+                    {
+                        // We either end the identifier, begin an escape sequence or end an escape sequence.
+                        if (lastChar == '`')
+                        {
+                            // This is the end of an escape sequence.
+                            // We continue being in an identifier.
+                            lastChar = '\0';
+                        }
+                        else
+                        {
+                            // This is either the beginning of an escape sequence, or the end of the identifier.
+                            // We will know the in the next iteration.
+                            lastChar = '`';
+                        }
+                    }
+                    else if (lastChar == '`')
+                    {
+                        // The last iteration was the end of an identifier.
+                        // Reset the current state and continue processing the current char.
+                        state = '\0';
+                        lastChar = '\0';
+                        States[i - 1] = state;
+                    }
+                }
+
+                if (state == '/')
+                {
+                    // We could be at the beginning or end of a comment, or this is just a slash.
+                    if (lastChar == '/')
+                    {
+                        // This is the beginning of a comment.
+                        Debug.Assert(c == '*');
+                        lastChar = '\0';
+                    }
+                    else if (lastChar == '*')
+                    {
+                        if (c == '/')
+                        {
+                            // This is the end of a comment.
+                            lastChar = '\0';
+                            state = '\0';
+                            skipProcessing = true;
+                        }
+                        else
+                        {
+                            // This was just an ordanary asterisk inside of a comment character all along.
+                            lastChar = '\0';
+                        }
+                    }
+                    else if (c == '*')
+                    {
+                        // This could be the beginning of the end of a comment, or it could just be an ordenary asterisk inside of a
+                        // comment.
+                        Debug.Assert(lastChar == '\0');
+                        lastChar = '*';
+                    }
+                    else
+                    {
+                        // This is just an ordenary character, either insider or outside of a comment.
+                        lastChar = '\0';
+                    }
+                }
+
+                if (state == '-')
+                {
+                    if (lastChar == '-')
+                    {
+                        if (c == '-' &&
+                            secondTolastChar == '\0')
+                        {
+                            // This could still be the beginning of a line comment.
+                            // In MySQL, a line comment starts with two dashes and a whitespace.
+                            secondTolastChar = '-';
+                        }
+                        else if (secondTolastChar == '-' &&
+                                 (c == ' ' || c == '\t'))
+                        {
+                            // A line comment has been started.
+                            lastChar = '\0';
+                            secondTolastChar = '\0';
+                        }
+                        else
+                        {
+                            // The previous character(s) was/were just a dash and not the beginning of a line comment.
+                            state = '\0';
+                            lastChar = '\0';
+                            States[i - 1] = state;
+
+                            if (secondTolastChar == '-')
+                            {
+                                secondTolastChar = '\0';
+                                States[i - 2] = state;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // We are in an established line comment.
+                        Debug.Assert(lastChar == '\0');
+                        Debug.Assert(secondTolastChar == '\0');
+
+                        if (c == '\r' ||
+                            c == '\n')
+                        {
+                            // The line comment ends here.
+                            state = '\0';
+                            skipProcessing = true;
+                        }
+                    }
+                }
+
+                if (state == '#')
+                {
+                    // We are inside of a line comment.
+                    if (c == '\r' ||
+                        c == '\n')
+                    {
+                        // The line comment ends here.
+                        state = '\0';
+                        skipProcessing = true;
+                    }
+                }
+
+                if (state == '\0' &&
+                    !skipProcessing)
+                {
+                    if (c == '"')
+                    {
+                        state = '"';
+                    }
+                    else if (c == '\'')
+                    {
+                        state = '\'';
+                    }
+                    else if (c == '`')
+                    {
+                        state = '`';
+                    }
+                    else if (c == '/')
+                    {
+                        state = '/';
+                        lastChar = '/';
+                    }
+                    else if (c == '-')
+                    {
+                        state = '-';
+                        lastChar = '-';
+                    }
+                    else if (c == '#')
+                    {
+                        state = '#';
+                    }
+                    else if (c == '@')
+                    {
+                        // This is either the beginning of a named parameter, or a global variable like @@version.
+                        state = '@';
+                    }
+                    else if (c == ';')
+                    {
+                        States[i] = ';';
+                    }
+                }
+                else if (state == '@')
+                {
+                    if (c == '@')
+                    {
+                        // This has not been a named parameter, but a global variable.
+                        // We use '$' to signal a global variable like @@version.
+                        States[i - 1] = '$';
+                    }
+
+                    state = '\0';
+                }
+
+                if (state != '\0')
+                {
+                    States[i] = state;
+                }
+            }
+
+            //
+            // Handle still pending states:
+            //
+
+            if (state == '\'' && lastChar == '\'' ||
+                state == '"' && lastChar == '"' ||
+                state == '`' && lastChar == '`' ||
+                state == '/' && lastChar == '/' ||
+                state == '-' && lastChar == '-')
+            {
+                // The last iteration was the end of a string or identifier,
+                // or not the start of a comment.
+                state = '\0';
+                lastChar = '\0';
+                States[States.Length - 1] = state;
+            }
+        }
+    }
+}

--- a/src/EFCore.MySql/Query/Internal/MySqlQueryStringFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQueryStringFactory.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Data.Common;
+using System.Data.SqlTypes;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
+{
+    // Based on: System.Data.Jet.JetCommandParser (EntityFrameworkCore.Jet)
+    public class MySqlQueryStringFactory : IRelationalQueryStringFactory
+    {
+        private static readonly Lazy<Regex> _limitExpressionParameterRegex = new Lazy<Regex>(
+            () => new Regex(
+                $@"(?<=\W)LIMIT\s+(?:(?<leading_offset>@?\w+),\s*)?(?<row_count>@?\w+)(?:\s*OFFSET\s*(?<trailing_offset>@?\w+))?",
+                RegexOptions.Singleline | RegexOptions.IgnoreCase));
+
+        private static readonly Lazy<Regex> _extractParameterRegex = new Lazy<Regex>(() => new Regex(@"@\w+"));
+
+        private readonly IRelationalTypeMappingSource _typeMapper;
+
+        public MySqlQueryStringFactory([NotNull] IRelationalTypeMappingSource typeMapper)
+        {
+            _typeMapper = typeMapper;
+        }
+
+        public virtual string Create(DbCommand command)
+        {
+            if (command.Parameters.Count == 0)
+            {
+                return command.CommandText;
+            }
+
+            // For parameter in LIMIT clauses and for string parameters, we need to inline the parameter values directly into the SQL.
+            PrepareCommand(command);
+
+            var builder = new StringBuilder();
+            foreach (DbParameter parameter in command.Parameters)
+            {
+                var typeName = TypeNameBuilder.CreateTypeName(parameter);
+                var typeMapping = _typeMapper.FindMapping(typeName);
+
+                builder
+                    .Append("SET ")
+                    .Append(parameter.ParameterName)
+                    .Append(" = ")
+                    .Append(GetParameterValue(parameter, typeName, typeMapping))
+                    .AppendLine(";");
+            }
+
+            return builder
+                .AppendLine()
+                .Append(command.CommandText).ToString();
+        }
+
+        private static string GetParameterValue(DbParameter parameter, string typeName, RelationalTypeMapping typeMapping)
+            => (parameter.Value == DBNull.Value
+                || parameter.Value == null)
+                ? "NULL"
+                : parameter.Value is SqlBytes sqlBytes
+                    ? new MySqlByteArrayTypeMapping(typeName).GenerateSqlLiteral(sqlBytes.Value)
+                    : typeMapping != null
+                        ? typeMapping.GenerateSqlLiteral(parameter.Value)
+                        : parameter.Value.ToString();
+
+        protected virtual void PrepareCommand(DbCommand command)
+        {
+            // MySQL does not support user variables in LIMIT statements.
+            // (It does however support parameters in LIMIT statements since 2010. See https://bugs.mysql.com/bug.php?id=11918)
+            //
+            // Because of that, we need to inline the parameter values as constants into the SQL command, in cases where they appear in a
+            // LIMIT clause.
+            //
+            // Also, the rules for applying collation from user variables are different than the once for parameters.
+            // We therefore inline all parameter values of type string as well.
+
+            var stringParameterNames = command.Parameters.Cast<DbParameter>()
+                .Where(p => p.Value is string)
+                .Select(p => p.ParameterName)
+                .ToList();
+
+            if (!command.CommandText.Contains("LIMIT", StringComparison.OrdinalIgnoreCase) &&
+                !stringParameterNames.Any())
+            {
+                return;
+            }
+
+            var matches = _limitExpressionParameterRegex.Value.Matches(command.CommandText);
+            if (matches.Count <= 0 &&
+                !stringParameterNames.Any())
+            {
+                return;
+            }
+
+            var limitGroupsWithParameter = matches.SelectMany(m => m.Groups["row_count"].Captures)
+                .Concat(matches.SelectMany(m => m.Groups["leading_offset"].Captures))
+                .Concat(matches.SelectMany(m => m.Groups["trailing_offset"].Captures))
+                .ToList();
+
+            if (!limitGroupsWithParameter.Any() &&
+                !stringParameterNames.Any())
+            {
+                return;
+            }
+
+            var parser = new MySqlCommandParser(command.CommandText);
+            var parameterPositions = parser.GetStateIndices('@');
+            var parameters = parameterPositions
+                .Select(
+                    i => new
+                    {
+                        Index = i,
+                        ParameterName = _extractParameterRegex.Value.Match(command.CommandText.Substring(i)).Value,
+                    })
+                .Where(t => !string.IsNullOrEmpty(t.ParameterName))
+                .ToList();
+
+            var validParameters = (limitGroupsWithParameter
+                    .Where(c => parameterPositions.Contains(c.Index) &&
+                                command.Parameters.Contains(c.Value))
+                    .Select(c => new {Index = c.Index, ParameterName = c.Value}))
+                .Concat(stringParameterNames.SelectMany(s => parameters.Where(p => p.ParameterName == s)))
+                .Distinct()
+                .OrderByDescending(c => c.Index)
+                .ToList();
+
+            foreach (var validParameter in validParameters)
+            {
+                var parameterIndex = validParameter.Index;
+                var parameterName = validParameter.ParameterName;
+
+                parameters.RemoveAt(
+                    parameters.FindIndex(
+                        t => t.Index == parameterIndex &&
+                             t.ParameterName == parameterName));
+
+                var parameter = command.Parameters[parameterName];
+                var typeName = TypeNameBuilder.CreateTypeName(parameter);
+                var typeMapping = _typeMapper.FindMapping(typeName);
+                var parameterValue = GetParameterValue(parameter, typeName, typeMapping);
+
+                command.CommandText = command.CommandText.Substring(0, parameterIndex) +
+                                      parameterValue +
+                                      command.CommandText.Substring(parameterIndex + validParameter.ParameterName.Length);
+            }
+
+            foreach (var parameterName in validParameters
+                .Select(c => c.ParameterName)
+                .Distinct()
+                .Where(s => parameters.FindIndex(t => t.ParameterName == s) == -1))
+            {
+                command.Parameters.RemoveAt(parameterName);
+            }
+        }
+    }
+}

--- a/src/EFCore.MySql/Query/Internal/TypeNameBuilder.cs
+++ b/src/EFCore.MySql/Query/Internal/TypeNameBuilder.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using MySqlConnector;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
+{
+    internal static class TypeNameBuilder
+    {
+        private static StringBuilder AppendSize(this StringBuilder builder, DbParameter parameter)
+        {
+            if (parameter.Size > 0)
+            {
+                builder
+                    .Append('(')
+                    .Append(parameter.Size.ToString(CultureInfo.InvariantCulture))
+                    .Append(')');
+            }
+
+            return builder;
+        }
+
+        private static StringBuilder AppendPrecision(this StringBuilder builder, DbParameter parameter)
+        {
+            if (parameter.Precision > 0)
+            {
+                builder
+                    .Append('(')
+                    .Append(parameter.Precision.ToString(CultureInfo.InvariantCulture))
+                    .Append(')');
+            }
+
+            return builder;
+        }
+
+        private static StringBuilder AppendPrecisionAndScale(this StringBuilder builder, DbParameter parameter)
+        {
+            if (parameter.Precision > 0
+                && parameter.Scale > 0)
+            {
+                builder
+                    .Append('(')
+                    .Append(parameter.Precision.ToString(CultureInfo.InvariantCulture))
+                    .Append(',')
+                    .Append(parameter.Scale.ToString(CultureInfo.InvariantCulture))
+                    .Append(')');
+            }
+
+            return builder.AppendPrecision(parameter);
+        }
+
+        public static string CreateTypeName(DbParameter parameter)
+        {
+            if (!(parameter is MySqlParameter mySqlParameter))
+            {
+                throw new ArgumentException($"The parameter is not of type '{nameof(MySqlParameter)}'.", nameof(parameter));
+            }
+
+            var builder = new StringBuilder();
+            return (mySqlParameter.MySqlDbType switch
+            {
+                MySqlDbType.Bool => builder.Append("bool"),
+                MySqlDbType.Decimal => builder.Append("decimal").AppendPrecisionAndScale(parameter),
+                MySqlDbType.Byte => builder.Append("tinyint"),
+                MySqlDbType.Int16 => builder.Append("smallint"),
+                MySqlDbType.Int32 => builder.Append("int"),
+                MySqlDbType.Float => builder.Append("float"),
+                MySqlDbType.Double => builder.Append("double"),
+                MySqlDbType.Null => builder.Append("null"),
+                MySqlDbType.Timestamp => builder.Append("timestamp"),
+                MySqlDbType.Int64 => builder.Append("bigint"),
+                MySqlDbType.Int24 => builder.Append("mediumint"),
+                MySqlDbType.Date => builder.Append("date").AppendPrecision(parameter),
+                MySqlDbType.Time => builder.Append("time").AppendPrecision(parameter),
+                MySqlDbType.DateTime => builder.Append("datetime").AppendPrecision(parameter),
+                MySqlDbType.Year => builder.Append("year"),
+                MySqlDbType.Newdate => builder.Append("date").AppendPrecision(parameter),
+                MySqlDbType.VarString => builder.Append("varchar").AppendSize(parameter),
+                MySqlDbType.Bit => builder.Append("bit"),
+                MySqlDbType.JSON => builder.Append("json"),
+                MySqlDbType.NewDecimal => builder.Append("decimal"),
+                MySqlDbType.Enum => builder.Append("enum"),
+                MySqlDbType.Set => builder.Append("set"),
+                MySqlDbType.TinyBlob => builder.Append("tinyblob"),
+                MySqlDbType.MediumBlob => builder.Append("mediumblob"),
+                MySqlDbType.LongBlob => builder.Append("longblob"),
+                MySqlDbType.Blob => builder.Append("blob"),
+                MySqlDbType.VarChar => builder.Append("varchar").AppendSize(parameter),
+                MySqlDbType.String => builder.Append("char").AppendSize(parameter),
+                MySqlDbType.Geometry => builder.Append("geometry"),
+                MySqlDbType.UByte => builder.Append("tinyint"),
+                MySqlDbType.UInt16 => builder.Append("smallint"),
+                MySqlDbType.UInt32 => builder.Append("int"),
+                MySqlDbType.UInt64 => builder.Append("bigint"),
+                MySqlDbType.UInt24 => builder.Append("mediumint"),
+                MySqlDbType.Binary => builder.Append("binary").AppendSize(parameter),
+                MySqlDbType.VarBinary => builder.Append("varbinary").AppendSize(parameter),
+                MySqlDbType.TinyText => builder.Append("tinytext"),
+                MySqlDbType.MediumText => builder.Append("mediumtext"),
+                MySqlDbType.LongText => builder.Append("longtext"),
+                MySqlDbType.Text => builder.Append("text"),
+                MySqlDbType.Guid => builder.Append("char"),
+                _ => throw new InvalidOperationException($"Unknown {nameof(MySqlDbType)} value of '{mySqlParameter.MySqlDbType}'.")
+            }).ToString();
+        }
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/AsyncGearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/AsyncGearsOfWarQueryMySqlTest.cs
@@ -11,5 +11,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
+
+        protected override bool CanExecuteQueryString
+            => true;
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsQueryMySqlTest.cs
@@ -18,6 +18,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.WindowFunctions))]
         public override Task SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
@@ -22,6 +22,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         public override Task DateTimeOffset_Contains_Less_than_Greater_than(bool async)
         {
             var dto = GearsOfWarQueryMySqlFixture.GetExpectedValue(new DateTimeOffset(599898024001234567, new TimeSpan(1, 30, 0)));

--- a/test/EFCore.MySql.FunctionalTests/Query/ManyToManyNoTrackingQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ManyToManyNoTrackingQueryMySqlTest.cs
@@ -18,8 +18,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        // TODO: CanExecuteQueryString
-        // protected override bool CanExecuteQueryString => true;
+        protected override bool CanExecuteQueryString
+            => true;
 
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.WindowFunctions))]
         public override Task Filtered_include_skip_navigation_order_by_split(bool async)

--- a/test/EFCore.MySql.FunctionalTests/Query/ManyToManyQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ManyToManyQueryMySqlTest.cs
@@ -16,6 +16,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             Fixture.TestSqlLoggerFactory.Clear();
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.WindowFunctions))]
         public override Task Filtered_include_skip_navigation_order_by_split(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindAggregateOperatorsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindAggregateOperatorsQueryMySqlTest.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.EntityFrameworkCore.Query;
+﻿using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
+using Pomelo.EntityFrameworkCore.MySql.Tests.TestUtilities.Attributes;
 using Xunit.Abstractions;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
@@ -18,6 +21,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 
         protected override bool CanExecuteQueryString
             => true;
+
+        [SupportedServerVersionCondition(nameof(ServerVersionSupport.OuterApply))]
+        public override Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
+        {
+            return base.Multiple_collection_navigation_with_FirstOrDefault_chained(async);
+        }
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindAggregateOperatorsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindAggregateOperatorsQueryMySqlTest.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit.Abstractions;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
+{
+    public class NorthwindAggregateOperatorsQueryMySqlTest : NorthwindAggregateOperatorsQueryRelationalTestBase<
+        NorthwindQueryMySqlFixture<NoopModelCustomizer>>
+    {
+        public NorthwindAggregateOperatorsQueryMySqlTest(
+            NorthwindQueryMySqlFixture<NoopModelCustomizer> fixture,
+            ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            ClearLog();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        protected override bool CanExecuteQueryString
+            => true;
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        protected override void ClearLog()
+            => Fixture.TestSqlLoggerFactory.Clear();
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindAsyncSimpleQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindAsyncSimpleQueryMySqlTest.cs
@@ -22,6 +22,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.ExceptIntercept))]
         public override async Task Intersect_non_entity()
             => await base.Intersect_non_entity();

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindFunctionsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindFunctionsQueryMySqlTest.cs
@@ -20,6 +20,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [ConditionalTheory]
         public override async Task String_StartsWith_Literal(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindGroupByQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindGroupByQueryMySqlTest.cs
@@ -22,6 +22,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.OuterApply))]
         public override Task Select_uncorrelated_collection_with_groupby_works(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindIncludeQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindIncludeQueryMySqlTest.cs
@@ -25,6 +25,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [ConditionalTheory]
         public override Task Include_duplicate_collection(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindJoinQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindJoinQueryMySqlTest.cs
@@ -18,6 +18,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.WindowFunctions))]
         public override Task SelectMany_correlated_subquery_take(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindKeylessEntitiesQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindKeylessEntitiesQueryMySqlTest.cs
@@ -14,6 +14,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/21627")]
         public override void KeylessEntity_with_nav_defining_query()
             => base.KeylessEntity_with_nav_defining_query();

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindMiscellaneousQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindMiscellaneousQueryMySqlTest.cs
@@ -25,6 +25,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         public override void Select_bitwise_or()
         {
             base.Select_bitwise_or();

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.cs
@@ -24,6 +24,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [ConditionalTheory]
         public override async Task Select_datetime_year_component(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSetOperationsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSetOperationsQueryMySqlTest.cs
@@ -22,6 +22,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.ExceptIntercept))]
         public override async Task Intersect(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindWhereQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindWhereQueryMySqlTest.cs
@@ -21,6 +21,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [ConditionalTheory]
         public override async Task Where_datetime_now(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/OwnedQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/OwnedQueryMySqlTest.cs
@@ -13,6 +13,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         public class OwnedQueryMySqlFixture : RelationalOwnedQueryFixture
         {
             protected override ITestStoreFactory TestStoreFactory

--- a/test/EFCore.MySql.FunctionalTests/Query/QueryNavigationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/QueryNavigationsMySqlTest.cs
@@ -22,6 +22,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         [ConditionalTheory(Skip = "Issue #573")]
         public override Task Where_subquery_on_navigation(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/TPTGearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/TPTGearsOfWarQueryMySqlTest.cs
@@ -24,6 +24,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        protected override bool CanExecuteQueryString
+            => true;
+
         public override Task DateTimeOffset_Contains_Less_than_Greater_than(bool async)
         {
             var dto = GearsOfWarQueryMySqlFixture.GetExpectedValue(new DateTimeOffset(599898024001234567, new TimeSpan(1, 30, 0)));

--- a/test/EFCore.MySql.FunctionalTests/Query/TPTManyToManyNoTrackingQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/TPTManyToManyNoTrackingQueryMySqlTest.cs
@@ -17,8 +17,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        // TODO: TPTManyToManyQueryMySqlTest
-        // protected override bool CanExecuteQueryString => true;
+        protected override bool CanExecuteQueryString
+            => true;
 
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.WindowFunctions))]
         public override Task Filtered_include_skip_navigation_order_by_split(bool async)

--- a/test/EFCore.MySql.FunctionalTests/Query/TPTManyToManyQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/TPTManyToManyQueryMySqlTest.cs
@@ -17,8 +17,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        // TODO: CanExecuteQueryString
-        // protected override bool CanExecuteQueryString => true;
+        protected override bool CanExecuteQueryString
+            => true;
 
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.WindowFunctions))]
         public override Task Filtered_include_skip_navigation_order_by_split(bool async)


### PR DESCRIPTION
This was a bit more complicated than expected, because MySQL does not allow for user variables in `LIMIT` clauses (though it does allow parameters in them since 2010, see [SP does not accept variables in LIMIT clause](https://bugs.mysql.com/bug.php?id=11918)) and there are collation issues that arise for string user variables, that are not an issue when using parameters.

To workaround these issues, we inline/inject the paramater values in cases they are used in a `LIMIT` clause or contain a `string` value, directly into the SQL command text of the `DbCommand`.

To aid with that, I copied over a SQL parser state machine I implemented for `EntityFramworkCore.Jet` and heavily modified it.

In case there are issues in the future with specifically typed parameters and `ToQueryString()`, we could also just decide to inline all parameters if needed.

Closes #999