### PR TITLE
Fix handling of string version parameters

### DIFF
--- a/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
@@ -10,6 +10,7 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class MariaDbServerVersion : ServerVersion
     {
+        public static readonly string MariaDbTypeIdentifier = nameof(ServerType.MariaDb).ToLowerInvariant();
         public static readonly ServerVersion LatestSupportedServerVersion = new MariaDbServerVersion(new Version(10, 5, 5));
 
         public override ServerVersionSupport Supports { get; }
@@ -21,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public MariaDbServerVersion(string versionString)
-            : this(FromString(versionString))
+            : this(FromString(versionString, ServerType.MariaDb))
         {
         }
 
@@ -29,10 +30,12 @@ namespace Microsoft.EntityFrameworkCore
             : base(serverVersion.Version, serverVersion.Type, serverVersion.TypeIdentifier)
         {
             if (Type != ServerType.MariaDb ||
-                !string.Equals(TypeIdentifier, nameof(ServerType.MariaDb).ToLowerInvariant()))
+                !string.Equals(TypeIdentifier, MariaDbTypeIdentifier))
             {
                 throw new ArgumentException($"{nameof(MariaDbServerVersion)} is not compatible with the supplied server type.");
             }
+
+            Supports = new MariaDbServerVersionSupport(this);
         }
 
         public class MariaDbServerVersionSupport : ServerVersionSupport

--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -10,6 +10,7 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class MySqlServerVersion : ServerVersion
     {
+        public static readonly string MySqlTypeIdentifier = nameof(ServerType.MySql).ToLowerInvariant();
         public static readonly ServerVersion LatestSupportedServerVersion = new MySqlServerVersion(new Version(8, 0, 21));
 
         public override ServerVersionSupport Supports { get; }
@@ -21,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public MySqlServerVersion(string versionString)
-            : this(FromString(versionString))
+            : this(FromString(versionString, ServerType.MySql))
         {
         }
 
@@ -29,10 +30,12 @@ namespace Microsoft.EntityFrameworkCore
             : base(serverVersion.Version, serverVersion.Type, serverVersion.TypeIdentifier)
         {
             if (Type != ServerType.MySql ||
-                !string.Equals(TypeIdentifier, nameof(ServerType.MySql).ToLowerInvariant()))
+                !string.Equals(TypeIdentifier, MySqlTypeIdentifier))
             {
                 throw new ArgumentException($"{nameof(MySqlServerVersion)} is not compatible with the supplied server type.");
             }
+
+            Supports = new MySqlServerVersionSupport(this);
         }
 
         public class MySqlServerVersionSupport : ServerVersionSupport

--- a/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
@@ -106,5 +106,239 @@ namespace Pomelo.EntityFrameworkCore.MySql
 
             Assert.Equal(MySqlBooleanType.TinyInt1, mySqlOptions.DefaultDataTypeMappings.ClrBoolean);
         }
+
+        [Fact]
+        public void UseMySql_with_MySqlServerVersion_Version()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                new MySqlServerVersion(new Version(8, 0, 21)));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(8, 0, 21), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MySql, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mysql", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MySqlServerVersion_string_version_only()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                new MySqlServerVersion("8.0.21"));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(8, 0, 21), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MySql, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mysql", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MySqlServerVersion_string_version_full()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                new MySqlServerVersion("8.0.21-mysql"));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(8, 0, 21), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MySql, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mysql", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MySqlServerVersion_ServerVersion()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                new MySqlServerVersion(new MySqlServerVersion(new Version(8, 0, 21))));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(8, 0, 21), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MySql, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mysql", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MySqlServerVersion_incorrect_ServerVersion_throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () =>
+                {
+                    var builder = new DbContextOptionsBuilder();
+
+                    builder.UseMySql(
+                        "Server=foo",
+                        new MySqlServerVersion(new MariaDbServerVersion("10.5.5-mariadb")));
+                });
+        }
+
+        [Fact]
+        public void UseMySql_with_MySqlServerVersion_LatestSupportedServerVersion()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                MySqlServerVersion.LatestSupportedServerVersion);
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(MySqlServerVersion.LatestSupportedServerVersion.Version, mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MySql, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mysql", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MariaDbServerVersion_Version()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                new MariaDbServerVersion(new Version(10, 5, 5)));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(10, 5, 5), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MariaDb, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mariadb", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MariaDbServerVersion_string_version_only()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                new MariaDbServerVersion("10.5.5"));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(10, 5, 5), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MariaDb, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mariadb", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MariaDbServerVersion_string_version_full()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                new MariaDbServerVersion("10.5.5-mariadb"));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(10, 5, 5), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MariaDb, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mariadb", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MariaDbServerVersion_ServerVersion()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                new MariaDbServerVersion(new MariaDbServerVersion(new Version(10, 5, 5))));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(10, 5, 5), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MariaDb, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mariadb", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_MariaDbServerVersion_incorrect_ServerVersion_throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () =>
+                {
+                    var builder = new DbContextOptionsBuilder();
+
+                    builder.UseMySql(
+                        "Server=foo",
+                        new MariaDbServerVersion(new MySqlServerVersion("8.0.21-mysql")));
+                });
+        }
+
+        [Fact]
+        public void UseMySql_with_MariaDbServerVersion_LatestSupportedServerVersion()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                "Server=foo",
+                MariaDbServerVersion.LatestSupportedServerVersion);
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(MariaDbServerVersion.LatestSupportedServerVersion.Version, mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MariaDb, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mariadb", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_ServerVersion_FromString()
+        {
+            var builder = new DbContextOptionsBuilder();
+            var serverVersion = ServerVersion.FromString("8.0.21-mysql");
+
+            builder.UseMySql(
+                "Server=foo",
+                serverVersion);
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(new Version(8, 0, 21), mySqlOptions.ServerVersion.Version);
+            Assert.Equal(ServerType.MySql, mySqlOptions.ServerVersion.Type);
+            Assert.Equal("mysql", mySqlOptions.ServerVersion.TypeIdentifier);
+        }
+
+        [Fact]
+        public void UseMySql_with_ServerVersion_AutoDetect()
+        {
+            var builder = new DbContextOptionsBuilder();
+            var serverVersion = ServerVersion.AutoDetect(AppConfig.ConnectionString);
+
+            builder.UseMySql(
+                "Server=foo",
+                serverVersion);
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(serverVersion.Version, mySqlOptions.ServerVersion.Version);
+            Assert.Equal(serverVersion.Type, mySqlOptions.ServerVersion.Type);
+            Assert.Equal(serverVersion.TypeIdentifier, mySqlOptions.ServerVersion.TypeIdentifier);
+        }
     }
 }


### PR DESCRIPTION
When using a string version parameter in a `new MySqlServerVersion()` or `new MariaDbServerVersion()` call, the `Supports` property was not setup and therefore remained `null`.

This would typically lead to an unexpected `NullReferenceException` much later on in the `MySqlOptions.ApplyDefaultDataTypeMappings()` method.

Fixes #1247 