### PR TITLE
Add scaffolding support for computed columns

### DIFF
--- a/src/EFCore.MySql/Extensions/StringExtensions.cs
+++ b/src/EFCore.MySql/Extensions/StringExtensions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+namespace Pomelo.EntityFrameworkCore.MySql.Extensions
+{
+    internal static class StringExtensions
+    {
+        internal static string NullIfEmpty(this string value)
+            => value?.Length > 0
+                ? value
+                : null;
+    }
+}

--- a/src/EFCore.MySql/Storage/ServerVersion.Support.cs
+++ b/src/EFCore.MySql/Storage/ServerVersion.Support.cs
@@ -25,6 +25,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public const string NullableGeneratedColumnsMySqlSupportVersionString = "5.7.0-mysql";
         // public const string NullableGeneratedColumnsMariaDbSupportVersionString = "?.?.?-mariadb";
 
+        public const string ParenthesisEnclosedGeneratedColumnExpressionsMySqlSupportVersionString = GeneratedColumnsMySqlSupportVersionString;
+        // public const string ParenthesisEnclosedGeneratedColumnExpressionsMariaDbSupportVersionString = GeneratedColumnsMariaDbSupportVersionString;
+
         public const string JsonMySqlSupportVersionString = "5.7.8-mysql";
         public const string JsonMariaDbSupportVersionString = "10.2.4-mariadb";
 
@@ -117,6 +120,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public const string JsonSupportKey = nameof(JsonSupportKey);
         public const string GeneratedColumnsSupportKey = nameof(GeneratedColumnsSupportKey);
         public const string NullableGeneratedColumnsSupportKey = nameof(NullableGeneratedColumnsSupportKey);
+        public const string ParenthesisEnclosedGeneratedColumnExpressionsSupportKey = nameof(ParenthesisEnclosedGeneratedColumnExpressionsSupportKey);
         public const string DefaultCharSetUtf8Mb4SupportKey = nameof(DefaultCharSetUtf8Mb4SupportKey);
         public const string DefaultExpressionSupportKey = nameof(DefaultExpressionSupportKey);
         public const string AlternativeDefaultExpressionSupportKey = nameof(AlternativeDefaultExpressionSupportKey);
@@ -152,6 +156,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
             { JsonSupportKey, new ServerVersionSupport(JsonMySqlSupportVersionString/*, JsonMariaDbSupportVersionString*/) },
             { GeneratedColumnsSupportKey, new ServerVersionSupport(GeneratedColumnsMySqlSupportVersionString, GeneratedColumnsMariaDbSupportVersionString) },
             { NullableGeneratedColumnsSupportKey, new ServerVersionSupport(NullableGeneratedColumnsMySqlSupportVersionString/*, NullableGeneratedColumnsMariaDbSupportVersionString*/) },
+            { ParenthesisEnclosedGeneratedColumnExpressionsSupportKey, new ServerVersionSupport(ParenthesisEnclosedGeneratedColumnExpressionsMySqlSupportVersionString/*, ParenthesisEnclosedGeneratedColumnExpressionsMariaDbSupportVersionString*/) },
             { DefaultCharSetUtf8Mb4SupportKey, new ServerVersionSupport(DefaultCharSetUtf8Mb4MySqlSupportVersionString/*, DefaultCharSetUtf8Mb4MariaDbSupportVersionString*/) },
             { DefaultExpressionSupportKey, new ServerVersionSupport(DefaultExpressionMySqlSupportVersionString/*, DefaultExpressionMariaDbSupportVersionString*/) },
             { AlternativeDefaultExpressionSupportKey, new ServerVersionSupport(/*AlternativeDefaultExpressionMySqlSupportVersionString, */AlternativeDefaultExpressionMariaDbSupportVersionString) },
@@ -187,6 +192,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage
         public virtual bool SupportsJson => SupportMap[JsonSupportKey].IsSupported(this);
         public virtual bool SupportsGeneratedColumns => SupportMap[GeneratedColumnsSupportKey].IsSupported(this);
         public virtual bool SupportsNullableGeneratedColumns => SupportMap[NullableGeneratedColumnsSupportKey].IsSupported(this);
+        public virtual bool SupportsParenthesisEnclosedGeneratedColumnExpressions => SupportMap[ParenthesisEnclosedGeneratedColumnExpressionsSupportKey].IsSupported(this);
         public virtual bool SupportsDefaultCharSetUtf8Mb4 => SupportMap[DefaultCharSetUtf8Mb4SupportKey].IsSupported(this);
         public virtual bool SupportsDefaultExpression => SupportMap[DefaultExpressionSupportKey].IsSupported(this);
         public virtual bool SupportsAlternativeDefaultExpression => SupportMap[AlternativeDefaultExpressionSupportKey].IsSupported(this);

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -375,6 +375,27 @@ CREATE TABLE DefaultValue (
                 "DROP TABLE DefaultValueClr");
         }
 
+        [Fact]
+        public void Computed_value()
+            => Test(@"
+CREATE TABLE `ComputedValues` (
+    `Id` int,
+    `A` int NOT NULL,
+    `B` int NOT NULL,
+    `SumOfAAndB` int GENERATED ALWAYS AS (`A` + `B`) STORED
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single().Columns;
+
+                    var column = columns.Single(c => c.Name == "SumOfAAndB");
+                    Assert.Null(column.DefaultValueSql);
+                    Assert.Equal(@"`A` + `B`", column.ComputedColumnSql);
+                },
+                @"DROP TABLE `ComputedValues`");
+
         #endregion
 
         #region PrimaryKeyFacets


### PR DESCRIPTION
This adds the missing generated/computed column support for the `3.2-maint` branch.

Fixes #1256 