### PR TITLE
Add better support for SQL functions in default clauses when scaffolding

### DIFF
--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -257,6 +257,8 @@ ORDER BY
                                 ? Regex.Replace(generation, @"^\((.*)\)$", "$1", RegexOptions.Singleline)
                                 : generation;
 
+                            var isDefaultValueSqlFunction = IsDefaultValueSqlFunction(defaultValue, dataType);
+
                             defaultValue = generation == null
                                 ? FilterClrDefaults(
                                     dataType,
@@ -300,7 +302,7 @@ ORDER BY
                                 Name = name,
                                 StoreType = columType,
                                 IsNullable = nullable,
-                                DefaultValueSql = CreateDefaultValueString(defaultValue, dataType),
+                                DefaultValueSql = CreateDefaultValueString(defaultValue, dataType, isDefaultValueSqlFunction),
                                 ComputedColumnSql = generation,
                                 IsStored = isStored,
                                 ValueGenerated = valueGenerated,
@@ -315,6 +317,34 @@ ORDER BY
                     }
                 }
             }
+        }
+
+        private bool IsDefaultValueSqlFunction(string defaultValue, string dataType)
+        {
+            if (defaultValue == null)
+            {
+                return false;
+            }
+
+            // MySQL uses `CURRENT_TIMESTAMP` (or `CURRENT_TIMESTAMP(6)`),
+            // while MariaDB uses `current_timestamp()` (or `current_timestamp(6)`).
+            // MariaDB also allows the usage of `curdate()` as a default for datetime or timestamp columns, but this is handled by the next
+            // section.
+            if ((string.Equals(dataType, "timestamp", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(dataType, "datetime", StringComparison.OrdinalIgnoreCase)) &&
+                Regex.IsMatch(defaultValue, @"^CURRENT_TIMESTAMP(?:\(\d*\))?$", RegexOptions.IgnoreCase))
+            {
+                return true;
+            }
+
+            // If SQL functions are used as a default value in MariaDB, they will always end in a parenthesis pair.
+            if (_options.ServerVersion.Supports.AlternativeDefaultExpression &&
+                defaultValue.EndsWith("()", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -382,18 +412,14 @@ ORDER BY
             return defaultValue;
         }
 
-        protected virtual string CreateDefaultValueString(string defaultValue, string dataType)
+        protected virtual string CreateDefaultValueString(string defaultValue, string dataType, bool isSqlFunction)
         {
             if (defaultValue == null)
             {
                 return null;
             }
 
-            // MySQL uses `CURRENT_TIMESTAMP` (or `CURRENT_TIMESTAMP(6)`),
-            // while MariaDB uses `current_timestamp()` (or `current_timestamp(6)`).
-            if ((string.Equals(dataType, "timestamp", StringComparison.OrdinalIgnoreCase) ||
-                 string.Equals(dataType, "datetime", StringComparison.OrdinalIgnoreCase)) &&
-                Regex.IsMatch(defaultValue, @"^CURRENT_TIMESTAMP(?:\(\d*\))?$", RegexOptions.IgnoreCase))
+            if (isSqlFunction)
             {
                 return defaultValue;
             }

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -283,21 +283,7 @@ ORDER BY
                                 }
                                 else
                                 {
-                                    // BUG: EF Core does not handle code generation for `OnUpdate`.
-                                    //      Instead, it just generates an empty method call ".()".
-                                    //      Tracked by: https://github.com/aspnet/EntityFrameworkCore/issues/18579
-                                    //
-                                    //      As a partial workaround, use `OnAddOrUpdate`, if a default value
-                                    //      has been specified.
-
-                                    if (defaultValue != null)
-                                    {
-                                        valueGenerated = ValueGenerated.OnAddOrUpdate;
-                                    }
-                                    else
-                                    {
-                                        valueGenerated = ValueGenerated.OnUpdate;
-                                    }
+                                    valueGenerated = ValueGenerated.OnUpdate;
                                 }
                             }
                             else


### PR DESCRIPTION
Adds better support for functions in default clauses, including `curdate()` in `datetime` and `timestamp` columns that MariaDB allows (but MySQL doesn't).

Also removes workaround for an EF Core bug, that has been fixed upstream some time ago.

Fixes #1274 