### PR TITLE
Work around MySQL bug 96947

### DIFF
--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -74,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore
             public override bool ExceptInterceptPrecedence => false;
             public override bool JsonDataTypeEmulation => false;
             public override bool ImplicitBoolCheckUsesIndex => ServerVersion.Version >= new Version(8, 0, 0); // Exact version has not been verified yet
+            public override bool MySqlBug96947Workaround => ServerVersion.Version >= new Version(5, 7, 0); // Exact version has not been verified yet, but it is 5.7.x and could very well be 5.7.0
         }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
@@ -77,5 +77,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
         public virtual bool JsonDataTypeEmulation => false;
         public virtual bool ImplicitBoolCheckUsesIndex => false;
         public virtual bool Sequences => false;
+        public virtual bool MySqlBug96947Workaround => false;
     }
 }

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlBug96947WorkaroundExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlBug96947WorkaroundExpressionVisitor.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    /// When using constant values in an LEFT JOIN, an later an ORDER BY is applied, MySQL 5.7+ will incorrectly return a NULL values for
+    /// some columns.
+    /// This is not an issue with any MariaDB release and not an issue with MySQL 5.6.
+    ///
+    /// See https://bugs.mysql.com/bug.php?id=96947
+    ///     https://github.com/OData/WebApi/issues/2124
+    ///     https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1293
+    /// </summary>
+    public class MySqlBug96947WorkaroundExpressionVisitor : ExpressionVisitor
+    {
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
+
+        private bool _insideLeftJoin;
+        private bool _insideLeftJoinSelect;
+
+        public MySqlBug96947WorkaroundExpressionVisitor(MySqlSqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        protected override Expression VisitExtension(Expression extensionExpression)
+            => extensionExpression switch
+            {
+                LeftJoinExpression leftJoinExpression => VisitLeftJoin(leftJoinExpression),
+                SelectExpression selectExpression => VisitSelect(selectExpression),
+                ProjectionExpression projectionExpression => VisitProjection(projectionExpression),
+                ShapedQueryExpression shapedQueryExpression => shapedQueryExpression.Update(Visit(shapedQueryExpression.QueryExpression), Visit(shapedQueryExpression.ShaperExpression)),
+                _ => base.VisitExtension(extensionExpression)
+            };
+
+        protected virtual Expression VisitLeftJoin(LeftJoinExpression leftJoinExpression)
+        {
+            var oldInsideLeftJoin = _insideLeftJoin;
+
+            _insideLeftJoin = true;
+
+            var expression = base.VisitExtension(leftJoinExpression);
+
+            _insideLeftJoin = oldInsideLeftJoin;
+
+            return expression;
+        }
+
+        protected virtual Expression VisitSelect(SelectExpression selectExpression)
+        {
+            var oldInsideLeftJoinSelect = _insideLeftJoinSelect;
+
+            if (_insideLeftJoin)
+            {
+                _insideLeftJoinSelect = !_insideLeftJoinSelect;
+            }
+
+            var expression = base.VisitExtension(selectExpression);
+
+            _insideLeftJoinSelect = oldInsideLeftJoinSelect;
+
+            return expression;
+        }
+
+        protected virtual Expression VisitProjection(ProjectionExpression projectionExpression)
+        {
+            if (_insideLeftJoinSelect)
+            {
+                var expression = (SqlExpression)Visit(projectionExpression.Expression);
+
+                if (expression is SqlConstantExpression constantExpression)
+                {
+                    expression = _sqlExpressionFactory.Convert(
+                        constantExpression,
+                        projectionExpression.Type,
+                        constantExpression.TypeMapping);
+                }
+
+                return projectionExpression.Update(expression);
+            }
+
+            return base.VisitExtension(projectionExpression);
+        }
+    }
+}

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQueryTranslationPostprocessor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQueryTranslationPostprocessor.cs
@@ -31,6 +31,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
 
             query = new MySqlJsonParameterExpressionVisitor(_sqlExpressionFactory, _options).Visit(query);
 
+            if (_options.ServerVersion.Supports.MySqlBug96947Workaround)
+            {
+                query = new MySqlBug96947WorkaroundExpressionVisitor(_sqlExpressionFactory).Visit(query);
+            }
+
             return query;
         }
     }

--- a/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/GearsOfWarQueryMySqlTest.cs
@@ -249,18 +249,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             return base.Where_subquery_distinct_orderby_firstordefault_boolean_with_pushdown(async);
         }
 
-        [SupportedServerVersionLessThanCondition("5.6.0", Skip = "https://bugs.mysql.com/bug.php?id=96947")]
-        public override Task Correlated_collections_basic_projecting_constant(bool async)
-        {
-            return base.Correlated_collections_basic_projecting_constant(async);
-        }
-
-        [SupportedServerVersionLessThanCondition("5.6.0", Skip = "https://bugs.mysql.com/bug.php?id=96947")]
-        public override Task Correlated_collections_basic_projecting_constant_bool(bool async)
-        {
-            return base.Correlated_collections_basic_projecting_constant_bool(async);
-        }
-
         [ConditionalTheory( /*Skip = "https://github.com/mysql-net/MySqlConnector/pull/707"*/)]
         public override Task Optional_Navigation_Null_Coalesce_To_Clr_Type(bool async)
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/TPTGearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/TPTGearsOfWarQueryMySqlTest.cs
@@ -251,18 +251,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             return base.Where_subquery_distinct_orderby_firstordefault_boolean_with_pushdown(async);
         }
 
-        [SupportedServerVersionLessThanCondition("5.6.0", Skip = "https://bugs.mysql.com/bug.php?id=96947")]
-        public override Task Correlated_collections_basic_projecting_constant(bool async)
-        {
-            return base.Correlated_collections_basic_projecting_constant(async);
-        }
-
-        [SupportedServerVersionLessThanCondition("5.6.0", Skip = "https://bugs.mysql.com/bug.php?id=96947")]
-        public override Task Correlated_collections_basic_projecting_constant_bool(bool async)
-        {
-            return base.Correlated_collections_basic_projecting_constant_bool(async);
-        }
-
         [ConditionalTheory( /*Skip = "https://github.com/mysql-net/MySqlConnector/pull/707"*/)]
         public override Task Optional_Navigation_Null_Coalesce_To_Clr_Type(bool async)
         {


### PR DESCRIPTION
When using constant values in an LEFT JOIN, an later an ORDER BY is applied, MySQL 5.7+ will incorrectly return a NULL values for some columns.
This is not an issue with any MariaDB release and not an issue with MySQL 5.6.

For further information see:
* https://bugs.mysql.com/bug.php?id=96947
* https://github.com/OData/WebApi/issues/2124
* https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1293

This fix works around this issue by explicitly casting all constant values in the outer most `SELECT` statement projections of an `LEFT JOIN` clause if run on MySQL 5.7+.

The workaround has also been backported to `3.2.5` with 30295d1.

Fixes #1293 