### PR TITLE
Fix collation usage

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
             var property = propertyBuilder.Metadata;
-            property.SetCollation(collation);
+            MySqlPropertyExtensions.SetCollation(property, collation);
 
             return propertyBuilder;
         }

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
@@ -83,7 +83,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
                     charset);
             }
 
-            if (column.PropertyMappings.Select(m => m.Property.GetCollation())
+            if (column.PropertyMappings.Select(m => MySqlPropertyExtensions.GetCollation(m.Property))
                 .FirstOrDefault(c => c != null) is string collation)
             {
                 yield return new Annotation(

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -1199,7 +1199,7 @@ DELIMITER ;";
                     : columnType.TrimEnd() + " " + characterSetClause;
             }
 
-            var collation = operation[MySqlAnnotationNames.Collation];
+            var collation = operation[MySqlAnnotationNames.Collation] ?? operation.Collation;
             if (collation != null)
             {
                 const string collationClausePattern = @"COLLATE \w+";


### PR DESCRIPTION
Fix collation usage, that already called the `SetCollation()` method of the `RelationalPropertyExtensions` class by accident, even though the collation code has not been migrated to .NET 5 yet.

Using either `HasCollation()` or `UseCollation()` should now be honored as expected.

Fixes #1302