### PR TITLE
Backport: Fix precedence issue when it comes to expressions like `boolParam = nullableBoolColumn IS NOT NULL`

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
@@ -211,6 +211,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
 
         protected override Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression)
         {
+            Check.NotNull(sqlBinaryExpression, nameof(sqlBinaryExpression));
+
             if (sqlBinaryExpression.OperatorType == ExpressionType.Add &&
                 sqlBinaryExpression.Type == typeof(string) &&
                 sqlBinaryExpression.Left.TypeMapping?.ClrType == typeof(string) &&

--- a/test/EFCore.MySql.FunctionalTests/PropertyEntryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/PropertyEntryMySqlTest.cs
@@ -20,7 +20,7 @@ FROM `Engines` AS `e`
 LEFT JOIN (
     SELECT `e0`.`Id`, `e0`.`StorageLocation_Latitude`, `e0`.`StorageLocation_Longitude`
     FROM `Engines` AS `e0`
-    WHERE `e0`.`StorageLocation_Longitude` IS NOT NULL AND `e0`.`StorageLocation_Latitude` IS NOT NULL
+    WHERE `e0`.`StorageLocation_Longitude` IS NOT NULL AND (`e0`.`StorageLocation_Latitude` IS NOT NULL)
 ) AS `t` ON `e`.`Id` = `t`.`Id`
 ORDER BY `e`.`Id`
 LIMIT 1",

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.MySql.cs
@@ -100,7 +100,7 @@ SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`Cont
 FROM `Customers` AS `c`
 WHERE CASE
     WHEN @__comparison_0 IN (4, 0, 2) THEN `c`.`CustomerID` = CONVERT('anton' USING utf8mb4) COLLATE utf8mb4_bin
-    ELSE ((LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) AND (LCASE(`c`.`CustomerID`) IS NOT NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL)) OR (LCASE(`c`.`CustomerID`) IS NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL)
+    ELSE ((LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) AND (LCASE(`c`.`CustomerID`) IS NOT NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL))) OR (LCASE(`c`.`CustomerID`) IS NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL))
 END");
         }
 
@@ -158,7 +158,7 @@ WHERE `c`.`CustomerID` = CONVERT('anton' USING utf8mb4) COLLATE utf8mb4_bin");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL)");
+WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL))");
         }
 
         [ConditionalTheory]
@@ -173,7 +173,7 @@ WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE u
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL)");
+WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL))");
         }
 
         [ConditionalTheory]
@@ -188,7 +188,7 @@ WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE u
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL)");
+WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL))");
         }
 
         [ConditionalTheory]
@@ -220,7 +220,7 @@ SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`Cont
 FROM `Customers` AS `c`
 WHERE CASE
     WHEN @__comparison_0 IN (4, 0, 2) THEN `c`.`CustomerID` = CONVERT('anton' USING utf8mb4) COLLATE utf8mb4_bin
-    ELSE ((LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) AND (LCASE(`c`.`CustomerID`) IS NOT NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL)) OR (LCASE(`c`.`CustomerID`) IS NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL)
+    ELSE ((LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) AND (LCASE(`c`.`CustomerID`) IS NOT NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NOT NULL))) OR (LCASE(`c`.`CustomerID`) IS NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL))
 END");
         }
 
@@ -278,7 +278,7 @@ WHERE `c`.`CustomerID` = CONVERT('anton' USING utf8mb4) COLLATE utf8mb4_bin");
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL)");
+WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL))");
         }
 
         [ConditionalTheory]
@@ -293,7 +293,7 @@ WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE u
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL)");
+WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL))");
         }
 
         [ConditionalTheory]
@@ -308,7 +308,7 @@ WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE u
             AssertSql(
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL)");
+WHERE (LCASE(`c`.`CustomerID`) = CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin) OR (LCASE(`c`.`CustomerID`) IS NULL AND (CONVERT(LCASE('anton') USING utf8mb4) COLLATE utf8mb4_bin IS NULL))");
         }
 
         [ConditionalTheory]

--- a/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/SimpleQueryMySqlTest.cs
@@ -82,7 +82,7 @@ WHERE (UTC_TIMESTAMP() <> @__myDatetime_0) OR UTC_TIMESTAMP() IS NULL");
             AssertSql(
                 @"SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
 FROM `Employees` AS `e`
-WHERE (CONVERT(CURRENT_TIMESTAMP(), date) = CURDATE()) OR (CONVERT(CURRENT_TIMESTAMP(), date) IS NULL AND CURDATE() IS NULL)");
+WHERE (CONVERT(CURRENT_TIMESTAMP(), date) = CURDATE()) OR (CONVERT(CURRENT_TIMESTAMP(), date) IS NULL AND (CURDATE() IS NULL))");
         }
 
         [ConditionalTheory]


### PR DESCRIPTION
EF Core 3.1.x compatible backport.
Fixes #1309