### PR TITLE
Add HasMaxLength() support for string columns with only a store type base name

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
@@ -28,6 +28,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         public MySqlStringTypeMapping(
             [NotNull] string storeType,
             IMySqlOptions options,
+            StoreTypePostfix storeTypePostfix,
             bool unicode = true,
             int? size = null,
             bool fixedLength = false,
@@ -36,7 +37,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                 new RelationalTypeMappingParameters(
                     new CoreTypeMappingParameters(typeof(string)),
                     storeType,
-                    StoreTypePostfix.None, // Has to be None until EF #11896 is fixed
+                    storeTypePostfix,
                     unicode
                         ? fixedLength
                             ? System.Data.DbType.StringFixedLength

--- a/test/EFCore.MySql.FunctionalTests/MigrationsInfrastructureMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsInfrastructureMySqlTest.cs
@@ -25,7 +25,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 
             Assert.Equal(
                 @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
-    `MigrationId` varchar(95) NOT NULL,
+    `MigrationId` varchar(150) NOT NULL,
     `ProductVersion` varchar(32) NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
 );
@@ -41,7 +41,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 
             Assert.Equal(
                 @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
-    `MigrationId` varchar(95) NOT NULL,
+    `MigrationId` varchar(150) NOT NULL,
     `ProductVersion` varchar(32) NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
 );
@@ -57,7 +57,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 
             Assert.Equal(
                 @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
-    `MigrationId` varchar(95) NOT NULL,
+    `MigrationId` varchar(150) NOT NULL,
     `ProductVersion` varchar(32) NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
 );
@@ -139,7 +139,7 @@ COMMIT;
             base.Can_generate_idempotent_up_scripts();
 
             Assert.Equal(@"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
-    `MigrationId` varchar(95) NOT NULL,
+    `MigrationId` varchar(150) NOT NULL,
     `ProductVersion` varchar(32) NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
 );
@@ -402,7 +402,7 @@ COMMIT;
 
             Assert.Equal(
                 @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
-    `MigrationId` varchar(95) NOT NULL,
+    `MigrationId` varchar(150) NOT NULL,
     `ProductVersion` varchar(32) NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
 );
@@ -435,7 +435,7 @@ VALUES ('00000000000003_Migration3', '7.0.0-test');
 
             Assert.Equal(
                 @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
-    `MigrationId` varchar(95) NOT NULL,
+    `MigrationId` varchar(150) NOT NULL,
     `ProductVersion` varchar(32) NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
 );


### PR DESCRIPTION
Support the following scenario, which is now supported in EF Core 5.0:

```c#
entity.Property(e => e.Name)
    .HasColumnType("varchar") // <-- store type without size
    .HasMaxLength(200); // <-- specify length
```

Fixes #1323
Fixes #1050