### PR TITLE
Implement support for value generation strategies, that don't use an enum value but its underlying value equivalent.

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.MySql.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using NetTopologySuite.Geometries;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
@@ -197,6 +198,34 @@ ALTER TABLE `Cars` ADD CONSTRAINT `FK_Cars_LicensePlates_LicensePlateNumber` FOR
     `Name` varchar(255) NOT NULL
 );",
                 Sql.Trim(),
+                ignoreLineEndingDifferences: true);
+        }
+
+        [ConditionalFact]
+        public virtual void CreateTable_with_ValueGenerationStrategy_int_value()
+        {
+            Generate(
+                new CreateTableOperation
+                {
+                    Name = "IceCreamShops",
+                    Columns =
+                    {
+                        new AddColumnOperation
+                        {
+                            Name = "IceCreamShopId",
+                            ClrType = typeof(int),
+                            ColumnType = "int",
+                            [MySqlAnnotationNames.ValueGenerationStrategy] = (int)MySqlValueGenerationStrategy.IdentityColumn,
+                        }
+                    }
+                });
+
+            Assert.Equal(
+                @"CREATE TABLE `IceCreamShops` (
+    `IceCreamShopId` int NOT NULL AUTO_INCREMENT
+);
+",
+                Sql,
                 ignoreLineEndingDifferences: true);
         }
 


### PR DESCRIPTION
Allows to use the underlying value of `MySqlValueGenerationStrategy` instead of the actual enum value (`1` in the folloing sample, instead of `MySqlValueGenerationStrategy.IdentityColumn`):

```c#
protected override void Up(MigrationBuilder migrationBuilder)
{
    migrationBuilder.CreateTable(
        name: "IceCreams",
        columns: table => new
        {
            IceCreamId = table.Column<int>(nullable: false)
                .Annotation("MySql:ValueGenerationStrategy", /*MySqlValueGenerationStrategy.IdentityColumn*/ 1), // <--
            Name = table.Column<string>(nullable: true, defaultValue: "Vanilla")
        },
        constraints: table =>
        {
            table.PrimaryKey("PK_IceCreams", x => x.IceCreamId);
        });
}
```

Addresses https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1205#issuecomment-776910444