### PR TITLE
Add support for all possible `String.Concat()` variants

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/19828814</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <DebugType>portable</DebugType>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/EFCore.MySql/Query/Internal/MySqlMethodCallTranslatorProvider.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlMethodCallTranslatorProvider.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
@@ -13,6 +14,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             : base(dependencies)
         {
             var sqlExpressionFactory = (MySqlSqlExpressionFactory)dependencies.SqlExpressionFactory;
+            var relationalTypeMappingSource = (MySqlTypeMappingSource)dependencies.RelationalTypeMappingSource;
 
             AddTranslators(new IMethodCallTranslator[]
             {
@@ -27,7 +29,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 new MySqlObjectToStringTranslator(sqlExpressionFactory),
                 new MySqlRegexIsMatchTranslator(sqlExpressionFactory),
                 new MySqlStringComparisonMethodTranslator(sqlExpressionFactory),
-                new MySqlStringMethodTranslator(sqlExpressionFactory),
+                new MySqlStringMethodTranslator(sqlExpressionFactory, relationalTypeMappingSource),
             });
         }
     }

--- a/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
@@ -28,9 +28,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             _boolTypeMapping = _typeMappingSource.FindMapping(typeof(bool));
         }
 
-        public virtual RelationalTypeMapping FindMapping([NotNull] string storeTypeName)
-            => _typeMappingSource.FindMapping(storeTypeName);
-
         public virtual RelationalTypeMapping FindMapping(
             [NotNull] Type type,
             [CanBeNull] string storeTypeName,

--- a/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
@@ -170,10 +170,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 typeMappedArgumentParts.Add(ApplyDefaultTypeMapping(argument));
             }
 
-            return new MySqlComplexFunctionArgumentExpression(
-                typeMappedArgumentParts,
-                delimiter,
-                argumentType,
+            return (MySqlComplexFunctionArgumentExpression)ApplyTypeMapping(
+                new MySqlComplexFunctionArgumentExpression(
+                    typeMappedArgumentParts,
+                    delimiter,
+                    argumentType,
+                    typeMapping),
                 typeMapping);
         }
 
@@ -343,7 +345,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
         private MySqlComplexFunctionArgumentExpression ApplyTypeMappingOnComplexFunctionArgument(MySqlComplexFunctionArgumentExpression complexFunctionArgumentExpression)
         {
             var inferredTypeMapping = ExpressionExtensions.InferTypeMapping(complexFunctionArgumentExpression.ArgumentParts.ToArray())
-                                      ?? _typeMappingSource.FindMapping(complexFunctionArgumentExpression.Type);
+                                      ?? (complexFunctionArgumentExpression.Type.IsArray
+                                          ? _typeMappingSource.FindMapping(
+                                              complexFunctionArgumentExpression.Type.GetElementType() ??
+                                              complexFunctionArgumentExpression.Type)
+                                          : _typeMappingSource.FindMapping(complexFunctionArgumentExpression.Type));
 
             return new MySqlComplexFunctionArgumentExpression(
                 complexFunctionArgumentExpression.ArgumentParts,

--- a/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMapping.cs
@@ -62,6 +62,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                     unicode: true),
                 MySqlDbType.JSON,
                 options,
+                false,
                 false)
         {
             if (storeType != "json")
@@ -76,7 +77,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             RelationalTypeMappingParameters parameters,
             MySqlDbType mySqlDbType,
             IMySqlOptions options)
-            : base(parameters, mySqlDbType, options, false)
+            : base(parameters, mySqlDbType, options, false, false)
         {
             Options = options;
         }

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindWhereQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindWhereQueryMySqlTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
@@ -280,6 +281,318 @@ WHERE CONCAT(SUBSTRING(`c`.`City`, 1, 3), SUBSTRING(`c`.`City`, (3 + 1) + 1, CHA
 SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
 WHERE @__guidParameter_0 = UUID()");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_2(bool async)
+        {
+            var i = "A";
+            var j = "B";
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, j, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__i_0='A' (Size = 4000)
+@__j_1='B' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE CONCAT(@__i_0, @__j_1, `c`.`CustomerID`) = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_3(bool async)
+        {
+            var i = "A";
+            var j = "B";
+            var k = "C";
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, j, k, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__i_0='A' (Size = 4000)
+@__j_1='B' (Size = 4000)
+@__k_2='C' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE CONCAT(@__i_0, @__j_1, @__k_2, `c`.`CustomerID`) = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_single_object(bool async)
+        {
+            object i = 1;
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='1' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_object(bool async)
+        {
+            object i = 1;
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__i_0='1' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE CONCAT(@__i_0, `c`.`CustomerID`) = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_object_2(bool async)
+        {
+            object i = 1;
+            object j = 2;
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, j, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__i_0='1' (Size = 4000)
+@__j_1='2' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE CONCAT(@__i_0, @__j_1, `c`.`CustomerID`) = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_object_3(bool async)
+        {
+            object i = 1;
+            object j = 2;
+            object k = 3;
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, j, k, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__i_0='1' (Size = 4000)
+@__j_1='2' (Size = 4000)
+@__k_2='3' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE (CONCAT(@__i_0, @__j_1, @__k_2, `c`.`CustomerID`) = `c`.`CompanyName`) OR (CONCAT(@__i_0, @__j_1, @__k_2, `c`.`CustomerID`) IS NULL AND (`c`.`CompanyName` IS NULL))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_params_string_array(bool async)
+        {
+            var i = "A";
+            var j = "B";
+            var k = "C";
+            var m = "D";
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, j, k, m, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__i_0='A' (Size = 4000)
+@__j_1='B' (Size = 4000)
+@__k_2='C' (Size = 4000)
+@__m_3='D' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE (CONCAT(@__i_0, @__j_1, @__k_2, @__m_3, `c`.`CustomerID`) = `c`.`CompanyName`) OR (CONCAT(@__i_0, @__j_1, @__k_2, @__m_3, `c`.`CustomerID`) IS NULL AND (`c`.`CompanyName` IS NULL))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_explicit_string_array(bool async)
+        {
+            var array = new[] {"A", "B", "C", "D"};
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(array) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='ABCD' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_explicit_string_array_single_element(bool async)
+        {
+            var array = new[] {"A"};
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(array) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='A' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_params_object_array(bool async)
+        {
+            object i = 1;
+            object j = 2;
+            object k = 3;
+            object m = 4;
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, j, k, m, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__i_0='1' (Size = 4000)
+@__j_1='2' (Size = 4000)
+@__k_2='3' (Size = 4000)
+@__m_3='4' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE (CONCAT(@__i_0, @__j_1, @__k_2, @__m_3, `c`.`CustomerID`) = `c`.`CompanyName`) OR (CONCAT(@__i_0, @__j_1, @__k_2, @__m_3, `c`.`CustomerID`) IS NULL AND (`c`.`CompanyName` IS NULL))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_explicit_object_array(bool async)
+        {
+            var array = new object[] {1, 2, 3, 4};
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(array) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='1234' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_explicit_object_array_single_element(bool async)
+        {
+            var array = new object[] {1};
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(array) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='1' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_string_enumerable(bool async)
+        {
+            IEnumerable<string> enumerable = new[] {"A", "B", "C", "D"};
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(enumerable) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='ABCD' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_string_enumerable_single_element(bool async)
+        {
+            IEnumerable<string> enumerable = new[] {"A"};
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(enumerable) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='A' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_generic_enumerable(bool async)
+        {
+            IEnumerable<int> enumerable = new[] {1, 2, 3, 4};
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(enumerable) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='1234' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_string_concat_method_comparison_generic_enumerable_single_element(bool async)
+        {
+            IEnumerable<int> enumerable = new[] {1};
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(enumerable) == c.CompanyName).Select(c => c.CustomerID));
+
+            AssertSql(
+                @"@__Concat_0='1' (Size = 4000)
+
+SELECT `c`.`CustomerID`
+FROM `Customers` AS `c`
+WHERE @__Concat_0 = `c`.`CompanyName`");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
Implements support for all `String.Concat()` variants, except the `ReadOnlySpan<Char>` ones.
Fixes #1331