### PR TITLE
Fix #1352 InvalidOperationException when scaffolding without including referenced table

### DIFF
--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -653,7 +653,7 @@ ORDER BY
                                 // different casing than the actual table name. (#1017)
                                 // In the unlikely event that there are multiple tables with the same spelling, differing only in casing,
                                 // we can't be certain which is the right match, so rather fail to be safe.
-                                referencedTable = tables.Single(t => string.Equals(t.Name, referencedTableName, StringComparison.OrdinalIgnoreCase));
+                                referencedTable = tables.SingleOrDefault(t => string.Equals(t.Name, referencedTableName, StringComparison.OrdinalIgnoreCase));
                             }
                             if (referencedTable != null)
                             {

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -1142,6 +1142,33 @@ DROP TABLE DependentTable;
 DROP TABLE PrincipalTable;");
         }
 
+        [Fact]
+        public void Create_dependent_table_with_missing_principal_table_works()
+        {
+            Test(
+                @"
+CREATE TABLE PrincipalTable (
+    Id int PRIMARY KEY
+);
+
+CREATE TABLE DependentTable (
+    Id int PRIMARY KEY,
+    ForeignKeyId int,
+    FOREIGN KEY (ForeignKeyId) REFERENCES PrincipalTable(Id)
+);",
+                new[] { "dependenttable" },
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    //basically I just don't want to get any InvalidOperationExceptions
+                    var table = Assert.Single(dbModel.Tables);
+                    Assert.Equal("dependenttable", table.Name);
+                },
+                @"
+DROP TABLE DependentTable;
+DROP TABLE PrincipalTable;");
+        }
+
         #endregion
 
         public class MySqlDatabaseModelFixture : SharedStoreFixtureBase<PoolableDbContext>

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -1143,7 +1143,7 @@ DROP TABLE PrincipalTable;");
         }
 
         [Fact]
-        public void Create_dependent_table_with_missing_principal_table_works()
+        public void Create_dependent_table_with_missing_principal_table_creates_model_without_it()
         {
             Test(
                 @"
@@ -1156,13 +1156,13 @@ CREATE TABLE DependentTable (
     ForeignKeyId int,
     FOREIGN KEY (ForeignKeyId) REFERENCES PrincipalTable(Id)
 );",
-                new[] { "dependenttable" },
+                new[] { "DependentTable" },
                 Enumerable.Empty<string>(),
                 dbModel =>
                 {
                     //basically I just don't want to get any InvalidOperationExceptions
                     var table = Assert.Single(dbModel.Tables);
-                    Assert.Equal("dependenttable", table.Name);
+                    Assert.Equal("DependentTable", table.Name);
                 },
                 @"
 DROP TABLE DependentTable;


### PR DESCRIPTION
When scaffolding a table t1, that references another table t2 while explicitely only including t1, an InvalidOperation was thrown by the tables.Single(...) in MySqlDatabaseModelFactory in GetConstraints.
Replaced it with a SingleOrDefault, so the missing referenced table no longer causes an exception and the model is instead just created without it.