### PR TITLE
Fix MySQL json datatype charset and collation

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -1188,6 +1188,11 @@ DELIMITER ;";
 
         private static string GetColumnTypeWithCharSetAndCollation(ColumnOperation operation, string columnType)
         {
+            if (columnType.IndexOf("json", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return columnType;
+            }
+
             var charSet = operation[MySqlAnnotationNames.CharSet];
             if (charSet != null)
             {


### PR DESCRIPTION
Fix #1365. Disables `CHARACTER SET` and `COLLATE` clause appending on MySQL `json` columns.