### PR TITLE
Add full-text parser support

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlIndexBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlIndexBuilderExtensions.cs
@@ -22,12 +22,14 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="indexBuilder"> The index builder. </param>
         /// <param name="fullText"> The value to set. </param>
+        /// <param name="parser"> An optional argument (e.g. "ngram"), that will be used in an `WITH PARSER` clause. </param>
         /// <returns> The index builder. </returns>
-        public static IndexBuilder IsFullText([NotNull] this IndexBuilder indexBuilder, bool fullText = true)
+        public static IndexBuilder IsFullText([NotNull] this IndexBuilder indexBuilder, bool fullText = true, string parser = null)
         {
             Check.NotNull(indexBuilder, nameof(indexBuilder));
 
             indexBuilder.Metadata.SetIsFullText(fullText);
+            indexBuilder.Metadata.SetFullTextParser(parser);
 
             return indexBuilder;
         }

--- a/src/EFCore.MySql/Extensions/MySqlIndexExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlIndexExtensions.cs
@@ -53,6 +53,45 @@ namespace Pomelo.EntityFrameworkCore.MySql.Extensions
             => property.FindAnnotation(MySqlAnnotationNames.FullTextIndex)?.GetConfigurationSource();
 
         /// <summary>
+        ///     Returns a value indicating which full text parser to use.
+        /// </summary>
+        /// <param name="index"> The index. </param>
+        /// <returns> The name of the full text parser. </returns>
+        [CanBeNull] public static string FullTextParser([NotNull] this IIndex index)
+            => (string)index[MySqlAnnotationNames.FullTextParser];
+
+        /// <summary>
+        ///     Sets a value indicating which full text parser to used.
+        /// </summary>
+        /// <param name="value"> The value to set. </param>
+        /// <param name="index"> The index. </param>
+        public static void SetFullTextParser([NotNull] this IMutableIndex index, [CanBeNull] string value)
+            => index.SetOrRemoveAnnotation(
+                MySqlAnnotationNames.FullTextParser,
+                value);
+
+        /// <summary>
+        ///     Sets a value indicating which full text parser to used.
+        /// </summary>
+        /// <param name="value"> The value to set. </param>
+        /// <param name="index"> The index. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        public static void SetFullTextParser(
+            [NotNull] this IConventionIndex index, [CanBeNull] string value, bool fromDataAnnotation = false)
+            => index.SetOrRemoveAnnotation(
+                MySqlAnnotationNames.FullTextParser,
+                value,
+                fromDataAnnotation);
+
+        /// <summary>
+        ///     Returns the <see cref="ConfigurationSource" /> for whether the index is full text.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The <see cref="ConfigurationSource" /> for whether the index is full text. </returns>
+        public static ConfigurationSource? GetFullTextParserConfigurationSource([NotNull] this IConventionIndex property)
+            => property.FindAnnotation(MySqlAnnotationNames.FullTextParser)?.GetConfigurationSource();
+
+        /// <summary>
         ///     Returns prefix lengths for the index.
         /// </summary>
         /// <param name="index"> The index. </param>

--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -75,6 +75,7 @@ namespace Microsoft.EntityFrameworkCore
             public override bool JsonDataTypeEmulation => false;
             public override bool ImplicitBoolCheckUsesIndex => ServerVersion.Version >= new Version(8, 0, 0); // Exact version has not been verified yet
             public override bool MySqlBug96947Workaround => ServerVersion.Version >= new Version(5, 7, 0); // Exact version has not been verified yet, but it is 5.7.x and could very well be 5.7.0
+            public override bool FullTextParser => true;
         }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
@@ -78,5 +78,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
         public virtual bool ImplicitBoolCheckUsesIndex => false;
         public virtual bool Sequences => false;
         public virtual bool MySqlBug96947Workaround => false;
+        public virtual bool FullTextParser => false;
     }
 }

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
@@ -23,6 +23,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
         public const string LegacyValueGeneratedOnAdd = Prefix + "ValueGeneratedOnAdd";
         public const string LegacyValueGeneratedOnAddOrUpdate = Prefix + "ValueGeneratedOnAddOrUpdate";
         public const string FullTextIndex = Prefix + "FullTextIndex";
+        public const string FullTextParser = Prefix + "FullTextParser";
         public const string SpatialIndex = Prefix + "SpatialIndex";
         public const string CharSet = Prefix + "CharSet";
         public const string Collation = Prefix + "Collation";

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
@@ -54,6 +54,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
                     isFullText.Value);
             }
 
+            var fullTextParser = modelIndex.FullTextParser();
+            if (!string.IsNullOrEmpty(fullTextParser))
+            {
+                yield return new Annotation(
+                    MySqlAnnotationNames.FullTextParser,
+                    fullTextParser);
+            }
+
             var isSpatial = modelIndex.IsSpatial();
             if (isSpatial.HasValue)
             {

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -1470,7 +1470,19 @@ DELIMITER ;";
         protected override void IndexOptions(CreateIndexOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
             // The base implementation supports index filters in form of a WHERE clause.
-            // This is not supported by MySQL.
+            // This is not supported by MySQL, so we don't call it here.
+
+            var fullText = operation[MySqlAnnotationNames.FullTextIndex] as bool?;
+            if (fullText == true)
+            {
+                var fullTextParser = operation[MySqlAnnotationNames.FullTextParser] as string;
+                if (!string.IsNullOrEmpty(fullTextParser))
+                {
+                    builder.Append(" /*!50100 WITH PARSER ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(fullTextParser))
+                        .Append(" */");
+                }
+            }
         }
 
         /// <summary>

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -1478,7 +1478,10 @@ DELIMITER ;";
                 var fullTextParser = operation[MySqlAnnotationNames.FullTextParser] as string;
                 if (!string.IsNullOrEmpty(fullTextParser))
                 {
-                    builder.Append(" /*!50100 WITH PARSER ")
+                    // Official MySQL support exists since 5.1, but since MariaDB does not support full-text parsers and does not recognize
+                    // the "/*!xxxxx" syntax for versions below 50700, we use 50700 here, even though the statement would work in lower
+                    // versions as well. Since we don't support MySQL 5.6 officially anymore, this is fine.
+                    builder.Append(" /*!50700 WITH PARSER ")
                         .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(fullTextParser))
                         .Append(" */");
                 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlTransientExceptionDetector.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTransientExceptionDetector.cs
@@ -20,7 +20,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         {
             if (ex is MySqlException mySqlException)
             {
-                switch ((MySqlErrorCode)mySqlException.Number)
+                switch (mySqlException.ErrorCode)
                 {
                     // Thrown if timer queue couldn't be cleared while reading sockets
                     case MySqlErrorCode.CommandTimeoutExpired:

--- a/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
@@ -854,6 +854,24 @@ SELECT ROW_COUNT();");
         }
 
         [ConditionalFact]
+        public virtual void CreateIndexOperation_fulltext_with_parser()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "FirstName", "LastName" },
+                    [MySqlAnnotationNames.FullTextIndex] = true,
+                    [MySqlAnnotationNames.FullTextParser] = "ngram",
+                });
+
+            Assert.Equal(
+                "CREATE FULLTEXT INDEX `IX_People_Name` ON `People` (`FirstName`, `LastName`) /*!50100 WITH PARSER `ngram` */;" + EOL,
+                Sql);
+        }
+
+        [ConditionalFact]
         public virtual void CreateIndexOperation_spatial()
         {
             // TODO: Use meaningful column names.

--- a/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
@@ -867,7 +867,7 @@ SELECT ROW_COUNT();");
                 });
 
             Assert.Equal(
-                "CREATE FULLTEXT INDEX `IX_People_Name` ON `People` (`FirstName`, `LastName`) /*!50100 WITH PARSER `ngram` */;" + EOL,
+                "CREATE FULLTEXT INDEX `IX_People_Name` ON `People` (`FirstName`, `LastName`) /*!50700 WITH PARSER `ngram` */;" + EOL,
                 Sql);
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -801,7 +801,7 @@ CREATE FULLTEXT INDEX `IX_IceCreams_Name` ON `IceCreams` (`Name`);",
                 @"DROP TABLE IF EXISTS `IceCreams`;");
         }
 
-        [Fact]
+        [ConditionalFact]
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.FullTextParser))]
         public void Set_fulltextparser_for_fulltext_index_with_parser()
         {
@@ -813,7 +813,7 @@ CREATE TABLE `IceCreams` (
     PRIMARY KEY (`IceCreamId`)
 );
 
-CREATE FULLTEXT INDEX `IX_IceCreams_Name` ON `IceCreams` (`Name`) /*!50100 WITH PARSER `ngram` */;",
+CREATE FULLTEXT INDEX `IX_IceCreams_Name` ON `IceCreams` (`Name`) /*!50700 WITH PARSER `ngram` */;",
                 Enumerable.Empty<string>(),
                 Enumerable.Empty<string>(),
                 dbModel =>

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -802,6 +802,34 @@ CREATE FULLTEXT INDEX `IX_IceCreams_Name` ON `IceCreams` (`Name`);",
         }
 
         [Fact]
+        [SupportedServerVersionCondition(nameof(ServerVersionSupport.FullTextParser))]
+        public void Set_fulltextparser_for_fulltext_index_with_parser()
+        {
+            Test(
+                @"
+CREATE TABLE `IceCreams` (
+    `IceCreamId` int NOT NULL,
+    `Name` varchar(255) NOT NULL,
+    PRIMARY KEY (`IceCreamId`)
+);
+
+CREATE FULLTEXT INDEX `IX_IceCreams_Name` ON `IceCreams` (`Name`) /*!50100 WITH PARSER `ngram` */;",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var index = Assert.Single(dbModel.Tables.Single().Indexes);
+
+                    Assert.Equal("IceCreams", index.Table.Name, StringComparer.OrdinalIgnoreCase);
+                    Assert.Equal(1, index.Columns.Count);
+                    Assert.Equal("Name", index.Columns[0].Name, StringComparer.OrdinalIgnoreCase);
+                    Assert.Equal(true, index.FindAnnotation(MySqlAnnotationNames.FullTextIndex)?.Value);
+                    Assert.Equal("ngram", index.FindAnnotation(MySqlAnnotationNames.FullTextParser)?.Value);
+                },
+                @"DROP TABLE IF EXISTS `IceCreams`;");
+        }
+
+        [Fact]
         public void Set_spatial_for_spatial_index()
         {
             Test(


### PR DESCRIPTION
Supports specifying a full-text parser in model definitions via an additional optional parameter to the `.IsFullText()` extension method for indexes.
Also adds support for full-text parsers in migrations and when scaffolding.

Fixes #1367