### PR TITLE
Improve scaffolding of JSON columns from MariaDB databases

### DIFF
--- a/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
@@ -74,6 +74,9 @@ namespace Microsoft.EntityFrameworkCore
             public override bool JsonDataTypeEmulation => ServerVersion.Version >= new Version(10, 2, 4); // JSON_COMPACT was added in 10.2.4, though most other functions where added in 10.2.3
             public override bool ImplicitBoolCheckUsesIndex => ServerVersion.Version >= new Version(10, 0, 0); // Exact version has not been verified yet
             public override bool Sequences => ServerVersion.Version >= new Version(10, 3, 0);
+            public override bool InformationSchemaCheckConstraintsTable => ServerVersion.Version >= new Version(10, 3, 10) ||
+                                                                           ServerVersion.Version.Major == 10 && ServerVersion.Version.Minor == 2 && ServerVersion.Version.Build >= 22;  // MySQL is missing the explicit TABLE_NAME column that MariaDB supports, so always join the TABLE_CONSTRAINTS table when accessing CHECK_CONSTRAINTS for any database server that supports CHECK_CONSTRAINTS.
+            public override bool IdentifyJsonColumsByCheckConstraints => true;
         }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -76,6 +76,7 @@ namespace Microsoft.EntityFrameworkCore
             public override bool ImplicitBoolCheckUsesIndex => ServerVersion.Version >= new Version(8, 0, 0); // Exact version has not been verified yet
             public override bool MySqlBug96947Workaround => ServerVersion.Version >= new Version(5, 7, 0); // Exact version has not been verified yet, but it is 5.7.x and could very well be 5.7.0
             public override bool FullTextParser => true;
+            public override bool InformationSchemaCheckConstraintsTable => ServerVersion.Version >= new Version(8, 0, 16); // MySQL is missing the explicit TABLE_NAME column that MariaDB supports, so always join the TABLE_CONSTRAINTS table when accessing CHECK_CONSTRAINTS for any database server that supports CHECK_CONSTRAINTS.
         }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
@@ -79,5 +79,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
         public virtual bool Sequences => false;
         public virtual bool MySqlBug96947Workaround => false;
         public virtual bool FullTextParser => false;
+        public virtual bool InformationSchemaCheckConstraintsTable => false;
+        public virtual bool IdentifyJsonColumsByCheckConstraints => false;
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -339,14 +339,42 @@ DROP TABLE PrincipalTable;");
             Test(
                 @"
 CREATE TABLE `PlaceDetails` (
-    `Characteristics` json
-);",
+    `JsonCharacteristics` json,
+    `TextDescription` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
+    `TextDependingOnValidJsonCharacteristics` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci CHECK (json_valid(`JsonCharacteristics`)),
+    `TextCharacteristics` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci CHECK (json_valid(`TextCharacteristics`)),
+    `OtherJsonCharacteristics` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin CHECK (json_valid(`OtherJsonCharacteristics`))
+) CHARACTER SET latin1 COLLATE latin1_general_ci;",
                 Enumerable.Empty<string>(),
                 Enumerable.Empty<string>(),
                 dbModel =>
                     {
-                        var characteristicsColumn = Assert.Single(dbModel.Tables.Single(t => t.Name == "PlaceDetails").Columns);
-                        Assert.Equal("json", characteristicsColumn.StoreType);
+                        var table = Assert.Single(dbModel.Tables.Where(t => t.Name == "PlaceDetails"));
+                        var jsonCharacteristicsColumn = Assert.Single(table.Columns.Where(c => c.Name == "JsonCharacteristics"));
+                        var textDescriptionColumn = Assert.Single(table.Columns.Where(c => c.Name == "TextDescription"));
+                        var textDependingOnValidJsonCharacteristicsColumn = Assert.Single(table.Columns.Where(c => c.Name == "TextDependingOnValidJsonCharacteristics"));
+                        var textCharacteristicsColumn = Assert.Single(table.Columns.Where(c => c.Name == "TextCharacteristics"));
+                        var otherJsonCharacteristicsColumn = Assert.Single(table.Columns.Where(c => c.Name == "OtherJsonCharacteristics"));
+
+                        Assert.Equal("json", jsonCharacteristicsColumn.StoreType);
+                        Assert.Null(jsonCharacteristicsColumn[MySqlAnnotationNames.CharSet]);
+                        Assert.Null(jsonCharacteristicsColumn.Collation);
+
+                        Assert.Equal("longtext", textDescriptionColumn.StoreType);
+                        Assert.Equal("utf8mb4", textDescriptionColumn[MySqlAnnotationNames.CharSet]);
+                        Assert.Equal("utf8mb4_bin", textDescriptionColumn.Collation);
+
+                        Assert.Equal("longtext", textDependingOnValidJsonCharacteristicsColumn.StoreType);
+                        Assert.Equal("utf8mb4", textDependingOnValidJsonCharacteristicsColumn[MySqlAnnotationNames.CharSet]);
+                        Assert.Equal("utf8mb4_general_ci", textDependingOnValidJsonCharacteristicsColumn.Collation);
+
+                        Assert.Equal("longtext", textCharacteristicsColumn.StoreType);
+                        Assert.Equal("utf8mb4", textCharacteristicsColumn[MySqlAnnotationNames.CharSet]);
+                        Assert.Equal("utf8mb4_general_ci", textCharacteristicsColumn.Collation);
+
+                        Assert.Equal("json", otherJsonCharacteristicsColumn.StoreType);
+                        Assert.Null(otherJsonCharacteristicsColumn[MySqlAnnotationNames.CharSet]);
+                        Assert.Null(otherJsonCharacteristicsColumn.Collation);
                     },
                 @"
 DROP TABLE `PlaceDetails`;");


### PR DESCRIPTION
Scaffold `LONGTEXT` columns from MariaDB databases as `JSON`, if they contain the default CHECK CONSTRAINT `` json_valid(`columnName`) `` added by MariaDB >= 10.4.3 for `JSON` columns, in addition to the `utf8mb4` charset and `utf8mb4_bin` collation, because `JSON` is just an alias for `LONGTEXT` for MariaDB.

Don't scaffold charsets and collations for `JSON` columns, because they are enforced/expected to have the `utf8mb4` charset and `utf8mb4_bin` collation.