### PR TITLE
Make string method translations, that contain a StringComparison parameter, opt-in

### DIFF
--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -20,5 +20,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         bool IndexOptimizedBooleanColumns { get; }
         MySqlJsonChangeTrackingOptions JsonChangeTrackingOptions { get; }
         bool LimitKeyedOrIndexedStringColumnLength { get; }
+        bool StringComparisonTranslations { get; }
     }
 }

--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -38,6 +38,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             SchemaNameTranslator = copyFrom.SchemaNameTranslator;
             IndexOptimizedBooleanColumns = copyFrom.IndexOptimizedBooleanColumns;
             LimitKeyedOrIndexedStringColumnLength = copyFrom.LimitKeyedOrIndexedStringColumnLength;
+            StringComparisonTranslations = copyFrom.StringComparisonTranslations;
         }
 
         /// <summary>
@@ -78,6 +79,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         public MySqlSchemaNameTranslator SchemaNameTranslator { get; private set; }
         public bool IndexOptimizedBooleanColumns { get; private set; }
         public bool LimitKeyedOrIndexedStringColumnLength { get; private set; }
+        public bool StringComparisonTranslations { get; private set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -159,6 +161,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             return clone;
         }
 
+        public MySqlOptionsExtension WithStringComparisonTranslations(bool enable)
+        {
+            var clone = (MySqlOptionsExtension)Clone();
+            clone.StringComparisonTranslations = enable;
+            return clone;
+        }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -222,6 +231,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                     hashCode.Add(Extension.SchemaNameTranslator);
                     hashCode.Add(Extension.IndexOptimizedBooleanColumns);
                     hashCode.Add(Extension.LimitKeyedOrIndexedStringColumnLength);
+                    hashCode.Add(Extension.StringComparisonTranslations);
 
                     _serviceProviderHash = hashCode.ToHashCode();
                 }
@@ -240,6 +250,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                 debugInfo["Pomelo.EntityFrameworkCore.MySql:" + nameof(Extension.SchemaNameTranslator)] = HashCode.Combine(Extension.SchemaNameTranslator).ToString(CultureInfo.InvariantCulture);
                 debugInfo["Pomelo.EntityFrameworkCore.MySql:" + nameof(MySqlDbContextOptionsBuilder.EnableIndexOptimizedBooleanColumns)] = HashCode.Combine(Extension.IndexOptimizedBooleanColumns).ToString(CultureInfo.InvariantCulture);
                 debugInfo["Pomelo.EntityFrameworkCore.MySql:" + nameof(MySqlDbContextOptionsBuilder.LimitKeyedOrIndexedStringColumnLength)] = HashCode.Combine(Extension.LimitKeyedOrIndexedStringColumnLength).ToString(CultureInfo.InvariantCulture);
+                debugInfo["Pomelo.EntityFrameworkCore.MySql:" + nameof(MySqlDbContextOptionsBuilder.EnableStringComparisonTranslations)] = HashCode.Combine(Extension.StringComparisonTranslations).ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDbContextOptionsBuilder.cs
@@ -114,5 +114,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         public virtual MySqlDbContextOptionsBuilder LimitKeyedOrIndexedStringColumnLength(bool enable = true)
             => WithOption(e => e.WithKeyedOrIndexedStringColumnLengthLimit(enable));
+
+        /// <summary>
+        ///     Configures the context to translate string related methods, containing a parameter of type <see cref="StringComparison"/>,
+        ///     to their SQL equivalent, even though MySQL might not be able to use indexes when executing the query, resulting in decreased
+        ///     performance. Whether MySQL is able to use indexes for the query, depends on the <see cref="StringComparison"/> option, the
+        ///     underlying collation and the scenario.
+        ///     It is also possible to just use `EF.Functions.Collate()`, possibly in addition to `string.ToUpper()` if needed, to achieve
+        ///     the same result but with full control over the SQL generation.
+        /// </summary>
+        public virtual MySqlDbContextOptionsBuilder EnableStringComparisonTranslations(bool enable = true)
+            => WithOption(e => e.WithStringComparisonTranslations(enable));
     }
 }

--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -42,6 +42,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             IndexOptimizedBooleanColumns = false;
 
             LimitKeyedOrIndexedStringColumnLength = true;
+            StringComparisonTranslations = false;
         }
 
         public virtual void Initialize(IDbContextOptions options)
@@ -60,6 +61,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             IndexOptimizedBooleanColumns = mySqlOptions.IndexOptimizedBooleanColumns;
             JsonChangeTrackingOptions = mySqlJsonOptions?.JsonChangeTrackingOptions ?? default;
             LimitKeyedOrIndexedStringColumnLength = mySqlOptions.LimitKeyedOrIndexedStringColumnLength;
+            StringComparisonTranslations = mySqlOptions.StringComparisonTranslations;
         }
 
         public virtual void Validate(IDbContextOptions options)
@@ -151,6 +153,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
                         nameof(MySqlDbContextOptionsBuilder.LimitKeyedOrIndexedStringColumnLength),
                         nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
             }
+
+            if (!Equals(StringComparisonTranslations, mySqlOptions.StringComparisonTranslations))
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.SingletonOptionChanged(
+                        nameof(MySqlDbContextOptionsBuilder.EnableStringComparisonTranslations),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
+            }
         }
 
         protected virtual MySqlDefaultDataTypeMappings ApplyDefaultDataTypeMappings(MySqlDefaultDataTypeMappings defaultDataTypeMappings, MySqlConnectionSettings connectionSettings)
@@ -221,7 +231,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
                    Equals(SchemaNameTranslator, other.SchemaNameTranslator) &&
                    IndexOptimizedBooleanColumns == other.IndexOptimizedBooleanColumns &&
                    JsonChangeTrackingOptions == other.JsonChangeTrackingOptions &&
-                   LimitKeyedOrIndexedStringColumnLength == other.LimitKeyedOrIndexedStringColumnLength;
+                   LimitKeyedOrIndexedStringColumnLength == other.LimitKeyedOrIndexedStringColumnLength &&
+                   StringComparisonTranslations == other.StringComparisonTranslations;
         }
 
         public override bool Equals(object obj)
@@ -259,6 +270,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             hashCode.Add(IndexOptimizedBooleanColumns);
             hashCode.Add(JsonChangeTrackingOptions);
             hashCode.Add(LimitKeyedOrIndexedStringColumnLength);
+            hashCode.Add(StringComparisonTranslations);
 
             return hashCode.ToHashCode();
         }
@@ -274,5 +286,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
         public virtual bool IndexOptimizedBooleanColumns { get; private set; }
         public virtual MySqlJsonChangeTrackingOptions JsonChangeTrackingOptions { get; private set; }
         public virtual bool LimitKeyedOrIndexedStringColumnLength { get; private set; }
+        public virtual bool StringComparisonTranslations { get; private set; }
     }
 }

--- a/src/EFCore.MySql/Properties/MySqlStrings.Designer.cs
+++ b/src/EFCore.MySql/Properties/MySqlStrings.Designer.cs
@@ -145,6 +145,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
         public static string ExpressionTypeMismatch
             => GetString("ExpressionTypeMismatch");
 
+        /// <summary>
+        ///     Translation of the '{declaringTypeName}.{methodName}' overload with a 'StringComparison' parameter is not supported by default. To opt-in to translations of methods with a 'StringComparison' parameter, call `{optionName}` on your MySQL specific 'DbContext' options. For general EF Core information about this error, see https://go.microsoft.com/fwlink/?linkid=2129535 for more information.
+        /// </summary>
+        public static string QueryUnableToTranslateMethodWithStringComparison([CanBeNull] object declaringTypeName, [CanBeNull] object methodName, [CanBeNull] object optionName)
+            => string.Format(
+                GetString("QueryUnableToTranslateMethodWithStringComparison", nameof(declaringTypeName), nameof(methodName), nameof(optionName)),
+                declaringTypeName, methodName, optionName);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.MySql/Properties/MySqlStrings.resx
+++ b/src/EFCore.MySql/Properties/MySqlStrings.resx
@@ -228,4 +228,7 @@
   <data name="ExpressionTypeMismatch" xml:space="preserve">
     <value>The specified expression does not have the correct Type.</value>
   </data>
+  <data name="QueryUnableToTranslateMethodWithStringComparison" xml:space="preserve">
+    <value>Translation of the '{declaringTypeName}.{methodName}' overload with a 'StringComparison' parameter is not supported by default. To opt-in to translations of methods with a 'StringComparison' parameter, call `{optionName}` on your MySQL specific 'DbContext' options. For general EF Core information about this error, see https://go.microsoft.com/fwlink/?linkid=2129535 for more information.</value>
+  </data>
 </root>

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 
@@ -35,13 +36,31 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
         private static readonly MethodInfo _indexOfMethodInfo
             = typeof(string).GetRuntimeMethod(nameof(string.IndexOf), new[] {typeof(string), typeof(StringComparison)});
 
+        internal static readonly MethodInfo[] StringComparisonMethodInfos =
+        {
+            _equalsMethodInfo,
+            _staticEqualsMethodInfo,
+            _startsWithMethodInfo,
+            _endsWithMethodInfo,
+            _containsMethodInfo,
+            _indexOfMethodInfo,
+        };
+
+        internal static readonly MethodInfo[] RelationalErrorHandledStringComparisonMethodInfos =
+        {
+            _equalsMethodInfo,
+            _staticEqualsMethodInfo,
+        };
+
         private readonly SqlExpression _caseSensitiveComparisons;
 
         private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
+        private readonly IMySqlOptions _options;
 
-        public MySqlStringComparisonMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlStringComparisonMethodTranslator(ISqlExpressionFactory sqlExpressionFactory, IMySqlOptions options)
         {
             _sqlExpressionFactory = (MySqlSqlExpressionFactory)sqlExpressionFactory;
+            _options = options;
             _caseSensitiveComparisons = _sqlExpressionFactory.Constant(
                 new[] {StringComparison.Ordinal, StringComparison.CurrentCulture, StringComparison.InvariantCulture});
         }
@@ -52,7 +71,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
             IReadOnlyList<SqlExpression> arguments,
             IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
-            if (Equals(method, _equalsMethodInfo) && instance != null)
+            if (Equals(method, _equalsMethodInfo) && instance != null && _options.StringComparisonTranslations)
             {
                 return MakeStringEqualsExpression(
                     instance,
@@ -61,7 +80,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                 );
             }
 
-            if (Equals(method, _staticEqualsMethodInfo))
+            if (Equals(method, _staticEqualsMethodInfo) && _options.StringComparisonTranslations)
             {
                 return MakeStringEqualsExpression(
                     arguments[0],
@@ -70,7 +89,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                 );
             }
 
-            if (Equals(method, _startsWithMethodInfo) && instance != null)
+            if (Equals(method, _startsWithMethodInfo) && instance != null && _options.StringComparisonTranslations)
             {
                 return MakeStartsWithExpression(
                     instance,
@@ -79,7 +98,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                 );
             }
 
-            if (Equals(method, _endsWithMethodInfo) && instance != null)
+            if (Equals(method, _endsWithMethodInfo) && instance != null && _options.StringComparisonTranslations)
             {
                 return MakeEndsWithExpression(
                     instance,
@@ -88,7 +107,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                 );
             }
 
-            if (Equals(method, _containsMethodInfo) && instance != null)
+            if (Equals(method, _containsMethodInfo) && instance != null && _options.StringComparisonTranslations)
             {
                 return MakeContainsExpression(
                     instance,
@@ -97,7 +116,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                 );
             }
 
-            if (Equals(method, _indexOfMethodInfo) && instance != null)
+            if (Equals(method, _indexOfMethodInfo) && instance != null && _options.StringComparisonTranslations)
             {
                 return MakeIndexOfExpression(
                     instance,
@@ -462,6 +481,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
                     e => e,
                     search,
                     e => e);
+            }
+
+            // Users have to opt-in, to use string method translations with an explicit StringComparison parameter.
+            if (!_options.StringComparisonTranslations)
+            {
+                return null;
             }
 
             if (TryGetExpressionValue<StringComparison>(stringComparison, out var cmp))

--- a/src/EFCore.MySql/Query/Internal/MySqlMethodCallTranslatorProvider.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlMethodCallTranslatorProvider.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
@@ -10,7 +11,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlMethodCallTranslatorProvider : RelationalMethodCallTranslatorProvider
     {
-        public MySqlMethodCallTranslatorProvider([NotNull] RelationalMethodCallTranslatorProviderDependencies dependencies)
+        public MySqlMethodCallTranslatorProvider(
+            [NotNull] RelationalMethodCallTranslatorProviderDependencies dependencies,
+            [NotNull] IMySqlOptions options)
             : base(dependencies)
         {
             var sqlExpressionFactory = (MySqlSqlExpressionFactory)dependencies.SqlExpressionFactory;
@@ -28,8 +31,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 new MySqlNewGuidTranslator(sqlExpressionFactory),
                 new MySqlObjectToStringTranslator(sqlExpressionFactory),
                 new MySqlRegexIsMatchTranslator(sqlExpressionFactory),
-                new MySqlStringComparisonMethodTranslator(sqlExpressionFactory),
-                new MySqlStringMethodTranslator(sqlExpressionFactory, relationalTypeMappingSource),
+                new MySqlStringComparisonMethodTranslator(sqlExpressionFactory, options),
+                new MySqlStringMethodTranslator(sqlExpressionFactory, relationalTypeMappingSource, options),
             });
         }
     }

--- a/src/EFCore.MySql/Query/Internal/MySqlStringMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlStringMethodTranslator.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
@@ -19,6 +20,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
     public class MySqlStringMethodTranslator : IMethodCallTranslator
     {
         private readonly IRelationalTypeMappingSource _typeMappingSource;
+        private readonly IMySqlOptions _options;
 
         private static readonly MethodInfo _indexOfMethodInfo
             = typeof(string).GetRuntimeMethod(nameof(string.IndexOf), new[] { typeof(string) });
@@ -109,10 +111,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 
         public MySqlStringMethodTranslator(
             MySqlSqlExpressionFactory sqlExpressionFactory,
-            MySqlTypeMappingSource typeMappingSource)
+            MySqlTypeMappingSource typeMappingSource,
+            IMySqlOptions options)
         {
-            _typeMappingSource = typeMappingSource;
             _sqlExpressionFactory = sqlExpressionFactory;
+            _typeMappingSource = typeMappingSource;
+            _options = options;
         }
 
         public virtual SqlExpression Translate(
@@ -123,7 +127,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
         {
             if (_indexOfMethodInfo.Equals(method))
             {
-                return new MySqlStringComparisonMethodTranslator(_sqlExpressionFactory)
+                return new MySqlStringComparisonMethodTranslator(_sqlExpressionFactory, _options)
                     .MakeIndexOfExpression(instance, arguments[0]);
             }
 
@@ -214,19 +218,19 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 
             if (_containsMethodInfo.Equals(method))
             {
-                return new MySqlStringComparisonMethodTranslator(_sqlExpressionFactory)
+                return new MySqlStringComparisonMethodTranslator(_sqlExpressionFactory, _options)
                     .MakeContainsExpression(instance, arguments[0]);
             }
 
             if (_startsWithMethodInfo.Equals(method))
             {
-                return new MySqlStringComparisonMethodTranslator(_sqlExpressionFactory)
+                return new MySqlStringComparisonMethodTranslator(_sqlExpressionFactory, _options)
                     .MakeStartsWithExpression(instance, arguments[0]);
             }
 
             if (_endsWithMethodInfo.Equals(method))
             {
-                return new MySqlStringComparisonMethodTranslator(_sqlExpressionFactory)
+                return new MySqlStringComparisonMethodTranslator(_sqlExpressionFactory, _options)
                     .MakeEndsWithExpression(instance, arguments[0]);
             }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/CaseSensitiveNorthwindQueryMySqlFixture.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/CaseSensitiveNorthwindQueryMySqlFixture.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
@@ -10,5 +11,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
     {
         protected override string StoreName => "NorthwindCs";
         protected override ITestStoreFactory TestStoreFactory => MySqlNorthwindTestStoreFactory.InstanceCs;
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            var optionsBuilder = base.AddOptions(builder);
+            new MySqlDbContextOptionsBuilder(optionsBuilder).EnableStringComparisonTranslations();
+            return optionsBuilder;
+        }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindWhereQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindWhereQueryMySqlTest.cs
@@ -206,16 +206,6 @@ FROM `Customers` AS `c`
 WHERE SUBSTRING(`c`.`City`, 1 + 1, 2) = 'ea'");
         }
 
-        [ConditionalTheory]
-        public override Task Where_equals_method_string_with_ignore_case(bool async)
-        {
-            // We have an implementation for this and therefore don't throw.
-            return AssertQuery(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.City.Equals("London", StringComparison.OrdinalIgnoreCase)),
-                entryCount: 6);
-        }
-
         [ConditionalTheory(Skip = "issue #573")]
         public override Task Where_as_queryable_expression(bool async)
         {


### PR DESCRIPTION
To enable translation support of `System.String` methods that contain a `StringComparison` parameter, call the `MySqlDbContextOptionsBuilder.EnableStringComparisonTranslations(true)` method from your `UseMySql()` call.

Fixes #1390