### PR TITLE
Improve XML documentation of ServerVersion and derived classes and rename methods

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbContextOptionsExtensions.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using MySqlConnector;
-using Pomelo.EntityFrameworkCore.MySql.Storage;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -32,7 +31,18 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         /// </summary>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
-        /// <param name="serverVersion"> The version of the database server. </param>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
+        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
+        ///         database server), or by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///      </para>
+        /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder UseMySql(
@@ -57,7 +67,18 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
         /// <param name="connectionString"> The connection string of the database to connect to. </param>
-        /// <param name="serverVersion"> The version of the database server used in the connection string. </param>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
+        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
+        ///         database server), or by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///      </para>
+        /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder UseMySql(
@@ -97,7 +118,18 @@ namespace Microsoft.EntityFrameworkCore
         ///     in the open state then EF will not open or close the connection. If the connection is in the closed
         ///     state then EF will open and close the connection as needed.
         /// </param>
-        /// <param name="serverVersion"> The version of the database server used in the connection string. </param>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
+        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
+        ///         database server), or by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///      </para>
+        /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder UseMySql(
@@ -153,7 +185,18 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <typeparam name="TContext"> The type of context to be configured. </typeparam>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
-        /// <param name="serverVersion"> The version of the database server. </param>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
+        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
+        ///         database server), or by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///      </para>
+        /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(
@@ -170,7 +213,18 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TContext"> The type of context to be configured. </typeparam>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
         /// <param name="connectionString"> The connection string of the database to connect to. </param>
-        /// <param name="serverVersion"> The version of the database server used in the connection string. </param>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
+        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
+        ///         database server), or by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///      </para>
+        /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(
@@ -192,7 +246,18 @@ namespace Microsoft.EntityFrameworkCore
         ///     state then EF will open and close the connection as needed.
         /// </param>
         /// <typeparam name="TContext"> The type of context to be configured. </typeparam>
-        /// <param name="serverVersion"> The version of the database server used in the connection string. </param>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
+        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
+        ///         database server), or by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///      </para>
+        /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(

--- a/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
@@ -8,6 +8,10 @@ using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
+    /// <summary>
+    /// Represents a <see cref="ServerVersion"/> for MariaDB database servers.
+    /// For MySQL database servers, use <see cref="MySqlServerVersion"/> instead.
+    /// </summary>
     public class MariaDbServerVersion : ServerVersion
     {
         public static readonly string MariaDbTypeIdentifier = nameof(ServerType.MariaDb).ToLowerInvariant();
@@ -22,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public MariaDbServerVersion(string versionString)
-            : this(FromString(versionString, ServerType.MariaDb))
+            : this(Parse(versionString, ServerType.MariaDb))
         {
         }
 

--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -8,6 +8,10 @@ using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
+    /// <summary>
+    /// Represents a <see cref="ServerVersion"/> for MySQL database servers.
+    /// For MariaDB database servers, use <see cref="MariaDbServerVersion"/> instead.
+    /// </summary>
     public class MySqlServerVersion : ServerVersion
     {
         public static readonly string MySqlTypeIdentifier = nameof(ServerType.MySql).ToLowerInvariant();
@@ -22,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public MySqlServerVersion(string versionString)
-            : this(FromString(versionString, ServerType.MySql))
+            : this(Parse(versionString, ServerType.MySql))
         {
         }
 

--- a/src/EFCore.MySql/Infrastructure/ServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerVersion.cs
@@ -11,6 +11,11 @@ using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
+    /// <summary>
+    /// The abstract base class of <see cref="MySqlServerVersion"/> and <see cref="MariaDbServerVersion"/>.
+    /// Contains static methods to create a <see cref="ServerVersion"/> from a string or to auto detect the server version from a database
+    /// server.
+    /// </summary>
     public abstract class ServerVersion
     {
         private static readonly Regex _versionRegex = new Regex(@"\d+\.\d+\.?(?:\d+)?");
@@ -46,17 +51,43 @@ namespace Microsoft.EntityFrameworkCore
         public override int GetHashCode()
             => HashCode.Combine(Version, Type, TypeIdentifier);
 
+        /// <summary>
+        /// Returns the server version and type in the format `major.minor.patch-type`.
+        /// </summary>
+        /// <returns>The server version and type string.</returns>
         public override string ToString()
             => $"{Version}-{TypeIdentifier}";
 
+        /// <summary>
+        /// Retrieves the <see cref="ServerVersion"/> (version number and server type) from a database server.
+        /// </summary>
+        /// <param name="connectionString">The connection string.</param>
+        /// <returns>The <see cref="ServerVersion"/>.</returns>
+        /// <remarks>
+        /// Uses a connection string to open a connection to the database server and then executes a command.
+        /// The connection will ignore the database specified in the connection string. It therefore makes not difference, whether the
+        /// database already exists or not.
+        /// </remarks>
         public static ServerVersion AutoDetect(string connectionString)
         {
             using var connection = new MySqlConnection(
                 new MySqlConnectionStringBuilder(connectionString) {Database = string.Empty}.ConnectionString);
             connection.Open();
-            return FromString(connection.ServerVersion);
+            return Parse(connection.ServerVersion);
         }
 
+        /// <summary>
+        /// Retrieves the <see cref="ServerVersion"/> (version number and server type) from a database server.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <returns>The <see cref="ServerVersion"/>.</returns>
+        /// <remarks>
+        /// Uses a connection to the database server to execute a command.
+        /// If the connection has already been opened, the connection is is being used as is. Otherwise, the connection is being cloned and
+        /// ignores any database specified in the connection string of the connection. It therefore makes not difference, whether the
+        /// database already exists or not, and the <see cref="ConnectionState"/> of the <paramref name="connection"/> parameter after the
+        /// return of the call is the same as before the call.
+        /// </remarks>
         public static ServerVersion AutoDetect(MySqlConnection connection)
         {
             string serverVersion;
@@ -73,17 +104,37 @@ namespace Microsoft.EntityFrameworkCore
                 serverVersion = connection.ServerVersion;
             }
 
-            return FromString(serverVersion);
+            return Parse(serverVersion);
         }
 
-        public static ServerVersion FromString(string versionString)
-            => FromString(versionString, null);
+        /// <summary>
+        /// Converts a string, containing the server version and type, into a <see cref="ServerVersion"/>.
+        /// </summary>
+        /// <param name="versionString">The server version (mandatory) and type (optional).</param>
+        /// <returns>The <see cref="ServerVersion"/>.</returns>
+        /// <remarks>
+        /// The general format is `major.minor.patch-type`, e.g. `8.0.21-mysql` or `10.5.3-mariadb`. If the type is being omitted, it is
+        /// assumed to be MySQL (and not MariaDB).
+        /// </remarks>
+        public static ServerVersion Parse(string versionString)
+            => Parse(versionString, null);
 
-        public static ServerVersion FromString(string versionString, ServerType? serverType)
+        /// <summary>
+        /// Converts a string, containing the server version and type, into a <see cref="ServerVersion"/>.
+        /// </summary>
+        /// <param name="versionString">The server version (mandatory) and type (optional).</param>
+        /// <param name="serverType">The <see cref="ServerType"/> or <see langword="null" />. </param>
+        /// <returns>The <see cref="ServerVersion"/>.</returns>
+        /// <remarks>
+        /// The general format is `major.minor.patch-type`, e.g. `8.0.21-mysql` or `10.5.3-mariadb`. If the type is being omitted, it is
+        /// assumed to be MySQL (and not MariaDB). The <paramref name="serverType"/> parameter takes precedence over a server type specified
+        /// in the <paramref name="versionString"/> parameter, if not <see langword="null" />.
+        /// </remarks>
+        public static ServerVersion Parse(string versionString, ServerType? serverType)
         {
             Check.NotEmpty(versionString, nameof(versionString));
 
-            if (!TryFromString(versionString, serverType, out var serverVersion))
+            if (!TryParse(versionString, serverType, out var serverVersion))
             {
                 throw new InvalidOperationException($"Unable to determine server version from version string '${versionString}'.");
             }
@@ -91,10 +142,32 @@ namespace Microsoft.EntityFrameworkCore
             return serverVersion;
         }
 
-        public static bool TryFromString(string versionString, out ServerVersion serverVersion)
-            => TryFromString(versionString, null, out serverVersion);
+        /// <summary>
+        /// Tries to converts a string, containing the server version and type, into a <see cref="ServerVersion"/>.
+        /// </summary>
+        /// <param name="versionString">The server version (mandatory) and type (optional).</param>
+        /// <param name="serverVersion">The <see cref="ServerVersion"/>.</param>
+        /// <returns><see langword="true" /> if the conversion was successful, otherwise <see langword="false" />.</returns>
+        /// <remarks>
+        /// The general format is `major.minor.patch-type`, e.g. `8.0.21-mysql` or `10.5.3-mariadb`. If the type is being omitted, it is
+        /// assumed to be MySQL (and not MariaDB).
+        /// </remarks>
+        public static bool TryParse(string versionString, out ServerVersion serverVersion)
+            => TryParse(versionString, null, out serverVersion);
 
-        public static bool TryFromString(string versionString, ServerType? serverType, out ServerVersion serverVersion)
+        /// <summary>
+        /// Tries to converts a string, containing the server version and type, into a <see cref="ServerVersion"/>.
+        /// </summary>
+        /// <param name="versionString">The server version (mandatory) and type (optional).</param>
+        /// <param name="serverType">The <see cref="ServerType"/> or <see langword="null" />. </param>
+        /// <param name="serverVersion">The <see cref="ServerVersion"/>.</param>
+        /// <returns><see langword="true" /> if the conversion was successful, otherwise <see langword="false" />.</returns>
+        /// <remarks>
+        /// The general format is `major.minor.patch-type`, e.g. `8.0.21-mysql` or `10.5.3-mariadb`. If the type is being omitted, it is
+        /// assumed to be MySQL (and not MariaDB). The <paramref name="serverType"/> parameter takes precedence over a server type specified
+        /// in the <paramref name="versionString"/> parameter, if not <see langword="null" />.
+        /// </remarks>
+        public static bool TryParse(string versionString, ServerType? serverType, out ServerVersion serverVersion)
         {
             Check.NotEmpty(versionString, nameof(versionString));
 

--- a/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
@@ -21,7 +21,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
             => throw new NotImplementedException(); // TODO: Remove or implement!
 
         public virtual bool Version(string versionString)
-            => Version(ServerVersion.FromString(versionString));
+            => Version(ServerVersion.Parse(versionString));
 
         public virtual bool Version(ServerVersion serverVersion)
             => ServerVersion.Type == serverVersion.Type &&
@@ -30,7 +30,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
 
         public virtual bool PropertyOrVersion(string propertyNameOrServerVersion)
         {
-            if (ServerVersion.TryFromString(propertyNameOrServerVersion, out var serverVersion))
+            if (ServerVersion.TryParse(propertyNameOrServerVersion, out var serverVersion))
             {
                 return ServerVersion.Type == serverVersion.Type &&
                        ServerVersion.TypeIdentifier == serverVersion.TypeIdentifier &&

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlCodeGenerationServerVersionCreationTypeMapping.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlCodeGenerationServerVersionCreationTypeMapping.cs
@@ -32,7 +32,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
         public override Expression GenerateCodeLiteral(object value)
             => value is MySqlCodeGenerationServerVersionCreation serverVersionCreation
                 ? Expression.Call(
-                    typeof(ServerVersion).GetMethod(nameof(ServerVersion.FromString), new[] {typeof(string)}),
+                    typeof(ServerVersion).GetMethod(nameof(ServerVersion.Parse), new[] {typeof(string)}),
                     Expression.Constant(serverVersionCreation.ServerVersion.ToString()))
                 : null;
     }

--- a/test/EFCore.MySql.FunctionalTests/ConnectionSettingsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/ConnectionSettingsMySqlTest.cs
@@ -24,7 +24,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         public virtual void Insert_and_read_Guid_value(MySqlGuidFormat guidFormat, string sqlEquivalent, string supportedServerVersion)
         {
             if (supportedServerVersion != null &&
-                !AppConfig.ServerVersion.Supports.Version(ServerVersion.FromString(supportedServerVersion)))
+                !AppConfig.ServerVersion.Supports.Version(ServerVersion.Parse(supportedServerVersion)))
             {
                 return;
             }

--- a/test/EFCore.MySql.Tests/Bugs/MySqlBug96947.cs
+++ b/test/EFCore.MySql.Tests/Bugs/MySqlBug96947.cs
@@ -29,7 +29,7 @@ ORDER BY `od1`.`OrderID`;";
             while (reader.Read())
             {
                 var constant = reader["Constant"];
-                var expected = ServerVersion.FromString(Connection.ServerVersion).Supports.MySqlBug96947Workaround
+                var expected = ServerVersion.Parse(Connection.ServerVersion).Supports.MySqlBug96947Workaround
                     ? (object)DBNull.Value
                     : "MyConstantValue";
 
@@ -58,7 +58,7 @@ ORDER BY `od1`.`OrderID`;";
             while (reader.Read())
             {
                 var constant = reader["Constant"];
-                var expected = ServerVersion.FromString(Connection.ServerVersion).Supports.MySqlBug96947Workaround
+                var expected = ServerVersion.Parse(Connection.ServerVersion).Supports.MySqlBug96947Workaround
                     ? (object)DBNull.Value
                     : "MyParameterValue";
 

--- a/test/EFCore.MySql.Tests/Migrations/ServerVersionTest.cs
+++ b/test/EFCore.MySql.Tests/Migrations/ServerVersionTest.cs
@@ -17,7 +17,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
         [InlineData("5.1", ServerType.MySql, "5.1", false)]
         public void TestValidVersion(string input, ServerType serverType, string actualVersion, bool supportsRenameIndex)
         {
-            var serverVersion = ServerVersion.FromString(input);
+            var serverVersion = ServerVersion.Parse(input);
             Assert.Equal(serverVersion.Type, serverType);
             Assert.Equal(serverVersion.Version, new Version(actualVersion));
             Assert.Equal(serverVersion.Supports.RenameIndex, supportsRenameIndex);
@@ -29,7 +29,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations
         [InlineData("8-mysql")]
         public void TestInvalidVersion(string input)
         {
-            Assert.Throws<InvalidOperationException>(() => ServerVersion.FromString("unknown"));
+            Assert.Throws<InvalidOperationException>(() => ServerVersion.Parse("unknown"));
         }
     }
 }

--- a/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
@@ -309,7 +309,7 @@ namespace Pomelo.EntityFrameworkCore.MySql
         public void UseMySql_with_ServerVersion_FromString()
         {
             var builder = new DbContextOptionsBuilder();
-            var serverVersion = ServerVersion.FromString("8.0.21-mysql");
+            var serverVersion = ServerVersion.Parse("8.0.21-mysql");
 
             builder.UseMySql(
                 "Server=foo",

--- a/test/Shared/AppConfig.cs
+++ b/test/Shared/AppConfig.cs
@@ -54,7 +54,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Tests
             return string.IsNullOrEmpty(serverVersionString) ||
                    string.Equals(serverVersionString, "auto", StringComparison.OrdinalIgnoreCase)
                 ? ServerVersion.AutoDetect(ConnectionString)
-                : ServerVersion.FromString(serverVersionString);
+                : ServerVersion.Parse(serverVersionString);
         });
 
         public static IConfigurationRoot Config => _lazyConfig.Value;


### PR DESCRIPTION
Adds XML documentation to the `ServerVersion`, `MySqlServerVersion` and `MariaDbServerVersion` class.
Renames static `FromString()` and `TryFromString()` methods to `Parse()` and `TryParse()` respectively.