### PR TITLE
Setup Fluent API, to generate client-side sequential Guids for appropriate primary key columns, when scaffolding

### DIFF
--- a/src/EFCore.MySql/ValueGeneration/Internal/MySqlSequentialGuidValueGenerator.cs
+++ b/src/EFCore.MySql/ValueGeneration/Internal/MySqlSequentialGuidValueGenerator.cs
@@ -10,9 +10,8 @@ using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.ValueGeneration.Internal
 {
-    public class MySqlSequentialGuidValueGenerator  : ValueGenerator<Guid>
+    public class MySqlSequentialGuidValueGenerator : ValueGenerator<Guid>
     {
-
         private readonly IMySqlOptions _options;
 
         public MySqlSequentialGuidValueGenerator(IMySqlOptions options)
@@ -95,6 +94,5 @@ namespace Pomelo.EntityFrameworkCore.MySql.ValueGeneration.Internal
         ///     always returns false, meaning the generated values will be saved to the database.
         /// </summary>
         public override bool GeneratesTemporaryValues => false;
-
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseCleaner.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseCleaner.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
@@ -15,10 +16,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
     public class MySqlDatabaseCleaner : RelationalDatabaseCleaner
     {
         private readonly IMySqlOptions _options;
+        private readonly IRelationalTypeMappingSource _relationalTypeMappingSource;
 
-        public MySqlDatabaseCleaner(IMySqlOptions options)
+        public MySqlDatabaseCleaner(IMySqlOptions options, IRelationalTypeMappingSource relationalTypeMappingSource)
         {
             _options = options;
+            _relationalTypeMappingSource = relationalTypeMappingSource;
         }
 
         protected override IDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
@@ -29,6 +32,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
                     new DiagnosticListener("Fake"),
                     new MySqlLoggingDefinitions(),
                     new NullDbContextLogger()),
+                _relationalTypeMappingSource,
                 _options);
 
         protected override bool AcceptIndex(DatabaseIndex index) => false;

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseFacadeTestExtensions.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlDatabaseFacadeTestExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
@@ -7,7 +8,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
     public static class MySqlDatabaseFacadeTestExtensions
     {
         public static void EnsureClean(this DatabaseFacade databaseFacade)
-            => new MySqlDatabaseCleaner(databaseFacade.GetService<IMySqlOptions>())
+            => new MySqlDatabaseCleaner(
+                    databaseFacade.GetService<IMySqlOptions>(),
+                    databaseFacade.GetService<IRelationalTypeMappingSource>())
                 .Clean(databaseFacade);
     }
 }


### PR DESCRIPTION
Fixes #1397 
Fixes #1360 