### PR TITLE
Add optimized default collation for character based Guid storing columns

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlModelBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlModelBuilderExtensions.cs
@@ -377,5 +377,77 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         #endregion Collation and delegation
+
+        #region GuidCollation
+
+        /// <summary>
+        ///     Configures the explicit default collation for char-based <see cref="Guid"/> columns, which will be used by all appropriate
+        ///     columns without an explicit collation.
+        /// </summary>
+        /// <param name="modelBuilder"> The model builder. </param>
+        /// <param name="collation">
+        ///     The <see cref="Guid"/> default collation to apply.
+        ///     An empty string means that no explicit collation will be applied, while <see langword="null"/> means that the default
+        ///     collation `ascii_general_ci` will be applied.
+        /// </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static ModelBuilder UseGuidCollation(
+            [NotNull] this ModelBuilder modelBuilder,
+            string collation)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+
+            modelBuilder.Model.SetGuidCollation(collation);
+
+            return modelBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the explicit default collation for char-based <see cref="Guid"/> columns, which will be used by all appropriate
+        ///     columns without an explicit collation.
+        /// </summary>
+        /// <param name="modelBuilder"> The model builder. </param>
+        /// <param name="collation">
+        ///     The <see cref="Guid"/> default collation to apply.
+        ///     An empty string means that no explicit collation will be applied, while <see langword="null"/> means that the default
+        ///     collation `ascii_general_ci` will be applied.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        public static IConventionModelBuilder UseGuidCollation(
+            [NotNull] this IConventionModelBuilder modelBuilder,
+            string collation,
+            bool fromDataAnnotation = false)
+        {
+            if (modelBuilder.CanSetGuidCollation(collation, fromDataAnnotation))
+            {
+                modelBuilder.Metadata.SetGuidCollation(collation, fromDataAnnotation);
+                return modelBuilder;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether the given <see cref="Guid"/> default collation setting can be set.
+        /// </summary>
+        /// <param name="modelBuilder"> The model builder. </param>
+        /// <param name="collation"> The <see cref="Guid"/> default collation setting. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <see langword="true" /> if the given <see cref="Guid"/> default collation setting can be set. </returns>
+        public static bool CanSetGuidCollation(
+            [NotNull] this IConventionModelBuilder modelBuilder,
+            [CanBeNull] string collation,
+            bool fromDataAnnotation = false)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+
+            return modelBuilder.CanSetAnnotation(MySqlAnnotationNames.GuidCollation, collation, fromDataAnnotation);
+        }
+
+        #endregion GuidCollation
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlModelExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlModelExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
@@ -211,5 +212,70 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         #endregion CollationDelegation
+
+        #region GuidCollation
+
+        /// <summary>
+        ///     Returns the default collation used for char-based <see cref="Guid"/> columns.
+        /// </summary>
+        /// <param name="model"> The model. </param>
+        /// <returns>
+        ///     The <see cref="Guid"/> collation setting.
+        ///     An empty string means that no explicit collation will be applied, while <see langword="null"/> means that the default
+        ///     collation `ascii_general_ci` will be applied.
+        /// </returns>
+        public static string GetGuidCollation([NotNull] this IModel model)
+            => model[MySqlAnnotationNames.GuidCollation] as string;
+
+        /// <summary>
+        ///     Attempts to set the default collation used for char-based <see cref="Guid"/> columns.
+        /// </summary>
+        /// <param name="model"> The model. </param>
+        /// <param name="collation">
+        ///     The <see cref="Guid"/> collation setting.
+        ///     An empty string means that no explicit collation will be applied, while <see langword="null"/> means that the default
+        ///     collation `ascii_general_ci` will be applied.
+        /// </param>
+        public static void SetGuidCollation([NotNull] this IMutableModel model, string collation)
+            => model.SetOrRemoveAnnotation(MySqlAnnotationNames.GuidCollation, collation);
+
+        /// <summary>
+        ///     Attempts to set the default collation used for char-based <see cref="Guid"/> columns.
+        /// </summary>
+        /// <param name="model"> The model. </param>
+        /// <param name="collation">
+        ///     The <see cref="Guid"/> collation setting.
+        ///     An empty string means that no explicit collation will be applied, while <see langword="null"/> means that the default
+        ///     collation `ascii_general_ci` will be applied.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        public static void SetGuidCollation([NotNull] this IConventionModel model, string collation, bool fromDataAnnotation = false)
+            => model.SetOrRemoveAnnotation(MySqlAnnotationNames.GuidCollation, collation, fromDataAnnotation);
+
+        /// <summary>
+        ///     Returns the <see cref="ConfigurationSource" /> for the <see cref="Guid"/> collation setting.
+        /// </summary>
+        /// <param name="model"> The model. </param>
+        /// <returns> The <see cref="ConfigurationSource" />. </returns>
+        public static ConfigurationSource? GetGuidCollationConfigurationSource([NotNull] this IConventionModel model)
+            => model.FindAnnotation(MySqlAnnotationNames.GuidCollation)?.GetConfigurationSource();
+
+        /// <summary>
+        ///     Returns the actual <see cref="Guid"/> default collation used for char-based <see cref="Guid"/> columns.
+        /// </summary>
+        /// <param name="model"> The model. </param>
+        /// <param name="defaultCollation"> The default collation to use, if no default collation has been explicitly set. </param>
+        /// <returns>
+        ///     <see langword="null"/> if no collation should be set, otherwise the concrete collation to apply.
+        /// </returns>
+        public static string GetActualGuidCollation([NotNull] this IModel model, [CanBeNull] string defaultCollation)
+            => model.GetGuidCollation() switch
+            {
+                null => defaultCollation,
+                {Length: <= 0} => null,
+                var c => c
+            };
+
+        #endregion GuidCollation
     }
 }

--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -13,6 +13,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         ServerVersion ServerVersion { get; }
         CharSet DefaultCharSet { get; }
         CharSet NationalCharSet { get; }
+        string DefaultGuidCollation { get; }
         bool NoBackslashEscapes { get; }
         bool ReplaceLineBreaksWithCharFunction { get; }
         MySqlDefaultDataTypeMappings DefaultDataTypeMappings { get; }

--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -32,6 +32,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             // NCHAR and NVARCHAR are prefdefined by MySQL.
             NationalCharSet = CharSet.Utf8Mb3;
 
+            // Optimize space and performance for GUID columns.
+            DefaultGuidCollation = "ascii_general_ci";
+
             ReplaceLineBreaksWithCharFunction = true;
             DefaultDataTypeMappings = new MySqlDefaultDataTypeMappings();
 
@@ -225,6 +228,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
                    Equals(ServerVersion, other.ServerVersion) &&
                    Equals(DefaultCharSet, other.DefaultCharSet) &&
                    Equals(NationalCharSet, other.NationalCharSet) &&
+                   Equals(DefaultGuidCollation, other.DefaultGuidCollation) &&
                    NoBackslashEscapes == other.NoBackslashEscapes &&
                    ReplaceLineBreaksWithCharFunction == other.ReplaceLineBreaksWithCharFunction &&
                    Equals(DefaultDataTypeMappings, other.DefaultDataTypeMappings) &&
@@ -263,6 +267,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             hashCode.Add(ServerVersion);
             hashCode.Add(DefaultCharSet);
             hashCode.Add(NationalCharSet);
+            hashCode.Add(DefaultGuidCollation);
             hashCode.Add(NoBackslashEscapes);
             hashCode.Add(ReplaceLineBreaksWithCharFunction);
             hashCode.Add(DefaultDataTypeMappings);
@@ -279,6 +284,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
         public virtual ServerVersion ServerVersion { get; private set; }
         public virtual CharSet DefaultCharSet { get; private set; }
         public virtual CharSet NationalCharSet { get; }
+        public virtual string DefaultGuidCollation { get; private set; }
         public virtual bool NoBackslashEscapes { get; private set; }
         public virtual bool ReplaceLineBreaksWithCharFunction { get; private set; }
         public virtual MySqlDefaultDataTypeMappings DefaultDataTypeMappings { get; private set; }

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
@@ -33,6 +33,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
         public const string CollationDelegation = Prefix + "CollationDelegation";
         public const string IndexPrefixLength = Prefix + "IndexPrefixLength";
         public const string SpatialReferenceSystemId = Prefix + "SpatialReferenceSystemId";
+        public const string GuidCollation = Prefix + "GuidCollation";
 
         [Obsolete("Use '" + nameof(RelationalAnnotationNames) + "." + nameof(RelationalAnnotationNames.Collation) + "' instead.")]
         public const string Collation = Prefix + "Collation";

--- a/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
@@ -34,6 +34,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new MySqlGuidTypeMapping(parameters, _guidFormat);
 
+        public bool IsCharBasedStoreType
+            => GetStoreType(_guidFormat) == "char";
+
         protected override string GenerateNonNullSqlLiteral(object value)
         {
             switch (_guidFormat)

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -264,6 +264,117 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual async Task Add_guid_columns()
+        {
+            await Test(
+                common => { },
+                source => { },
+                target => target
+                    .UseCollation(DefaultCollation)
+                    .Entity(
+                        "IceCream",
+                        e => e.Property<Guid>("IceCreamId")),
+                result =>
+                {
+                    var table = Assert.Single(result.Tables);
+                    var iceCreamIdColumn = Assert.Single(table.Columns.Where(c => c.Name == "IceCreamId"));
+
+                    Assert.Equal("ascii_general_ci", iceCreamIdColumn.Collation);
+                });
+
+            AssertSql(
+                $@"ALTER DATABASE COLLATE {DefaultCollation};",
+                //
+                $@"CREATE TABLE `IceCream` (
+    `IceCreamId` char(36) COLLATE ascii_general_ci NOT NULL
+) COLLATE {DefaultCollation};");
+        }
+
+        [ConditionalFact]
+        public virtual async Task Add_guid_columns_with_collation()
+        {
+            await Test(
+                common => { },
+                source => { },
+                target => target
+                    .UseCollation(DefaultCollation)
+                    .Entity(
+                        "IceCream",
+                        e => e.Property<Guid>("IceCreamId")
+                            .UseCollation(NonDefaultCollation)),
+                result =>
+                {
+                    var table = Assert.Single(result.Tables);
+                    var iceCreamIdColumn = Assert.Single(table.Columns.Where(c => c.Name == "IceCreamId"));
+
+                    Assert.Equal(NonDefaultCollation, iceCreamIdColumn.Collation);
+                });
+
+            AssertSql(
+                $@"ALTER DATABASE COLLATE {DefaultCollation};",
+                //
+                $@"CREATE TABLE `IceCream` (
+    `IceCreamId` char(36) COLLATE {NonDefaultCollation} NOT NULL
+) COLLATE {DefaultCollation};");
+        }
+
+        [ConditionalFact]
+        public virtual async Task Add_guid_columns_with_explicit_default_collation()
+        {
+            await Test(
+                common => { },
+                source => { },
+                target => target
+                    .UseCollation(DefaultCollation)
+                    .UseGuidCollation(NonDefaultCollation)
+                    .Entity(
+                        "IceCream",
+                        e => e.Property<Guid>("IceCreamId")),
+                result =>
+                {
+                    var table = Assert.Single(result.Tables);
+                    var iceCreamIdColumn = Assert.Single(table.Columns.Where(c => c.Name == "IceCreamId"));
+
+                    Assert.Equal(NonDefaultCollation, iceCreamIdColumn.Collation);
+                });
+
+            AssertSql(
+                $@"ALTER DATABASE COLLATE {DefaultCollation};",
+                //
+                $@"CREATE TABLE `IceCream` (
+    `IceCreamId` char(36) COLLATE {NonDefaultCollation} NOT NULL
+) COLLATE {DefaultCollation};");
+        }
+
+        [ConditionalFact]
+        public virtual async Task Add_guid_columns_with_disabled_default_collation()
+        {
+            await Test(
+                common => { },
+                source => { },
+                target => target
+                    .UseCollation(DefaultCollation)
+                    .UseGuidCollation(string.Empty)
+                    .Entity(
+                        "IceCream",
+                        e => e.Property<Guid>("IceCreamId")),
+                result =>
+                {
+                    var table = Assert.Single(result.Tables);
+                    var iceCreamIdColumn = Assert.Single(table.Columns.Where(c => c.Name == "IceCreamId"));
+
+                    Assert.Null(iceCreamIdColumn.Collation);
+                });
+
+            AssertSql(
+                $@"ALTER DATABASE COLLATE {DefaultCollation};",
+                //
+                $@"CREATE TABLE `IceCream` (
+    `IceCreamId` char(36) NOT NULL
+) COLLATE {DefaultCollation};");
+        }
+
+        [ConditionalFact]
         public virtual async Task Alter_column_collations_with_delegation()
         {
             await Test(


### PR DESCRIPTION
Adds `ascii_general_ci` as the default collation for character based `Guid` columns/properties (currently `char(36)` and `char(32)`).
The `Guid` default collation can be overridden using `modelBuilder.UseGuidCollation("latin1_general_ci")`.
It can be completely disabled by setting it to an empty string: `modelBuilder.UseGuidCollation(string.Empty)`.

Addresses #1402
Fixes #1403 