### PR TITLE
Implement support for value generation strategies, that don't use an enum value but its underlying value equivalent

### DIFF
--- a/src/EFCore.MySql/Internal/MySqlValueGenerationStrategyCompatibility.cs
+++ b/src/EFCore.MySql/Internal/MySqlValueGenerationStrategyCompatibility.cs
@@ -12,7 +12,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
     {
         public static MySqlValueGenerationStrategy? GetValueGenerationStrategy(IAnnotation[] annotations)
         {
-            var valueGenerationStrategy = annotations.FirstOrDefault(a => a.Name == MySqlAnnotationNames.ValueGenerationStrategy)?.Value as MySqlValueGenerationStrategy?;
+            var valueGenerationStrategy = ObjectToEnumConverter.GetEnumValue<MySqlValueGenerationStrategy>(
+                annotations.FirstOrDefault(a => a.Name == MySqlAnnotationNames.ValueGenerationStrategy)?.Value);
 
             if (!valueGenerationStrategy.HasValue ||
                 valueGenerationStrategy == MySqlValueGenerationStrategy.None)

--- a/src/EFCore.MySql/Metadata/Internal/EnumExtensions.cs
+++ b/src/EFCore.MySql/Metadata/Internal/EnumExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
+{
+    public static class ObjectToEnumConverter
+    {
+        /// <summary>
+        /// Can be used to allow substitution of enum values with their underlying type in annotations, so that multi-provider models can
+        /// be setup without provider specific dependencies.
+        /// </summary>
+        /// <remarks>
+        /// See https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1205 for further information.
+        /// </remarks>
+        public static T? GetEnumValue<T>(object value)
+            where T : struct
+            => value != null &&
+               Enum.IsDefined(typeof(T), value)
+                ? (T?)(T)Enum.ToObject(typeof(T), value)
+                : null;
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationSqlGeneratorMySqlTest.MySql.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using NetTopologySuite.Geometries;
@@ -256,6 +256,34 @@ DROP PROCEDURE `POMELO_BEFORE_DROP_PRIMARY_KEY`;");
             Assert.Equal(
                 @"CREATE TABLE `IceCreamParlor_IceCreams` (
     `Name` varchar(255) NOT NULL
+);
+",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        [ConditionalFact]
+        public virtual void CreateTable_with_ValueGenerationStrategy_int_value()
+        {
+            Generate(
+                new CreateTableOperation
+                {
+                    Name = "IceCreamShops",
+                    Columns =
+                    {
+                        new AddColumnOperation
+                        {
+                            Name = "IceCreamShopId",
+                            ClrType = typeof(int),
+                            ColumnType = "int",
+                            [MySqlAnnotationNames.ValueGenerationStrategy] = (int)MySqlValueGenerationStrategy.IdentityColumn,
+                        }
+                    }
+                });
+
+            Assert.Equal(
+                @"CREATE TABLE `IceCreamShops` (
+    `IceCreamShopId` int NOT NULL AUTO_INCREMENT
 );
 ",
                 Sql,


### PR DESCRIPTION
Implementation of #1329 for 5.0.
Addresses https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1205#issuecomment-776910444 for 5.0.