### PR TITLE
Fix leaking annotations and empty migration operations

### DIFF
--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
@@ -7,7 +7,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 


### PR DESCRIPTION
Removes delegation annotations from migration operations (but keeps them in the model snapshot) and ensures, that no empty migration operations are being created (which could happen, if a charset or collation is being delegated only, but not applied to the database or table in question).

Addresses https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1402#issuecomment-827141383