### PR TITLE
Support MariaDB specific comments in column type when scaffolding

### DIFF
--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlDatabaseModelFactory.cs
@@ -316,6 +316,11 @@ ORDER BY
                                 ? (bool?)extra.Contains("stored generated", StringComparison.OrdinalIgnoreCase)
                                 : null;
 
+                            // Cleanup the column type, because it might contain trailing C style comments on MariaDB, like the following,
+                            // if an explicit cast is being done in the SELECT of a VIEW:
+                            //     datetime /* mariadb-5.3 */
+                            columnType = Regex.Replace(columnType, @"\s*/\*(?:.*?)\*/\s*$", string.Empty, RegexOptions.Singleline);
+
                             // Override this column's type, if we detected earlier that this column should actually by added to the model
                             // with a different type than the one returned by INFORMATION_SCHEMA.COLUMNS.
                             // This ensures, that e.g. the `json` alias for the `longtext` type for MariaDB databases will be added to the


### PR DESCRIPTION
MariaDB adds a `/* mariadb-5.3 */` comment to `INFORMATION_SCHEMA.COLUMNS.COLUMN_TYPE`, if it represents the column of a view that explicitly casts.

Fixes #1427