### PR TITLE
Fix and improve test framework

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/Xunit/MySqlXunitTestFrameworkDiscoverer.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/Xunit/MySqlXunitTestFrameworkDiscoverer.cs
@@ -37,9 +37,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Xunit
                IsTestConditionMet<SupportedServerVersionConditionAttribute>(type) &&
                IsTestConditionMet<SupportedServerVersionLessThanConditionAttribute>(type);
 
-        protected virtual bool IsTestConditionMet<TType>(ITypeInfo type)
+        protected virtual bool IsTestConditionMet<TType>(ITypeInfo type) where TType : ITestCondition
         {
-            var condition = GetTestCondition<SupportedServerVersionConditionAttribute>(type);
+            var condition = GetTestCondition<TType>(type);
 
             if (condition == null)
             {

--- a/test/EFCore.MySql.Tests/AssemblyInfo.cs
+++ b/test/EFCore.MySql.Tests/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+// #define FIXED_TEST_ORDER
+
+using Xunit;
+
+//
+// Optional: Control the test execution order.
+//           This can be helpful for diffing etc.
+//
+
+#if FIXED_TEST_ORDER
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: TestCollectionOrderer("Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Xunit.MySqlTestCollectionOrderer", "Pomelo.EntityFrameworkCore.MySql.FunctionalTests")]
+[assembly: TestCaseOrderer("Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Xunit.MySqlTestCaseOrderer", "Pomelo.EntityFrameworkCore.MySql.FunctionalTests")]
+
+#endif
+
+// Our custom MySqlXunitTestFrameworkDiscoverer class allows filtering whole classes like SupportedServerVersionConditionAttribute, instead
+// of just the test cases. This is necessary, if a fixture is database server version dependent.
+[assembly: TestFramework("Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.Xunit.MySqlXunitTestFramework", "Pomelo.EntityFrameworkCore.MySql.FunctionalTests")]

--- a/test/EFCore.MySql.Tests/TestWithFixture.cs
+++ b/test/EFCore.MySql.Tests/TestWithFixture.cs
@@ -8,21 +8,21 @@ namespace Pomelo.EntityFrameworkCore.MySql
     public class RawSqlTestWithFixture<TFixture> : TestWithFixture<TFixture>
         where TFixture : MySqlTestFixtureBase
     {
-        private readonly DbContext _context;
+        protected DbContext Context { get; }
         protected MySqlConnection Connection { get; }
 
         protected RawSqlTestWithFixture(TFixture fixture)
             : base(fixture)
         {
-            _context = Fixture.CreateDefaultDbContext();
-            _context.Database.OpenConnection();
+            Context = Fixture.CreateDefaultDbContext();
+            Context.Database.OpenConnection();
 
-            Connection = (MySqlConnection)_context.Database.GetDbConnection();
+            Connection = (MySqlConnection)Context.Database.GetDbConnection();
         }
 
         protected override void Dispose(bool disposing)
         {
-            _context.Dispose();
+            Context.Dispose();
             base.Dispose(disposing);
         }
     }


### PR DESCRIPTION
* Fixes missing support for the `SupportedServerVersionConditionAttribute` in our custom `MySqlXunitTestFramework` implementation.
* Improves our custom test project, so our raw SQL tests can also access the underlying `DbContext` and the database can be initialized by the model in addition to the custom SQL script.