### PR TITLE
Use alias in HAVING clause, to workaround MySQL/MariaDB bug

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlBug96947WorkaroundExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlBug96947WorkaroundExpressionVisitor.cs
@@ -82,7 +82,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             {
                 var expression = (SqlExpression)Visit(projectionExpression.Expression);
 
-                // Parameters trigger this bug as well, because the get inlined by MySqlConnector and
+                // Parameters trigger this bug as well, because they get inlined by MySqlConnector and
                 // become constant values in the end.
                 if (expression is SqlConstantExpression ||
                     expression is SqlParameterExpression)
@@ -91,14 +91,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
                         expression,
                         projectionExpression.Type,
                         expression.TypeMapping);
-                }
-
-                if (expression is SqlParameterExpression parameterExpression)
-                {
-                    expression = _sqlExpressionFactory.Convert(
-                        parameterExpression,
-                        projectionExpression.Type,
-                        parameterExpression.TypeMapping);
                 }
 
                 return projectionExpression.Update(expression);

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlHavingExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlHavingExpressionVisitor.cs
@@ -1,0 +1,280 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
+{
+    public class MySqlHavingExpressionVisitor : ExpressionVisitor
+    {
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
+        private MySqlContainsAggregateFunctionExpressionVisitor _containsAggregateFunctionExpressionVisitor;
+
+        public MySqlHavingExpressionVisitor(MySqlSqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        protected override Expression VisitExtension(Expression extensionExpression)
+            => extensionExpression switch
+            {
+                // Any of those work, but are a bit of a hack:
+                // SelectExpression selectExpression => VisitSelect1(selectExpression),
+                SelectExpression selectExpression => VisitSelect2(selectExpression),
+
+                ShapedQueryExpression shapedQueryExpression => shapedQueryExpression.Update(Visit(shapedQueryExpression.QueryExpression), Visit(shapedQueryExpression.ShaperExpression)),
+                _ => base.VisitExtension(extensionExpression)
+            };
+
+        protected virtual Expression VisitSelect1(SelectExpression selectExpression)
+        {
+            // MySQL & MariaDB currently do not support complex expressions in HAVING clauses (e.g. function calls).
+            // Instead, they want you to reference SELECT aliases for those expressions in the HAVING clause.
+            // See https://bugs.mysql.com/bug.php?id=103961
+            var havingExpression = selectExpression.Having;
+            if (havingExpression != null)
+            {
+                var projection = selectExpression.Projection.ToList();
+
+                // Hack around the fact, that EF Core does not allow us to add our own ProjectionExpression with an alias.
+                //
+                // new ProjectionExpression(havingExpression, GetUniqueAlias(projection))
+                var havingProjectionExpression = (ProjectionExpression)Activator.CreateInstance(
+                    typeof(ProjectionExpression),
+                    BindingFlags.NonPublic | BindingFlags.Instance,
+                    null,
+                    new object[]
+                    {
+                        havingExpression,
+                        GetUniqueAlias(projection)
+                    },
+                    null);
+
+                projection.Add(havingProjectionExpression);
+
+                var columnAliasReferenceExpression = _sqlExpressionFactory.ColumnAliasReference(
+                    havingProjectionExpression.Alias,
+                    havingProjectionExpression.Expression,
+                    havingExpression.Type,
+                    havingExpression.TypeMapping);
+
+                // Having expressions, not containing an aggregate function, need to be part of the GROUP BY clause, because they now also
+                // appear as part of the SELECT clause.
+                var groupBy = selectExpression.GroupBy;
+
+                _containsAggregateFunctionExpressionVisitor ??= new MySqlContainsAggregateFunctionExpressionVisitor();
+                if (!_containsAggregateFunctionExpressionVisitor.Process(havingExpression))
+                {
+                    var mutableGroupBy = selectExpression.GroupBy.ToList();
+                    mutableGroupBy.Add(columnAliasReferenceExpression);
+
+                    groupBy = mutableGroupBy;
+                }
+
+                selectExpression = selectExpression.Update(
+                    projection,
+                    selectExpression.Tables,
+                    selectExpression.Predicate,
+                    groupBy,
+                    columnAliasReferenceExpression,
+                    selectExpression.Orderings,
+                    selectExpression.Limit,
+                    selectExpression.Offset);
+            }
+
+            return base.VisitExtension(selectExpression);
+        }
+
+        protected virtual Expression VisitSelect2(SelectExpression selectExpression)
+        {
+            // MySQL & MariaDB currently do not support complex expressions in HAVING clauses (e.g. function calls).
+            // Instead, they want you to reference SELECT aliases for those expressions in the HAVING clause.
+            // See https://bugs.mysql.com/bug.php?id=103961
+            var havingExpression = selectExpression.Having;
+            if (havingExpression != null)
+            {
+                var alias = GetUniqueAlias(selectExpression.Projection);
+
+                // Hack around the fact, that EF Core does not allow us to add our own ProjectionExpression with an alias.
+                // We can however indirectly control the alias, by first setting a ColumnExpression, whose name is then used as the base
+                // for the alias, and then updating it afterwards with the actual expression we are interested in, when it gets visited.
+                selectExpression.AddToProjection(
+                    new HatSwappingColumnExpression(
+                        havingExpression,
+                        alias,
+                        havingExpression.Type,
+                        havingExpression.TypeMapping));
+
+                var columnAliasReferenceExpression = _sqlExpressionFactory.ColumnAliasReference(
+                    alias,
+                    havingExpression,
+                    havingExpression.Type,
+                    havingExpression.TypeMapping);
+
+                // Having expressions, not containing an aggregate function, need to be part of the GROUP BY clause, because they now also
+                // appear as part of the SELECT clause.
+                var groupBy = selectExpression.GroupBy;
+
+                _containsAggregateFunctionExpressionVisitor ??= new MySqlContainsAggregateFunctionExpressionVisitor();
+                if (!_containsAggregateFunctionExpressionVisitor.Process(havingExpression))
+                {
+                    var mutableGroupBy = selectExpression.GroupBy.ToList();
+                    mutableGroupBy.Add(columnAliasReferenceExpression);
+
+                    groupBy = mutableGroupBy;
+                }
+
+                selectExpression = selectExpression.Update(
+                    selectExpression.Projection,
+                    selectExpression.Tables,
+                    selectExpression.Predicate,
+                    groupBy,
+                    columnAliasReferenceExpression,
+                    selectExpression.Orderings,
+                    selectExpression.Limit,
+                    selectExpression.Offset);
+            }
+
+            return base.VisitExtension(selectExpression);
+        }
+
+        /// <summary>
+        /// This is just a magic wrapper for an arbitrary SqlExpression, posing as a ColumnExpression.
+        /// Returns the inner SqlExpression, when visited.
+        /// </summary>
+        private sealed class HatSwappingColumnExpression : ColumnExpression
+        {
+            private readonly SqlExpression _expression;
+
+            public HatSwappingColumnExpression(
+                SqlExpression expression,
+                [CanBeNull] string name,
+                [NotNull] Type type,
+                [CanBeNull] RelationalTypeMapping typeMapping)
+                : base(type, typeMapping)
+            {
+                _expression = expression;
+                Name = name;
+            }
+
+            public override ColumnExpression MakeNullable()
+                => this;
+
+            public override string Name { get; }
+            public override TableExpressionBase Table { get; }
+            public override string TableAlias { get; }
+            public override bool IsNullable { get; }
+
+            protected override Expression VisitChildren(ExpressionVisitor visitor)
+                => _expression; // HACK: returns the inner expression
+
+            public override bool Equals(object obj)
+                => Equals(obj as HatSwappingColumnExpression);
+
+            public bool Equals(HatSwappingColumnExpression other)
+                => ReferenceEquals(this, other) ||
+                   other != null &&
+                   base.Equals(other) &&
+                   Equals(_expression, other._expression);
+
+            public override int GetHashCode()
+                => HashCode.Combine(base.GetHashCode(), _expression);
+
+            protected override void Print(ExpressionPrinter expressionPrinter)
+                => expressionPrinter.Visit(_expression);
+
+            public override string ToString()
+                => _expression.ToString();
+        }
+
+        private static string GetUniqueAlias(IReadOnlyCollection<ProjectionExpression> projection)
+        {
+            const string baseAlias = "having";
+
+            var counter = 0;
+            var currentAlias = baseAlias;
+
+            while (projection.Any(pe => string.Equals(pe.Alias, currentAlias, StringComparison.OrdinalIgnoreCase)))
+            {
+                currentAlias = $"{baseAlias}{counter++}";
+            }
+
+            return currentAlias;
+        }
+    }
+
+    /// <summary>
+    /// Looks for aggregate functions (like SUM(), AVG() etc.) in an expression tree, but not in subqueries.
+    /// </summary>
+    public class MySqlContainsAggregateFunctionExpressionVisitor : ExpressionVisitor
+    {
+        // See https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html
+        private static readonly SortedSet<string> _aggregateFunctions = new SortedSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "AVG",
+            "BIT_AND",
+            "BIT_OR",
+            "BIT_XOR",
+            "COUNT",
+            "GROUP_CONCAT",
+            "JSON_ARRAYAGG",
+            "JSON_OBJECTAGG",
+            "MAX",
+            "MIN",
+            "STD",
+            "STDDEV",
+            "STDDEV_POP",
+            "STDDEV_SAMP",
+            "SUM",
+            "VAR_POP",
+            "VAR_SAMP",
+            "VARIANCE",
+        };
+
+        public virtual bool AggregateFunctionFound { get; protected set; }
+
+        public virtual bool Process(Expression node)
+        {
+            // Can be reused within the same thread.
+            AggregateFunctionFound = false;
+
+            Visit(node);
+
+            return AggregateFunctionFound;
+        }
+
+        public override Expression Visit(Expression node)
+            => AggregateFunctionFound
+                ? node
+                : base.Visit(node);
+
+        protected override Expression VisitExtension(Expression extensionExpression)
+            => extensionExpression switch
+            {
+                SqlFunctionExpression sqlFunctionExpression => VisitSqlFunction(sqlFunctionExpression),
+                SelectExpression selectExpression => selectExpression,
+                ShapedQueryExpression shapedQueryExpression => shapedQueryExpression,
+                _ => base.VisitExtension(extensionExpression)
+            };
+
+        protected virtual Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
+        {
+            if (_aggregateFunctions.Contains(sqlFunctionExpression.Name))
+            {
+                AggregateFunctionFound = true;
+                return sqlFunctionExpression;
+            }
+
+            return base.VisitExtension(sqlFunctionExpression);
+        }
+    }
+}

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlHavingExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlHavingExpressionVisitor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
@@ -27,74 +26,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
         protected override Expression VisitExtension(Expression extensionExpression)
             => extensionExpression switch
             {
-                // Any of those work, but are a bit of a hack:
-                // SelectExpression selectExpression => VisitSelect1(selectExpression),
-                SelectExpression selectExpression => VisitSelect2(selectExpression),
-
-                ShapedQueryExpression shapedQueryExpression => shapedQueryExpression.Update(Visit(shapedQueryExpression.QueryExpression), Visit(shapedQueryExpression.ShaperExpression)),
+                SelectExpression selectExpression => VisitSelect(selectExpression),
+                ShapedQueryExpression shapedQueryExpression => shapedQueryExpression.Update(
+                    Visit(shapedQueryExpression.QueryExpression), Visit(shapedQueryExpression.ShaperExpression)),
                 _ => base.VisitExtension(extensionExpression)
             };
 
-        protected virtual Expression VisitSelect1(SelectExpression selectExpression)
-        {
-            // MySQL & MariaDB currently do not support complex expressions in HAVING clauses (e.g. function calls).
-            // Instead, they want you to reference SELECT aliases for those expressions in the HAVING clause.
-            // See https://bugs.mysql.com/bug.php?id=103961
-            var havingExpression = selectExpression.Having;
-            if (havingExpression != null)
-            {
-                var projection = selectExpression.Projection.ToList();
-
-                // Hack around the fact, that EF Core does not allow us to add our own ProjectionExpression with an alias.
-                //
-                // new ProjectionExpression(havingExpression, GetUniqueAlias(projection))
-                var havingProjectionExpression = (ProjectionExpression)Activator.CreateInstance(
-                    typeof(ProjectionExpression),
-                    BindingFlags.NonPublic | BindingFlags.Instance,
-                    null,
-                    new object[]
-                    {
-                        havingExpression,
-                        GetUniqueAlias(projection)
-                    },
-                    null);
-
-                projection.Add(havingProjectionExpression);
-
-                var columnAliasReferenceExpression = _sqlExpressionFactory.ColumnAliasReference(
-                    havingProjectionExpression.Alias,
-                    havingProjectionExpression.Expression,
-                    havingExpression.Type,
-                    havingExpression.TypeMapping);
-
-                // Having expressions, not containing an aggregate function, need to be part of the GROUP BY clause, because they now also
-                // appear as part of the SELECT clause.
-                var groupBy = selectExpression.GroupBy;
-
-                _containsAggregateFunctionExpressionVisitor ??= new MySqlContainsAggregateFunctionExpressionVisitor();
-                if (!_containsAggregateFunctionExpressionVisitor.Process(havingExpression))
-                {
-                    var mutableGroupBy = selectExpression.GroupBy.ToList();
-                    mutableGroupBy.Add(columnAliasReferenceExpression);
-
-                    groupBy = mutableGroupBy;
-                }
-
-                selectExpression = selectExpression.Update(
-                    projection,
-                    selectExpression.Tables,
-                    selectExpression.Predicate,
-                    groupBy,
-                    columnAliasReferenceExpression,
-                    selectExpression.Orderings,
-                    selectExpression.Limit,
-                    selectExpression.Offset);
-            }
-
-            return base.VisitExtension(selectExpression);
-        }
-
-        protected virtual Expression VisitSelect2(SelectExpression selectExpression)
+        protected virtual Expression VisitSelect(SelectExpression selectExpression)
         {
             // MySQL & MariaDB currently do not support complex expressions in HAVING clauses (e.g. function calls).
             // Instead, they want you to reference SELECT aliases for those expressions in the HAVING clause.
@@ -106,7 +44,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
 
                 // Hack around the fact, that EF Core does not allow us to add our own ProjectionExpression with an alias.
                 // We can however indirectly control the alias, by first setting a ColumnExpression, whose name is then used as the base
-                // for the alias, and then updating it afterwards with the actual expression we are interested in, when it gets visited.
+                // for the alias, and then update it afterwards with the actual expression we are interested in, when it gets visited.
                 selectExpression.AddToProjection(
                     new HatSwappingColumnExpression(
                         havingExpression,
@@ -147,6 +85,21 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             return base.VisitExtension(selectExpression);
         }
 
+        private static string GetUniqueAlias(IReadOnlyCollection<ProjectionExpression> projection)
+        {
+            const string baseAlias = "having";
+
+            var counter = 0;
+            var currentAlias = baseAlias;
+
+            while (projection.Any(pe => string.Equals(pe.Alias, currentAlias, StringComparison.OrdinalIgnoreCase)))
+            {
+                currentAlias = $"{baseAlias}{counter++}";
+            }
+
+            return currentAlias;
+        }
+
         /// <summary>
         /// This is just a magic wrapper for an arbitrary SqlExpression, posing as a ColumnExpression.
         /// Returns the inner SqlExpression, when visited.
@@ -175,7 +128,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             public override bool IsNullable { get; }
 
             protected override Expression VisitChildren(ExpressionVisitor visitor)
-                => _expression; // HACK: returns the inner expression
+                => _expression; // does not return itself or a copy of itself, but the inner expression instead
 
             public override bool Equals(object obj)
                 => Equals(obj as HatSwappingColumnExpression);
@@ -196,85 +149,70 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
                 => _expression.ToString();
         }
 
-        private static string GetUniqueAlias(IReadOnlyCollection<ProjectionExpression> projection)
+        /// <summary>
+        /// Looks for aggregate functions (like SUM(), AVG() etc.) in an expression tree, but not in subqueries.
+        /// </summary>
+        private sealed class MySqlContainsAggregateFunctionExpressionVisitor : ExpressionVisitor
         {
-            const string baseAlias = "having";
-
-            var counter = 0;
-            var currentAlias = baseAlias;
-
-            while (projection.Any(pe => string.Equals(pe.Alias, currentAlias, StringComparison.OrdinalIgnoreCase)))
+            // See https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html
+            private static readonly SortedSet<string> _aggregateFunctions = new SortedSet<string>(StringComparer.OrdinalIgnoreCase)
             {
-                currentAlias = $"{baseAlias}{counter++}";
-            }
-
-            return currentAlias;
-        }
-    }
-
-    /// <summary>
-    /// Looks for aggregate functions (like SUM(), AVG() etc.) in an expression tree, but not in subqueries.
-    /// </summary>
-    public class MySqlContainsAggregateFunctionExpressionVisitor : ExpressionVisitor
-    {
-        // See https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html
-        private static readonly SortedSet<string> _aggregateFunctions = new SortedSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "AVG",
-            "BIT_AND",
-            "BIT_OR",
-            "BIT_XOR",
-            "COUNT",
-            "GROUP_CONCAT",
-            "JSON_ARRAYAGG",
-            "JSON_OBJECTAGG",
-            "MAX",
-            "MIN",
-            "STD",
-            "STDDEV",
-            "STDDEV_POP",
-            "STDDEV_SAMP",
-            "SUM",
-            "VAR_POP",
-            "VAR_SAMP",
-            "VARIANCE",
-        };
-
-        public virtual bool AggregateFunctionFound { get; protected set; }
-
-        public virtual bool Process(Expression node)
-        {
-            // Can be reused within the same thread.
-            AggregateFunctionFound = false;
-
-            Visit(node);
-
-            return AggregateFunctionFound;
-        }
-
-        public override Expression Visit(Expression node)
-            => AggregateFunctionFound
-                ? node
-                : base.Visit(node);
-
-        protected override Expression VisitExtension(Expression extensionExpression)
-            => extensionExpression switch
-            {
-                SqlFunctionExpression sqlFunctionExpression => VisitSqlFunction(sqlFunctionExpression),
-                SelectExpression selectExpression => selectExpression,
-                ShapedQueryExpression shapedQueryExpression => shapedQueryExpression,
-                _ => base.VisitExtension(extensionExpression)
+                "AVG",
+                "BIT_AND",
+                "BIT_OR",
+                "BIT_XOR",
+                "COUNT",
+                "GROUP_CONCAT",
+                "JSON_ARRAYAGG",
+                "JSON_OBJECTAGG",
+                "MAX",
+                "MIN",
+                "STD",
+                "STDDEV",
+                "STDDEV_POP",
+                "STDDEV_SAMP",
+                "SUM",
+                "VAR_POP",
+                "VAR_SAMP",
+                "VARIANCE",
             };
 
-        protected virtual Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
-        {
-            if (_aggregateFunctions.Contains(sqlFunctionExpression.Name))
+            public bool AggregateFunctionFound { get; private set; }
+
+            public bool Process(Expression node)
             {
-                AggregateFunctionFound = true;
-                return sqlFunctionExpression;
+                // Can be reused within the same thread.
+                AggregateFunctionFound = false;
+
+                Visit(node);
+
+                return AggregateFunctionFound;
             }
 
-            return base.VisitExtension(sqlFunctionExpression);
+            public override Expression Visit(Expression node)
+                => AggregateFunctionFound
+                    ? node
+                    : base.Visit(node);
+
+            protected override Expression VisitExtension(Expression extensionExpression)
+                => extensionExpression switch
+                {
+                    SqlFunctionExpression sqlFunctionExpression => VisitSqlFunction(sqlFunctionExpression),
+                    SelectExpression selectExpression => selectExpression,
+                    ShapedQueryExpression shapedQueryExpression => shapedQueryExpression,
+                    _ => base.VisitExtension(extensionExpression)
+                };
+
+            private Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
+            {
+                if (_aggregateFunctions.Contains(sqlFunctionExpression.Name))
+                {
+                    AggregateFunctionFound = true;
+                    return sqlFunctionExpression;
+                }
+
+                return base.VisitExtension(sqlFunctionExpression);
+            }
         }
     }
 }

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
@@ -66,8 +66,16 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             => extensionExpression switch
             {
                 MySqlJsonTraversalExpression jsonTraversalExpression => VisitJsonPathTraversal(jsonTraversalExpression),
+                MySqlColumnAliasReferenceExpression columnAliasReferenceExpression => VisitColumnAliasReference(columnAliasReferenceExpression),
                 _ => base.VisitExtension(extensionExpression)
             };
+
+        private Expression VisitColumnAliasReference(MySqlColumnAliasReferenceExpression columnAliasReferenceExpression)
+        {
+            Sql.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(columnAliasReferenceExpression.Alias));
+
+            return columnAliasReferenceExpression;
+        }
 
         protected virtual Expression VisitJsonPathTraversal(MySqlJsonTraversalExpression expression)
         {

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQueryTranslationPostprocessor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQueryTranslationPostprocessor.cs
@@ -29,6 +29,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
         {
             query = base.Process(query);
 
+            query = new MySqlHavingExpressionVisitor(_sqlExpressionFactory).Visit(query);
             query = new MySqlJsonParameterExpressionVisitor(_sqlExpressionFactory, _options).Visit(query);
 
             if (_options.ServerVersion.Supports.MySqlBug96947Workaround)

--- a/src/EFCore.MySql/Query/Expressions/Internal/MySqlColumnAliasReferenceExpression.cs
+++ b/src/EFCore.MySql/Query/Expressions/Internal/MySqlColumnAliasReferenceExpression.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal
+{
+    /// <summary>
+    /// Allows to reference an alias from within the same SELECT statement, e.g. in a HAVING clause.
+    /// </summary>
+    public class MySqlColumnAliasReferenceExpression : SqlExpression, IEquatable<MySqlColumnAliasReferenceExpression>
+    {
+        [NotNull]
+        public virtual string Alias { get; }
+
+        [NotNull]
+        public virtual SqlExpression Expression { get; }
+
+        public MySqlColumnAliasReferenceExpression(
+            [NotNull] string alias,
+            [NotNull] SqlExpression expression,
+            [NotNull] Type type,
+            [CanBeNull] RelationalTypeMapping typeMapping)
+            : base(type, typeMapping)
+        {
+            Alias = alias;
+            Expression = expression;
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+            => this;
+
+        public virtual MySqlColumnAliasReferenceExpression Update(
+            [NotNull] string alias,
+            [NotNull] SqlExpression expression)
+            => alias == Alias &&
+               expression.Equals(Expression)
+                ? this
+                : new MySqlColumnAliasReferenceExpression(alias, expression, Type, TypeMapping);
+
+        public override bool Equals(object obj)
+            => Equals(obj as MySqlColumnAliasReferenceExpression);
+
+        public virtual bool Equals(MySqlColumnAliasReferenceExpression other)
+            => ReferenceEquals(this, other) ||
+               other != null &&
+               base.Equals(other) &&
+               Equals(Expression, other.Expression);
+
+        public override int GetHashCode()
+            => HashCode.Combine(base.GetHashCode(), Expression);
+
+        protected override void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Append("`");
+            expressionPrinter.Append(Alias);
+            expressionPrinter.Append("`");
+        }
+
+        public override string ToString()
+            => $"`{Alias}`";
+
+        public virtual SqlExpression ApplyTypeMapping(RelationalTypeMapping typeMapping)
+            => new MySqlColumnAliasReferenceExpression(Alias, Expression, Type, typeMapping);
+    }
+}

--- a/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
@@ -219,6 +219,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 right,
                 typeMapping);
 
+        public virtual MySqlColumnAliasReferenceExpression ColumnAliasReference(
+            string alias,
+            SqlExpression expression,
+            Type type,
+            RelationalTypeMapping typeMapping = null)
+            => new MySqlColumnAliasReferenceExpression(alias, expression, type, typeMapping);
+
         #endregion Expression factory methods
 
         public virtual MySqlBinaryExpression MakeBinary(

--- a/src/EFCore.MySql/Query/Internal/MySqlSqlNullabilityProcessor.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlSqlNullabilityProcessor.cs
@@ -39,8 +39,18 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 MySqlJsonArrayIndexExpression arrayIndexExpression => VisitJsonArrayIndex(arrayIndexExpression, allowOptimizedExpansion, out nullable),
                 MySqlJsonTraversalExpression jsonTraversalExpression => VisitJsonTraversal(jsonTraversalExpression, allowOptimizedExpansion, out nullable),
                 MySqlRegexpExpression regexpExpression => VisitRegexp(regexpExpression, allowOptimizedExpansion, out nullable),
+                MySqlColumnAliasReferenceExpression columnAliasReferenceExpression => VisitColumnAliasReference(columnAliasReferenceExpression, allowOptimizedExpansion, out nullable),
                 _ => base.VisitCustomSqlExpression(sqlExpression, allowOptimizedExpansion, out nullable)
             };
+
+        private SqlExpression VisitColumnAliasReference(MySqlColumnAliasReferenceExpression columnAliasReferenceExpression, bool allowOptimizedExpansion, out bool nullable)
+        {
+            Check.NotNull(columnAliasReferenceExpression, nameof(columnAliasReferenceExpression));
+
+            var expression = Visit(columnAliasReferenceExpression.Expression, allowOptimizedExpansion, out nullable);
+
+            return columnAliasReferenceExpression.Update(columnAliasReferenceExpression.Alias, expression);
+        }
 
         /// <summary>
         /// Visits a <see cref="MySqlBinaryExpression" /> and computes its nullability.

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.MySql.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
-using Pomelo.EntityFrameworkCore.MySql.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Tests.TestUtilities.Attributes;
 using Xunit;
 
@@ -22,6 +22,22 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
         public virtual Task OuterApply_not_supported_throws(bool async)
         {
             return Assert.ThrowsAsync<InvalidOperationException>(() => base.SelectMany_correlated_with_outer_3(async));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_with_function_using_having_clause(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(o => o.CustomerID == "ALFKI" &&
+                                o.OrderDate != null)
+                    .GroupBy(o => new {o.CustomerID, o.OrderDate.Value.Year})
+                    .Select(g => new {g.Key.Year, Count = g.Count()})
+                    .Where(k => k.Year == 1995)
+                    .OrderBy(k => k.Year),
+                assertOrder: true);
         }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.MySql.cs
@@ -26,9 +26,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Select_with_function_using_having_clause(bool async)
+        public virtual async Task Select_with_function_using_having_clause(bool async)
         {
-            return AssertQuery(
+            await AssertQuery(
                 async,
                 ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI" &&
@@ -38,6 +38,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                     .Where(k => k.Year == 1995)
                     .OrderBy(k => k.Year),
                 assertOrder: true);
+
+            AssertSql(
+                @"SELECT EXTRACT(year FROM `o`.`OrderDate`) AS `Year`, COUNT(*) AS `Count`, (EXTRACT(year FROM `o`.`OrderDate`) = 1995) AND EXTRACT(year FROM `o`.`OrderDate`) IS NOT NULL AS `having`
+FROM `Orders` AS `o`
+WHERE (`o`.`CustomerID` = 'ALFKI') AND `o`.`OrderDate` IS NOT NULL
+GROUP BY `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`), `having`
+HAVING `having`
+ORDER BY EXTRACT(year FROM `o`.`OrderDate`)");
         }
     }
 }


### PR DESCRIPTION
MySQL & MariaDB return an [Error: "Unknown column 'foo' in 'having clause'" when using a function in HAVING](https://bugs.mysql.com/bug.php?id=103961).

For example, the following query will not work in MySQL & MariaDB (but in basically all other major database servers):

```sql
SELECT YEAR(`o`.`OrderDate`) AS `Year`, COUNT(*) as `Count`
FROM `Orders` AS `o`
GROUP BY YEAR(`o`.`OrderDate`)
HAVING YEAR(`o`.`OrderDate`) = 1995
```

The error message is:

```
Error Code: 1054. Unknown column 'o.OrderDate' in 'having clause'
```

While using an expression in GROUP BY and ORDER BY clauses works as expected, it does not work when using them in HAVING clauses.

---

Until this bug is fixed in both database server implementations, we now implement a workaround, that uses the SELECT clause alias instead, which is valid for MySQL/MariaDB HAVING clauses and _does_ work.