### PR TITLE
Fix HasCharSet(null) call, that is ambiguous

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlEntityTypeBuilderExtensions.cs
@@ -70,40 +70,6 @@ namespace Microsoft.EntityFrameworkCore
         /// uses its default collation.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="charSet"> The character set. </param>
-        /// <param name="delegationModes">
-        /// Finely controls where to recursively apply the character set and where not (including this entity/table).
-        /// Implicitly uses <see cref="DelegationModes.ApplyToAll"/> if set to <see langword="null"/>.
-        /// </param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder HasCharSet(
-            [NotNull] this EntityTypeBuilder entityTypeBuilder,
-            [CanBeNull] CharSet charSet,
-            DelegationModes? delegationModes = null)
-            => entityTypeBuilder.HasCharSet(charSet?.Name, delegationModes);
-
-        /// <summary>
-        /// Sets the MySQL character set on the table associated with this entity. When you only specify the character set, MySQL implicitly
-        /// uses its default collation.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="charSet"> The character set. </param>
-        /// <param name="explicitlyDelegateToChildren">
-        /// Properties/columns don't explicitly inherit the character set if set to <see langword="false"/>.
-        /// They will explicitly inherit the character set if set to <see langword="true"/>.
-        /// </param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder HasCharSet(
-            [NotNull] this EntityTypeBuilder entityTypeBuilder,
-            [CanBeNull] CharSet charSet,
-            bool explicitlyDelegateToChildren)
-            => entityTypeBuilder.HasCharSet(charSet?.Name, explicitlyDelegateToChildren);
-
-        /// <summary>
-        /// Sets the MySQL character set on the table associated with this entity. When you only specify the character set, MySQL implicitly
-        /// uses its default collation.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <param name="charSet"> The name of the character set. </param>
         /// <param name="delegationModes">
         /// Finely controls where to recursively apply the character set and where not (including this entity/table).
@@ -134,42 +100,6 @@ namespace Microsoft.EntityFrameworkCore
             bool explicitlyDelegateToChildren)
             where TEntity : class
             => (EntityTypeBuilder<TEntity>)HasCharSet((EntityTypeBuilder)entityTypeBuilder, charSet, explicitlyDelegateToChildren);
-
-        /// <summary>
-        /// Sets the MySQL character set on the table associated with this entity. When you only specify the character set, MySQL implicitly
-        /// uses its default collation.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="charSet"> The character set. </param>
-        /// <param name="delegationModes">
-        /// Finely controls where to recursively apply the character set and where not (including this entity/table).
-        /// Implicitly uses <see cref="DelegationModes.ApplyToAll"/> if set to <see langword="null"/>.
-        /// </param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder<TEntity> HasCharSet<TEntity>(
-            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
-            [CanBeNull] CharSet charSet,
-            DelegationModes? delegationModes = null)
-            where TEntity : class
-            => entityTypeBuilder.HasCharSet(charSet?.Name, delegationModes);
-
-        /// <summary>
-        /// Sets the MySQL character set on the table associated with this entity. When you only specify the character set, MySQL implicitly
-        /// uses its default collation.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="charSet"> The character set. </param>
-        /// <param name="explicitlyDelegateToChildren">
-        /// Properties/columns don't explicitly inherit the character set if set to <see langword="false"/>.
-        /// They will explicitly inherit the character set if set to <see langword="true"/>.
-        /// </param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder<TEntity> HasCharSet<TEntity>(
-            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
-            [CanBeNull] CharSet charSet,
-            bool explicitlyDelegateToChildren)
-            where TEntity : class
-            => entityTypeBuilder.HasCharSet(charSet?.Name, explicitlyDelegateToChildren);
 
         /// <summary>
         /// Sets the MySQL character set on the table associated with this entity. When you only specify the character set, MySQL implicitly
@@ -230,44 +160,6 @@ namespace Microsoft.EntityFrameworkCore
                 fromDataAnnotation);
 
         /// <summary>
-        /// Sets the MySQL character set on the table associated with this entity. When you only specify the character set, MySQL implicitly
-        /// uses its default collation.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="charSet"> The character set. </param>
-        /// <param name="delegationModes">
-        /// Finely controls where to recursively apply the character set and where not (including this entity/table).
-        /// Implicitly uses <see cref="DelegationModes.ApplyToAll"/> if set to <see langword="null"/>.
-        /// </param>
-        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static IConventionEntityTypeBuilder HasCharSet(
-            [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder,
-            [CanBeNull] CharSet charSet,
-            DelegationModes? delegationModes = null,
-            bool fromDataAnnotation = false)
-            => entityTypeBuilder.HasCharSet(charSet?.Name, delegationModes, fromDataAnnotation);
-
-        /// <summary>
-        /// Sets the MySQL character set on the table associated with this entity. When you only specify the character set, MySQL implicitly
-        /// uses its default collation.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="charSet"> The character set. </param>
-        /// <param name="explicitlyDelegateToChildren">
-        /// Properties/columns don't explicitly inherit the character set if set to <see langword="false"/>.
-        /// They will explicitly inherit the character set if set to <see langword="true"/>.
-        /// </param>
-        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static IConventionEntityTypeBuilder HasCharSet(
-            [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder,
-            [CanBeNull] CharSet charSet,
-            bool explicitlyDelegateToChildren,
-            bool fromDataAnnotation = false)
-            => entityTypeBuilder.HasCharSet(charSet?.Name, explicitlyDelegateToChildren, fromDataAnnotation);
-
-        /// <summary>
         /// Returns a value indicating whether the MySQL character set can be set on the table associated with this entity.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
@@ -284,19 +176,6 @@ namespace Microsoft.EntityFrameworkCore
 
             return entityTypeBuilder.CanSetAnnotation(MySqlAnnotationNames.CharSet, charSet, fromDataAnnotation);
         }
-
-        /// <summary>
-        /// Returns a value indicating whether the MySQL character set can be set on the table associated with this entity.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="charSet"> The character set. </param>
-        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-        /// <returns><see langword="true"/> if the mapped table can be configured with the collation.</returns>
-        public static bool CanSetCharSet(
-            [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder,
-            [CanBeNull] CharSet charSet,
-            bool fromDataAnnotation = false)
-            => entityTypeBuilder.CanSetCharSet(charSet?.Name, fromDataAnnotation);
 
         /// <summary>
         ///     Returns a value indicating whether the given character set delegation modes can be set.

--- a/src/EFCore.MySql/Extensions/MySqlModelBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlModelBuilderExtensions.cs
@@ -70,40 +70,6 @@ namespace Microsoft.EntityFrameworkCore
         /// Sets the default character set to use for the model/database.
         /// </summary>
         /// <param name="modelBuilder">The model builder.</param>
-        /// <param name="charSet">The character set to use.</param>
-        /// <param name="delegationModes">
-        /// Finely controls where to recursively apply the character set and where not (including this model/database).
-        /// Implicitly uses <see cref="DelegationModes.ApplyToAll"/> if set to <see langword="null"/>.
-        /// </param>
-        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-        public static ModelBuilder HasCharSet(
-            [NotNull] this ModelBuilder modelBuilder,
-            [CanBeNull] CharSet charSet,
-            DelegationModes? delegationModes = null)
-            => modelBuilder.HasCharSet(charSet?.Name, delegationModes);
-
-        /// <summary>
-        /// Sets the default character set to use for the model/database.
-        /// </summary>
-        /// <param name="modelBuilder">The model builder.</param>
-        /// <param name="charSet">The character set to use.</param>
-        /// <param name="explicitlyDelegateToChildren">
-        /// Entities/tables (and possibly properties/columns) don't explicitly inherit the character set if set to <see langword="false"/>.
-        /// They will explicitly inherit the character set if set to <see langword="true"/>.
-        /// </param>
-        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-        public static ModelBuilder HasCharSet(
-            [NotNull] this ModelBuilder modelBuilder,
-            [CanBeNull] CharSet charSet,
-            bool explicitlyDelegateToChildren)
-            => modelBuilder.HasCharSet(
-                charSet?.Name,
-                explicitlyDelegateToChildren);
-
-        /// <summary>
-        /// Sets the default character set to use for the model/database.
-        /// </summary>
-        /// <param name="modelBuilder">The model builder.</param>
         /// <param name="charSet">The name of the character set to use.</param>
         /// <param name="delegationModes">
         /// Finely controls where to recursively apply the character set and where not (including this model/database).
@@ -163,51 +129,6 @@ namespace Microsoft.EntityFrameworkCore
                 fromDataAnnotation);
 
         /// <summary>
-        /// Sets the default character set to use for the model/database.
-        /// </summary>
-        /// <param name="modelBuilder">The model builder.</param>
-        /// <param name="charSet">The character set to use.</param>
-        /// <param name="delegationModes">
-        /// Finely controls where to recursively apply the character set and where not (including this model/database).
-        /// Implicitly uses <see cref="DelegationModes.ApplyToAll"/> if set to <see langword="null"/>.
-        /// </param>
-        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        /// <returns>
-        ///     The same builder instance if the configuration was applied,
-        ///     <see langword="null" /> otherwise.
-        /// </returns>
-        public static IConventionModelBuilder HasCharSet(
-            [NotNull] this IConventionModelBuilder modelBuilder,
-            [CanBeNull] CharSet charSet,
-            DelegationModes? delegationModes = null,
-            bool fromDataAnnotation = false)
-            => modelBuilder.HasCharSet(charSet?.Name, delegationModes, fromDataAnnotation);
-
-        /// <summary>
-        /// Sets the default character set to use for the model/database.
-        /// </summary>
-        /// <param name="modelBuilder">The model builder.</param>
-        /// <param name="charSet">The character set to use.</param>
-        /// <param name="explicitlyDelegateToChildren">
-        /// Entities/tables (and possibly properties/columns) don't explicitly inherit the character set if set to <see langword="false"/>.
-        /// They will explicitly inherit the character set if set to <see langword="true"/>.
-        /// </param>
-        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        /// <returns>
-        ///     The same builder instance if the configuration was applied,
-        ///     <see langword="null" /> otherwise.
-        /// </returns>
-        public static IConventionModelBuilder HasCharSet(
-            [NotNull] this IConventionModelBuilder modelBuilder,
-            [CanBeNull] CharSet charSet,
-            bool explicitlyDelegateToChildren,
-            bool fromDataAnnotation = false)
-            => modelBuilder.HasCharSet(
-                charSet?.Name,
-                explicitlyDelegateToChildren,
-                fromDataAnnotation);
-
-        /// <summary>
         ///     Returns a value indicating whether the given character set can be set as default.
         /// </summary>
         /// <param name="modelBuilder"> The model builder. </param>
@@ -224,19 +145,6 @@ namespace Microsoft.EntityFrameworkCore
 
             return modelBuilder.CanSetAnnotation(MySqlAnnotationNames.CharSet, charSet, fromDataAnnotation);
         }
-
-        /// <summary>
-        ///     Returns a value indicating whether the given character set can be set as default.
-        /// </summary>
-        /// <param name="modelBuilder"> The model builder. </param>
-        /// <param name="charSet"> The character set. </param>
-        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        /// <returns> <see langword="true" /> if the given character set can be set as default. </returns>
-        public static bool CanSetCharSet(
-            [NotNull] this IConventionModelBuilder modelBuilder,
-            [CanBeNull] CharSet charSet,
-            bool fromDataAnnotation = false)
-            => modelBuilder.CanSetCharSet(charSet?.Name, fromDataAnnotation);
 
         /// <summary>
         ///     Returns a value indicating whether the given character set delegation modes can be set.

--- a/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
@@ -102,35 +102,6 @@ namespace Microsoft.EntityFrameworkCore
             => (PropertyBuilder<TProperty>)HasCharSet((PropertyBuilder)propertyBuilder, charSet);
 
         /// <summary>
-        /// Configures the charset for the property's column.
-        /// </summary>
-        /// <param name="propertyBuilder">The builder for the property being configured.</param>
-        /// <param name="charSet">The <see cref="CharSet"/> to configure for the property's column.</param>
-        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-        public static PropertyBuilder HasCharSet(
-            [NotNull] this PropertyBuilder propertyBuilder,
-            CharSet charSet)
-        {
-            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
-
-            var property = propertyBuilder.Metadata;
-            property.SetCharSet(charSet?.Name);
-
-            return propertyBuilder;
-        }
-
-        /// <summary>
-        /// Configures the charset for the property's column.
-        /// </summary>
-        /// <param name="propertyBuilder">The builder for the property being configured.</param>
-        /// <param name="charSet">The <see cref="CharSet"/> to configure for the property's column.</param>
-        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-        public static PropertyBuilder<TProperty> HasCharSet<TProperty>(
-            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
-            CharSet charSet)
-            => (PropertyBuilder<TProperty>)HasCharSet((PropertyBuilder)propertyBuilder, charSet);
-
-        /// <summary>
         /// Configures the collation for the property's column.
         /// </summary>
         /// <param name="propertyBuilder">The builder for the property being configured.</param>

--- a/src/EFCore.MySql/Infrastructure/CharSet.cs
+++ b/src/EFCore.MySql/Infrastructure/CharSet.cs
@@ -21,6 +21,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
             MaxBytesPerChar = maxBytesPerChar > 0 ? maxBytesPerChar : throw new ArgumentOutOfRangeException(nameof(maxBytesPerChar));
         }
 
+        public static implicit operator string(CharSet charSet) => charSet?.ToString();
+
         public virtual bool IsUnicode => MaxBytesPerChar >= 2;
 
         public override string ToString() => Name;


### PR DESCRIPTION
* Remove `HasCharSet` overloads containing `CharSet` class parameter.
* Add implicit cast to `string` for the `CharSet` class, so that existing `HasCharSet(CharSet, ...)` calls will automatically call `HasCharSet(string, ...)` instead (once recompiled).

Addresses https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1426#issuecomment-841376055 and https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1435#issuecomment-846309406