### PR TITLE
Add Pomelo specific CharSet data annotation attribute

### DIFF
--- a/src/EFCore.MySql/DataAnnotations/CharSetAttribute.cs
+++ b/src/EFCore.MySql/DataAnnotations/CharSetAttribute.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace Pomelo.EntityFrameworkCore.MySql.DataAnnotations
+{
+    /// <summary>
+    ///     Configures the property as capable of persisting unicode characters.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field)]
+    public class CharSetAttribute : Attribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CharSetAttribute" /> class.
+        ///     Implicitly uses <see cref="Microsoft.EntityFrameworkCore.DelegationModes.ApplyToAll"/>.
+        /// </summary>
+        /// <param name="charSet"> The name of the character set to use. </param>
+        public CharSetAttribute(string charSet)
+            : this(charSet, null)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CharSetAttribute" /> class.
+        /// </summary>
+        /// <param name="charSet"> The name of the character set to use. </param>
+        /// <param name="delegationModes">
+        /// Finely controls where to recursively apply the character set and where not.
+        /// Ignored when <see cref="CharSetAttribute"/> is applied to properties/columns.
+        /// </param>
+        public CharSetAttribute(string charSet, DelegationModes delegationModes)
+            : this(charSet, (DelegationModes?)delegationModes)
+        {
+        }
+
+        protected CharSetAttribute(string charSet, DelegationModes? delegationModes)
+        {
+            CharSetName = charSet;
+            DelegationModes = delegationModes;
+        }
+
+        /// <summary>
+        ///     The name of the character set to use.
+        /// </summary>
+        public virtual string CharSetName { get; }
+
+        /// <summary>
+        /// Finely controls where to recursively apply the character set and where not.
+        /// Implicitly uses <see cref="Microsoft.EntityFrameworkCore.DelegationModes.ApplyToAll"/> if set to <see langword="null"/>.
+        /// Ignored when <see cref="CharSetAttribute"/> is applied to properties/columns.
+        /// </summary>
+        public virtual DelegationModes? DelegationModes { get; }
+    }
+}

--- a/src/EFCore.MySql/DataAnnotations/MySqlCharSetAttribute.cs
+++ b/src/EFCore.MySql/DataAnnotations/MySqlCharSetAttribute.cs
@@ -2,40 +2,40 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
-using Microsoft.EntityFrameworkCore;
 
-namespace Pomelo.EntityFrameworkCore.MySql.DataAnnotations
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
     ///     Configures the property as capable of persisting unicode characters.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field)]
-    public class CharSetAttribute : Attribute
+    public class MySqlCharSetAttribute : Attribute
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="CharSetAttribute" /> class.
+        ///     Initializes a new instance of the <see cref="MySqlCharSetAttribute" /> class.
         ///     Implicitly uses <see cref="Microsoft.EntityFrameworkCore.DelegationModes.ApplyToAll"/>.
         /// </summary>
         /// <param name="charSet"> The name of the character set to use. </param>
-        public CharSetAttribute(string charSet)
+        public MySqlCharSetAttribute(string charSet)
             : this(charSet, null)
         {
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="CharSetAttribute" /> class.
+        ///     Initializes a new instance of the <see cref="MySqlCharSetAttribute" /> class.
         /// </summary>
         /// <param name="charSet"> The name of the character set to use. </param>
         /// <param name="delegationModes">
         /// Finely controls where to recursively apply the character set and where not.
-        /// Ignored when <see cref="CharSetAttribute"/> is applied to properties/columns.
+        /// Ignored when <see cref="MySqlCharSetAttribute"/> is applied to properties/columns.
         /// </param>
-        public CharSetAttribute(string charSet, DelegationModes delegationModes)
+        public MySqlCharSetAttribute(string charSet, DelegationModes delegationModes)
             : this(charSet, (DelegationModes?)delegationModes)
         {
         }
 
-        protected CharSetAttribute(string charSet, DelegationModes? delegationModes)
+        protected MySqlCharSetAttribute(string charSet, DelegationModes? delegationModes)
         {
             CharSetName = charSet;
             DelegationModes = delegationModes;
@@ -49,7 +49,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.DataAnnotations
         /// <summary>
         /// Finely controls where to recursively apply the character set and where not.
         /// Implicitly uses <see cref="Microsoft.EntityFrameworkCore.DelegationModes.ApplyToAll"/> if set to <see langword="null"/>.
-        /// Ignored when <see cref="CharSetAttribute"/> is applied to properties/columns.
+        /// Ignored when <see cref="MySqlCharSetAttribute"/> is applied to properties/columns.
         /// </summary>
         public virtual DelegationModes? DelegationModes { get; }
     }

--- a/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
@@ -10,7 +10,6 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Pomelo.EntityFrameworkCore.MySql.DataAnnotations;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
@@ -149,7 +148,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
             {
                 var delegationModes = entityType[MySqlAnnotationNames.CharSetDelegation] as DelegationModes?;
                 return new AttributeCodeFragment(
-                    typeof(CharSetAttribute),
+                    typeof(MySqlCharSetAttribute),
                     new[] {annotation.Value}
                         .AppendIfTrue(delegationModes.HasValue, delegationModes)
                         .ToArray());
@@ -159,7 +158,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
                 entityType[MySqlAnnotationNames.CharSet] is null)
             {
                 return new AttributeCodeFragment(
-                    typeof(CharSetAttribute),
+                    typeof(MySqlCharSetAttribute),
                     null,
                     annotation.Value);
             }
@@ -174,7 +173,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
 
             return annotation.Name switch
             {
-                MySqlAnnotationNames.CharSet when annotation.Value is string {Length: > 0} charSet => new AttributeCodeFragment(typeof(CharSetAttribute), charSet),
+                MySqlAnnotationNames.CharSet when annotation.Value is string {Length: > 0} charSet => new AttributeCodeFragment(typeof(MySqlCharSetAttribute), charSet),
                 _ => base.GenerateDataAnnotation(property, annotation)
             };
         }

--- a/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.DataAnnotations;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
@@ -137,6 +138,45 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
             }
 
             return null;
+        }
+
+        protected override AttributeCodeFragment GenerateDataAnnotation(IEntityType entityType, IAnnotation annotation)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(annotation, nameof(annotation));
+
+            if (annotation.Name == MySqlAnnotationNames.CharSet)
+            {
+                var delegationModes = entityType[MySqlAnnotationNames.CharSetDelegation] as DelegationModes?;
+                return new AttributeCodeFragment(
+                    typeof(CharSetAttribute),
+                    new[] {annotation.Value}
+                        .AppendIfTrue(delegationModes.HasValue, delegationModes)
+                        .ToArray());
+            }
+
+            if (annotation.Name == MySqlAnnotationNames.CharSetDelegation &&
+                entityType[MySqlAnnotationNames.CharSet] is null)
+            {
+                return new AttributeCodeFragment(
+                    typeof(CharSetAttribute),
+                    null,
+                    annotation.Value);
+            }
+
+            return base.GenerateDataAnnotation(entityType, annotation);
+        }
+
+        protected override AttributeCodeFragment GenerateDataAnnotation(IProperty property, IAnnotation annotation)
+        {
+            Check.NotNull(property, nameof(property));
+            Check.NotNull(annotation, nameof(annotation));
+
+            return annotation.Name switch
+            {
+                MySqlAnnotationNames.CharSet when annotation.Value is string {Length: > 0} charSet => new AttributeCodeFragment(typeof(CharSetAttribute), charSet),
+                _ => base.GenerateDataAnnotation(property, annotation)
+            };
         }
 
         protected override MethodCallCodeFragment GenerateFluentApi(IProperty property, IAnnotation annotation)

--- a/src/EFCore.MySql/Design/Internal/MySqlDesignTimeServices.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlDesignTimeServices.cs
@@ -4,6 +4,7 @@
 using Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
@@ -17,6 +18,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
                 .TryAdd<IAnnotationCodeGenerator, MySqlAnnotationCodeGenerator>()
                 .TryAdd<IDatabaseModelFactory, MySqlDatabaseModelFactory>()
                 .TryAdd<IProviderConfigurationCodeGenerator, MySqlCodeGenerator>()
+                .TryAddProviderSpecificServices(serviceMap => serviceMap
+                    .TryAddSingleton<ICSharpEntityTypeGenerator, FixedCSharpEntityTypeGenerator>()) // TODO: Remove after CSharpEntityTypeGenerator has been fixed in EF Core upstream (6.0.0-preview.6).
                 .TryAddCoreServices();
         }
     }

--- a/src/EFCore.MySql/EFCore.MySql.csproj
+++ b/src/EFCore.MySql/EFCore.MySql.csproj
@@ -20,6 +20,9 @@
     <!-- TODO: Add Microsoft.EntityFrameworkCore as well for .NET 5. Makes it easier for users. -->
     <!-- PrivateAssets="none" is set to flow the EF Core analyzer to users referencing this package https://github.com/aspnet/EntityFrameworkCore/pull/11350 -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" PrivateAssets="none" />
+
+    <!-- TODO: Remove after CSharpEntityTypeGenerator has been fixed in EF Core upstream (6.0.0-preview.6). -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="none" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(LocalMySqlConnectorRepository)' == ''">
@@ -39,6 +42,12 @@
     <Reference Include="Microsoft.EntityFrameworkCore.Relational">
       <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
     </Reference>
+    
+    <!-- TODO: Remove after CSharpEntityTypeGenerator has been fixed in EF Core upstream (6.0.0-preview.6). -->
+    <Reference Include="Microsoft.EntityFrameworkCore.Design">
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Design.dll</HintPath>
+    </Reference>
+    
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
+using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -100,6 +101,46 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
             string charSet)
             => (PropertyBuilder<TProperty>)HasCharSet((PropertyBuilder)propertyBuilder, charSet);
+
+        /// <summary>
+        /// Configures the charset for the property's column.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="charSet">The name of the charset to configure for the property's column.</param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        public static IConventionPropertyBuilder HasCharSet(
+            this IConventionPropertyBuilder propertyBuilder,
+            string charSet,
+            bool fromDataAnnotation = false)
+        {
+            if (!propertyBuilder.CanSetCharSet(charSet, fromDataAnnotation))
+            {
+                return null;
+            }
+
+            propertyBuilder.Metadata.SetCharSet(charSet, fromDataAnnotation);
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the MySQL character set can be set on the column associated with this property.
+        /// </summary>
+        /// <param name="propertyBuilder"> The builder for the property being configured. </param>
+        /// <param name="charSet"> The name of the character set. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <see langword="true" /> if the given value can be set as the character set for the column. </returns>
+        public static bool CanSetCharSet(
+            this IConventionPropertyBuilder propertyBuilder,
+            string charSet,
+            bool fromDataAnnotation = false)
+            => propertyBuilder.CanSetAnnotation(
+                MySqlAnnotationNames.CharSet,
+                charSet,
+                fromDataAnnotation);
 
         /// <summary>
         /// Configures the collation for the property's column.

--- a/src/EFCore.MySql/Metadata/Conventions/ColumnCharSetAttributeConvention.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/ColumnCharSetAttributeConvention.cs
@@ -6,14 +6,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using Pomelo.EntityFrameworkCore.MySql.DataAnnotations;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Conventions
 {
     /// <summary>
-    ///     A convention that configures the column character set for a property or field based on the applied <see cref="CharSetAttribute" />.
+    ///     A convention that configures the column character set for a property or field based on the applied <see cref="MySqlCharSetAttribute" />.
     /// </summary>
-    public class ColumnCharSetAttributeConvention : PropertyAttributeConventionBase<CharSetAttribute>
+    public class ColumnCharSetAttributeConvention : PropertyAttributeConventionBase<MySqlCharSetAttribute>
     {
         /// <summary>
         ///     Creates a new instance of <see cref="UnicodeAttributeConvention" />.
@@ -27,7 +26,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Conventions
         /// <inheritdoc />
         protected override void ProcessPropertyAdded(
             IConventionPropertyBuilder propertyBuilder,
-            CharSetAttribute attribute,
+            MySqlCharSetAttribute attribute,
             MemberInfo clrMember,
             IConventionContext context)
             => propertyBuilder.HasCharSet(attribute.CharSetName);

--- a/src/EFCore.MySql/Metadata/Conventions/ColumnCharSetAttributeConvention.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/ColumnCharSetAttributeConvention.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Pomelo.EntityFrameworkCore.MySql.DataAnnotations;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures the column character set for a property or field based on the applied <see cref="CharSetAttribute" />.
+    /// </summary>
+    public class ColumnCharSetAttributeConvention : PropertyAttributeConventionBase<CharSetAttribute>
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="UnicodeAttributeConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public ColumnCharSetAttributeConvention(ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void ProcessPropertyAdded(
+            IConventionPropertyBuilder propertyBuilder,
+            CharSetAttribute attribute,
+            MemberInfo clrMember,
+            IConventionContext context)
+            => propertyBuilder.HasCharSet(attribute.CharSetName);
+    }
+}

--- a/src/EFCore.MySql/Metadata/Conventions/MySqlConventionSetBuilder.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/MySqlConventionSetBuilder.cs
@@ -37,6 +37,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             conventionSet.ModelInitializedConventions.Add(new RelationalMaxIdentifierLengthConvention(64, Dependencies, RelationalDependencies));
 
+            conventionSet.EntityTypeAddedConventions.Add(new TableCharSetAttributeConvention(Dependencies));
+            conventionSet.PropertyAddedConventions.Add(new ColumnCharSetAttributeConvention(Dependencies));
+
             var valueGeneratorConvention = new MySqlValueGenerationConvention(Dependencies, RelationalDependencies);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, valueGeneratorConvention);
             ReplaceConvention(conventionSet.EntityTypePrimaryKeyChangedConventions, valueGeneratorConvention);

--- a/src/EFCore.MySql/Metadata/Conventions/TableCharSetAttributeConvention.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/TableCharSetAttributeConvention.cs
@@ -5,14 +5,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using Pomelo.EntityFrameworkCore.MySql.DataAnnotations;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Conventions
 {
     /// <summary>
-    ///     A convention that configures the column character set for a property or field based on the applied <see cref="CharSetAttribute" />.
+    ///     A convention that configures the column character set for a property or field based on the applied <see cref="MySqlCharSetAttribute" />.
     /// </summary>
-    public class TableCharSetAttributeConvention : EntityTypeAttributeConventionBase<CharSetAttribute>
+    public class TableCharSetAttributeConvention : EntityTypeAttributeConventionBase<MySqlCharSetAttribute>
     {
         /// <summary>
         ///     Creates a new instance of <see cref="UnicodeAttributeConvention" />.
@@ -26,7 +25,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Conventions
         /// <inheritdoc />
         protected override void ProcessEntityTypeAdded(
             IConventionEntityTypeBuilder entityTypeBuilder,
-            CharSetAttribute attribute,
+            MySqlCharSetAttribute attribute,
             IConventionContext<IConventionEntityTypeBuilder> context)
             => entityTypeBuilder.HasCharSet(attribute.CharSetName, attribute.DelegationModes);
     }

--- a/src/EFCore.MySql/Metadata/Conventions/TableCharSetAttributeConvention.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/TableCharSetAttributeConvention.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Pomelo.EntityFrameworkCore.MySql.DataAnnotations;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures the column character set for a property or field based on the applied <see cref="CharSetAttribute" />.
+    /// </summary>
+    public class TableCharSetAttributeConvention : EntityTypeAttributeConventionBase<CharSetAttribute>
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="UnicodeAttributeConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public TableCharSetAttributeConvention(ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void ProcessEntityTypeAdded(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            CharSetAttribute attribute,
+            IConventionContext<IConventionEntityTypeBuilder> context)
+            => entityTypeBuilder.HasCharSet(attribute.CharSetName, attribute.DelegationModes);
+    }
+}

--- a/src/EFCore.MySql/Scaffolding/Internal/FixedCSharpEntityTypeGenerator.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/FixedCSharpEntityTypeGenerator.cs
@@ -1,0 +1,546 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
+{
+    public class FixedCSharpEntityTypeGenerator : ICSharpEntityTypeGenerator
+    {
+        private readonly IAnnotationCodeGenerator _annotationCodeGenerator;
+        private readonly ICSharpHelper _code;
+
+        private IndentedStringBuilder _sb = null!;
+        private bool _useDataAnnotations;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public FixedCSharpEntityTypeGenerator(
+            IAnnotationCodeGenerator annotationCodeGenerator,
+            ICSharpHelper cSharpHelper)
+        {
+            Check.NotNull(cSharpHelper, nameof(cSharpHelper));
+
+            _annotationCodeGenerator = annotationCodeGenerator;
+            _code = cSharpHelper;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string WriteCode(IEntityType entityType, string @namespace, bool useDataAnnotations)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            _sb = new IndentedStringBuilder();
+            _useDataAnnotations = useDataAnnotations;
+
+            _sb.AppendLine("using System;");
+            _sb.AppendLine("using System.Collections.Generic;");
+
+            if (_useDataAnnotations)
+            {
+                _sb.AppendLine("using System.ComponentModel.DataAnnotations;");
+                _sb.AppendLine("using System.ComponentModel.DataAnnotations.Schema;");
+                _sb.AppendLine("using Microsoft.EntityFrameworkCore;"); // For attributes coming out of Abstractions
+            }
+
+            foreach (var ns in entityType.GetProperties()
+                .SelectMany(p => p.ClrType.GetNamespaces())
+                .Where(ns => ns != "System" && ns != "System.Collections.Generic")
+                .Distinct()
+                .OrderBy(x => x, new NamespaceComparer()))
+            {
+                _sb.AppendLine($"using {ns};");
+            }
+
+            _sb.AppendLine();
+            _sb.AppendLine("#nullable disable");
+
+            _sb.AppendLine();
+
+            if (!string.IsNullOrEmpty(@namespace))
+            {
+                _sb.AppendLine($"namespace {@namespace}");
+                _sb.AppendLine("{");
+                _sb.IncrementIndent();
+            }
+
+            GenerateClass(entityType);
+
+            if (!string.IsNullOrEmpty(@namespace))
+            {
+                _sb.DecrementIndent();
+                _sb.AppendLine("}");
+            }
+
+            return _sb.ToString();
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual void GenerateClass(IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            GenerateComment(entityType.GetComment());
+
+            if (_useDataAnnotations)
+            {
+                GenerateEntityTypeDataAnnotations(entityType);
+            }
+
+            _sb.AppendLine($"public partial class {entityType.Name}");
+
+            _sb.AppendLine("{");
+
+            using (_sb.Indent())
+            {
+                GenerateConstructor(entityType);
+                GenerateProperties(entityType);
+                GenerateNavigationProperties(entityType);
+            }
+
+            _sb.AppendLine("}");
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual void GenerateEntityTypeDataAnnotations(IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            GenerateKeylessAttribute(entityType);
+            GenerateTableAttribute(entityType);
+            GenerateIndexAttributes(entityType);
+
+            var annotations = _annotationCodeGenerator
+                .FilterIgnoredAnnotations(entityType.GetAnnotations())
+                .ToDictionary(a => a.Name, a => a);
+            _annotationCodeGenerator.RemoveAnnotationsHandledByConventions(entityType, annotations);
+
+            foreach (var attribute in _annotationCodeGenerator.GenerateDataAnnotationAttributes(entityType, annotations))
+            {
+                var attributeWriter = new AttributeWriter(attribute.Type.Name);
+                foreach (var argument in attribute.Arguments)
+                {
+                    attributeWriter.AddParameter(_code.UnknownLiteral(argument));
+                }
+
+                _sb.AppendLine(attributeWriter.ToString()); // <-- FIXED
+            }
+        }
+
+        private void GenerateKeylessAttribute(IEntityType entityType)
+        {
+            if (entityType.FindPrimaryKey() == null)
+            {
+                _sb.AppendLine(new AttributeWriter(nameof(KeylessAttribute)).ToString());
+            }
+        }
+
+        private void GenerateTableAttribute(IEntityType entityType)
+        {
+            var tableName = entityType.GetTableName();
+            var schema = entityType.GetSchema();
+            var defaultSchema = entityType.Model.GetDefaultSchema();
+
+            var schemaParameterNeeded = schema != null && schema != defaultSchema;
+            var isView = entityType.GetViewName() != null;
+            var tableAttributeNeeded = !isView && (schemaParameterNeeded || tableName != null && tableName != entityType.GetDbSetName());
+            if (tableAttributeNeeded)
+            {
+                var tableAttribute = new AttributeWriter(nameof(TableAttribute));
+
+                tableAttribute.AddParameter(_code.Literal(tableName!));
+
+                if (schemaParameterNeeded)
+                {
+                    tableAttribute.AddParameter($"{nameof(TableAttribute.Schema)} = {_code.Literal(schema!)}");
+                }
+
+                _sb.AppendLine(tableAttribute.ToString());
+            }
+        }
+
+        private void GenerateIndexAttributes(IEntityType entityType)
+        {
+            // Do not generate IndexAttributes for indexes which
+            // would be generated anyway by convention.
+            foreach (var index in entityType.GetIndexes().Where(
+                i => ConfigurationSource.Convention != ((IConventionIndex)i).GetConfigurationSource()))
+            {
+                // If there are annotations that cannot be represented using an IndexAttribute then use fluent API instead.
+                var annotations = _annotationCodeGenerator
+                    .FilterIgnoredAnnotations(index.GetAnnotations())
+                    .ToDictionary(a => a.Name, a => a);
+                _annotationCodeGenerator.RemoveAnnotationsHandledByConventions(index, annotations);
+
+                if (annotations.Count == 0)
+                {
+                    var indexAttribute = new AttributeWriter(nameof(IndexAttribute));
+                    foreach (var property in index.Properties)
+                    {
+                        indexAttribute.AddParameter($"nameof({property.Name})");
+                    }
+
+                    if (index.Name != null)
+                    {
+                        indexAttribute.AddParameter($"{nameof(IndexAttribute.Name)} = {_code.Literal(index.Name)}");
+                    }
+
+                    if (index.IsUnique)
+                    {
+                        indexAttribute.AddParameter($"{nameof(IndexAttribute.IsUnique)} = {_code.Literal(index.IsUnique)}");
+                    }
+
+                    _sb.AppendLine(indexAttribute.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual void GenerateConstructor(IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            var collectionNavigations = entityType.GetNavigations().Where(n => n.IsCollection).ToList();
+
+            if (collectionNavigations.Count > 0)
+            {
+                _sb.AppendLine($"public {entityType.Name}()");
+                _sb.AppendLine("{");
+
+                using (_sb.Indent())
+                {
+                    foreach (var navigation in collectionNavigations)
+                    {
+                        _sb.AppendLine($"{navigation.Name} = new HashSet<{navigation.TargetEntityType.Name}>();");
+                    }
+                }
+
+                _sb.AppendLine("}");
+                _sb.AppendLine();
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual void GenerateProperties(IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            foreach (var property in entityType.GetProperties().OrderBy(p => p.GetColumnOrdinal()))
+            {
+                GenerateComment(property.GetComment());
+
+                if (_useDataAnnotations)
+                {
+                    GeneratePropertyDataAnnotations(property);
+                }
+
+                _sb.AppendLine($"public {_code.Reference(property.ClrType)} {property.Name} {{ get; set; }}");
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual void GeneratePropertyDataAnnotations(IProperty property)
+        {
+            Check.NotNull(property, nameof(property));
+
+            GenerateKeyAttribute(property);
+            GenerateRequiredAttribute(property);
+            GenerateColumnAttribute(property);
+            GenerateMaxLengthAttribute(property);
+            GenerateUnicodeAttribute(property);
+            GeneratePrecisionAttribute(property);
+
+            var annotations = _annotationCodeGenerator
+                .FilterIgnoredAnnotations(property.GetAnnotations())
+                .ToDictionary(a => a.Name, a => a);
+            _annotationCodeGenerator.RemoveAnnotationsHandledByConventions(property, annotations);
+
+            foreach (var attribute in _annotationCodeGenerator.GenerateDataAnnotationAttributes(property, annotations))
+            {
+                var attributeWriter = new AttributeWriter(attribute.Type.Name);
+                foreach (var argument in attribute.Arguments)
+                {
+                    attributeWriter.AddParameter(_code.UnknownLiteral(argument));
+                }
+
+                _sb.AppendLine(attributeWriter.ToString()); // <-- FIXED
+            }
+        }
+
+        private void GenerateKeyAttribute(IProperty property)
+        {
+            var key = property.FindContainingPrimaryKey();
+            if (key != null)
+            {
+                _sb.AppendLine(new AttributeWriter(nameof(KeyAttribute)).ToString());
+            }
+        }
+
+        private void GenerateColumnAttribute(IProperty property)
+        {
+            var columnName = property.GetColumnBaseName();
+            var columnType = property.GetConfiguredColumnType();
+
+            var delimitedColumnName = columnName != null && columnName != property.Name ? _code.Literal(columnName) : null;
+            var delimitedColumnType = columnType != null ? _code.Literal(columnType) : null;
+
+            if ((delimitedColumnName ?? delimitedColumnType) != null)
+            {
+                var columnAttribute = new AttributeWriter(nameof(ColumnAttribute));
+
+                if (delimitedColumnName != null)
+                {
+                    columnAttribute.AddParameter(delimitedColumnName);
+                }
+
+                if (delimitedColumnType != null)
+                {
+                    columnAttribute.AddParameter($"{nameof(ColumnAttribute.TypeName)} = {delimitedColumnType}");
+                }
+
+                _sb.AppendLine(columnAttribute.ToString());
+            }
+        }
+
+        private void GenerateRequiredAttribute(IProperty property)
+        {
+            if (!property.IsNullable
+                && property.ClrType.IsNullableType()
+                && !property.IsPrimaryKey())
+            {
+                _sb.AppendLine(new AttributeWriter(nameof(RequiredAttribute)).ToString());
+            }
+        }
+
+        private void GenerateMaxLengthAttribute(IProperty property)
+        {
+            var maxLength = property.GetMaxLength();
+
+            if (maxLength.HasValue)
+            {
+                var lengthAttribute = new AttributeWriter(
+                    property.ClrType == typeof(string)
+                        ? nameof(StringLengthAttribute)
+                        : nameof(MaxLengthAttribute));
+
+                lengthAttribute.AddParameter(_code.Literal(maxLength.Value));
+
+                _sb.AppendLine(lengthAttribute.ToString());
+            }
+        }
+
+        private void GenerateUnicodeAttribute(IProperty property)
+        {
+            if (property.ClrType != typeof(string))
+            {
+                return;
+            }
+
+            var unicode = property.IsUnicode();
+            if (unicode.HasValue)
+            {
+                var unicodeAttribute = new AttributeWriter(nameof(UnicodeAttribute));
+                if (!unicode.Value)
+                {
+                    unicodeAttribute.AddParameter(_code.Literal(false));
+                }
+                _sb.AppendLine(unicodeAttribute.ToString());
+            }
+        }
+
+        private void GeneratePrecisionAttribute(IProperty property)
+        {
+            var precision = property.GetPrecision();
+            if (precision.HasValue)
+            {
+                var precisionAttribute = new AttributeWriter(nameof(PrecisionAttribute));
+                precisionAttribute.AddParameter(_code.Literal(precision.Value));
+
+                var scale = property.GetScale();
+                if (scale.HasValue)
+                {
+                    precisionAttribute.AddParameter(_code.Literal(scale.Value));
+                }
+
+                _sb.AppendLine(precisionAttribute.ToString());
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual void GenerateNavigationProperties(IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            var sortedNavigations = entityType.GetNavigations()
+                .OrderBy(n => n.IsOnDependent ? 0 : 1)
+                .ThenBy(n => n.IsCollection ? 1 : 0)
+                .ToList();
+
+            if (sortedNavigations.Any())
+            {
+                _sb.AppendLine();
+
+                foreach (var navigation in sortedNavigations)
+                {
+                    if (_useDataAnnotations)
+                    {
+                        GenerateNavigationDataAnnotations(navigation);
+                    }
+
+                    var referencedTypeName = navigation.TargetEntityType.Name;
+                    var navigationType = navigation.IsCollection ? $"ICollection<{referencedTypeName}>" : referencedTypeName;
+                    _sb.AppendLine($"public virtual {navigationType} {navigation.Name} {{ get; set; }}");
+                }
+            }
+        }
+
+        private void GenerateNavigationDataAnnotations(INavigation navigation)
+        {
+            GenerateForeignKeyAttribute(navigation);
+            GenerateInversePropertyAttribute(navigation);
+        }
+
+        private void GenerateForeignKeyAttribute(INavigation navigation)
+        {
+            if (navigation.IsOnDependent)
+            {
+                if (navigation.ForeignKey.PrincipalKey.IsPrimaryKey())
+                {
+                    var foreignKeyAttribute = new AttributeWriter(nameof(ForeignKeyAttribute));
+
+                    if (navigation.ForeignKey.Properties.Count > 1)
+                    {
+                        foreignKeyAttribute.AddParameter(
+                            _code.Literal(
+                                string.Join(",", navigation.ForeignKey.Properties.Select(p => p.Name))));
+                    }
+                    else
+                    {
+                        foreignKeyAttribute.AddParameter($"nameof({navigation.ForeignKey.Properties.First().Name})");
+                    }
+
+                    _sb.AppendLine(foreignKeyAttribute.ToString());
+                }
+            }
+        }
+
+        private void GenerateInversePropertyAttribute(INavigation navigation)
+        {
+            if (navigation.ForeignKey.PrincipalKey.IsPrimaryKey())
+            {
+                var inverseNavigation = navigation.Inverse;
+
+                if (inverseNavigation != null)
+                {
+                    var inversePropertyAttribute = new AttributeWriter(nameof(InversePropertyAttribute));
+
+                    inversePropertyAttribute.AddParameter(
+                        !navigation.DeclaringEntityType.GetPropertiesAndNavigations().Any(
+                            m => m.Name == inverseNavigation.DeclaringEntityType.Name)
+                            ? $"nameof({inverseNavigation.DeclaringEntityType.Name}.{inverseNavigation.Name})"
+                            : _code.Literal(inverseNavigation.Name));
+
+                    _sb.AppendLine(inversePropertyAttribute.ToString());
+                }
+            }
+        }
+
+        private void GenerateComment(string comment)
+        {
+            if (!string.IsNullOrWhiteSpace(comment))
+            {
+                _sb.AppendLine("/// <summary>");
+
+                foreach (var line in comment.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
+                {
+                    _sb.AppendLine($"/// {System.Security.SecurityElement.Escape(line)}");
+                }
+
+                _sb.AppendLine("/// </summary>");
+            }
+        }
+
+        private sealed class AttributeWriter
+        {
+            private readonly string _attributeName;
+            private readonly List<string> _parameters = new();
+
+            public AttributeWriter(string attributeName)
+            {
+                Check.NotEmpty(attributeName, nameof(attributeName));
+
+                _attributeName = attributeName;
+            }
+
+            public void AddParameter(string parameter)
+            {
+                Check.NotEmpty(parameter, nameof(parameter));
+
+                _parameters.Add(parameter);
+            }
+
+            public override string ToString()
+                => "["
+                    + (_parameters.Count == 0
+                        ? StripAttribute(_attributeName)
+                        : StripAttribute(_attributeName) + "(" + string.Join(", ", _parameters) + ")")
+                    + "]";
+
+            private static string StripAttribute(string attributeName)
+                => attributeName.EndsWith("Attribute", StringComparison.Ordinal)
+                    ? attributeName[..^9]
+                    : attributeName;
+        }
+    }
+}

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -12,6 +12,26 @@ namespace System
     [DebuggerStepThrough]
     internal static class SharedTypeExtensions
     {
+        private static readonly Dictionary<Type, string> _builtInTypeNames = new()
+        {
+            { typeof(bool), "bool" },
+            { typeof(byte), "byte" },
+            { typeof(char), "char" },
+            { typeof(decimal), "decimal" },
+            { typeof(double), "double" },
+            { typeof(float), "float" },
+            { typeof(int), "int" },
+            { typeof(long), "long" },
+            { typeof(object), "object" },
+            { typeof(sbyte), "sbyte" },
+            { typeof(short), "short" },
+            { typeof(string), "string" },
+            { typeof(uint), "uint" },
+            { typeof(ulong), "ulong" },
+            { typeof(ushort), "ushort" },
+            { typeof(void), "void" }
+        };
+
         public static Type UnwrapNullableType(this Type type) => Nullable.GetUnderlyingType(type) ?? type;
 
         public static bool IsNullableType(this Type type)
@@ -252,6 +272,27 @@ namespace System
             return _commonTypeDictionary.TryGetValue(type, out var value)
                 ? value
                 : Activator.CreateInstance(type);
+        }
+
+        public static IEnumerable<string> GetNamespaces(this Type type)
+        {
+            if (_builtInTypeNames.ContainsKey(type))
+            {
+                yield break;
+            }
+
+            yield return type.Namespace!;
+
+            if (type.IsGenericType)
+            {
+                foreach (var typeArgument in type.GenericTypeArguments)
+                {
+                    foreach (var ns in typeArgument.GetNamespaces())
+                    {
+                        yield return ns;
+                    }
+                }
+            }
         }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/DataAnnotationMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/DataAnnotationMySqlTest.cs
@@ -6,7 +6,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Pomelo.EntityFrameworkCore.MySql.DataAnnotations;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -178,7 +177,7 @@ WHERE ROW_COUNT() = 1 AND `Unique_No` = LAST_INSERT_ID();");
         {
             public int Id { get; set; }
 
-            [CharSet("latin1")]
+            [MySqlCharSet("latin1")]
             public string PersonFirstName { get; set; }
         }
 
@@ -196,7 +195,7 @@ WHERE ROW_COUNT() = 1 AND `Unique_No` = LAST_INSERT_ID();");
             return modelBuilder;
         }
 
-        [CharSet("latin1")]
+        [MySqlCharSet("latin1")]
         protected class TableWithCharSet
         {
             public int Id { get; set; }

--- a/test/EFCore.MySql.FunctionalTests/DataAnnotationMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/DataAnnotationMySqlTest.cs
@@ -1,10 +1,12 @@
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Pomelo.EntityFrameworkCore.MySql.DataAnnotations;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -157,6 +159,51 @@ SELECT `Unique_No`
 FROM `Sample`
 WHERE ROW_COUNT() = 1 AND `Unique_No` = LAST_INSERT_ID();");
         }
+
+        [ConditionalFact]
+        public virtual ModelBuilder CharSet_attribute_is_applied_to_column()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<ColumnWithCharSet>();
+
+            Validate(modelBuilder);
+
+            Assert.Equal("latin1", GetProperty<ColumnWithCharSet>(modelBuilder, "PersonFirstName").GetCharSet());
+
+            return modelBuilder;
+        }
+
+        protected class ColumnWithCharSet
+        {
+            public int Id { get; set; }
+
+            [CharSet("latin1")]
+            public string PersonFirstName { get; set; }
+        }
+
+        [ConditionalFact]
+        public virtual ModelBuilder CharSet_attribute_is_applied_to_table()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<TableWithCharSet>();
+
+            Validate(modelBuilder);
+
+            Assert.Equal("latin1", GetEntityType<TableWithCharSet>(modelBuilder).GetCharSet());
+
+            return modelBuilder;
+        }
+
+        [CharSet("latin1")]
+        protected class TableWithCharSet
+        {
+            public int Id { get; set; }
+        }
+
+        protected static IMutableEntityType GetEntityType<TEntity>(ModelBuilder modelBuilder)
+            => modelBuilder.Model.FindEntityType(typeof(TEntity));
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
Allows to use a Pomelo specific data annotation attribute named `MySqlCharSet` to be applied to entity classes and/or their properties/fields:

```c#
[MySqlCharSet("utf8mb4")]
protected class IceCreams
{
    public int IceCreamId { get; set; }

    public string InternationalName { get; set; }

    [MySqlCharSet("latin1")]
    public string WesternName { get; set; }
}
```

Character set delegation is handled the same way it is using the `HasCharSet()` fluent API call.

Addresses #1410