### PR TITLE
Remove explicit database character set change to utf8mb4, at the beginning of migration scripts

### DIFF
--- a/src/EFCore.MySql/Migrations/Internal/MySqlHistoryRepository.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlHistoryRepository.cs
@@ -2,13 +2,16 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
 {
@@ -96,5 +99,73 @@ DELIMITER ;
 CALL {MigrationsScript}();
 DROP PROCEDURE {MigrationsScript};
 ";
+
+        public virtual void ConfigureModel(ModelBuilder modelBuilder)
+            => modelBuilder.HasCharSet(null, DelegationModes.ApplyToDatabases);
+
+        #region Necessary implementation because we cannot directly override EnsureModel
+
+        private IModel _model;
+        private string _migrationIdColumnName;
+        private string _productVersionColumnName;
+
+        // Customized implementation.
+        protected virtual IModel EnsureModel()
+        {
+            if (_model == null)
+            {
+                var conventionSet = Dependencies.ConventionSetBuilder.CreateConventionSet();
+
+                // Use public API to remove the convention, issue #214
+                ConventionSet.Remove(conventionSet.ModelInitializedConventions, typeof(DbSetFindingConvention));
+                ConventionSet.Remove(conventionSet.ModelInitializedConventions, typeof(RelationalDbFunctionAttributeConvention));
+
+                var modelBuilder = new ModelBuilder(conventionSet);
+
+                #region Custom implementation
+
+                ConfigureModel(modelBuilder);
+
+                #endregion
+
+                modelBuilder.Entity<HistoryRow>(
+                    x =>
+                    {
+                        ConfigureTable(x);
+                        x.ToTable(TableName, TableSchema);
+                    });
+
+                _model = Dependencies.ModelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), designTime: true, validationLogger: null);
+            }
+
+            return _model;
+        }
+
+        // Original implementation.
+        public override string GetCreateScript()
+        {
+            var model = EnsureModel();
+
+            var operations = Dependencies.ModelDiffer.GetDifferences(null, model.GetRelationalModel());
+            var commandList = Dependencies.MigrationsSqlGenerator.Generate(operations, model);
+
+            return string.Concat(commandList.Select(c => c.CommandText));
+        }
+
+        // Original implementation.
+        protected override string MigrationIdColumnName
+            => _migrationIdColumnName ??= EnsureModel()
+                .FindEntityType(typeof(HistoryRow))!
+                .FindProperty(nameof(HistoryRow.MigrationId))!
+                .GetColumnBaseName();
+
+        // Original implementation.
+        protected override string ProductVersionColumnName
+            => _productVersionColumnName ??= EnsureModel()
+                .FindEntityType(typeof(HistoryRow))!
+                .FindProperty(nameof(HistoryRow.ProductVersion))!
+                .GetColumnBaseName();
+
+        #endregion Necessary implementation because we cannot directly override EnsureModel
     }
 }

--- a/src/EFCore.MySql/Migrations/Internal/MySqlHistoryRepository.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlHistoryRepository.cs
@@ -24,8 +24,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
         protected override void ConfigureTable([NotNull] EntityTypeBuilder<HistoryRow> history)
         {
             base.ConfigureTable(history);
-            history.Property(h => h.MigrationId).HasColumnType("varchar(95)");
-            history.Property(h => h.ProductVersion).HasColumnType("varchar(32)").IsRequired();
+
+            history.HasCharSet(CharSet.Utf8Mb4);
         }
 
         protected override string ExistsSql

--- a/test/EFCore.MySql.FunctionalTests/MigrationsInfrastructureMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsInfrastructureMySqlTest.cs
@@ -23,8 +23,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.Can_generate_migration_from_initial_database_to_initial();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -40,8 +39,7 @@ CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
             base.Can_generate_no_migration_script();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -57,8 +55,7 @@ CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
             base.Can_generate_up_scripts();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -140,8 +137,7 @@ COMMIT;
         {
             base.Can_generate_idempotent_up_scripts();
 
-            Assert.Equal(@"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+            Assert.Equal(@"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -404,8 +400,7 @@ COMMIT;
             base.Can_generate_up_scripts_noTransactions();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -438,8 +433,7 @@ VALUES ('00000000000003_Migration3', '7.0.0-test');
             base.Can_generate_idempotent_up_scripts_noTransactions();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)


### PR DESCRIPTION
The following header was added to all migrations scripts, despite what character set was setup:

```sql
ALTER DATABASE CHARACTER SET utf8mb4;
CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
    `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
    `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
    CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
) CHARACTER SET utf8mb4;
```

Now, we do not emit the initial `ALTER DATABASE` statement anymore, so the script header just looks like this:

```sql
CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
    `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
    `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
    CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
) CHARACTER SET utf8mb4;
```

As can be seen, we are explicitly keeping the `utf8mb4` charset for the `__EFMigrationsHistory` table and its columns.

Fixes #1426