### PR TITLE
[BACKPORT] Remove explicit database character set change to utf8mb4, at the beginning of migration scripts

### DIFF
--- a/src/EFCore.MySql/Migrations/Internal/MySqlHistoryRepository.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlHistoryRepository.cs
@@ -118,7 +118,10 @@ DROP PROCEDURE {MigrationsScript};
 
                 // Use public API to remove the convention, issue #214
                 ConventionSet.Remove(conventionSet.ModelInitializedConventions, typeof(DbSetFindingConvention));
-                ConventionSet.Remove(conventionSet.ModelInitializedConventions, typeof(RelationalDbFunctionAttributeConvention));
+                if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23312", out var enabled) && enabled))
+                {
+                    ConventionSet.Remove(conventionSet.ModelInitializedConventions, typeof(RelationalDbFunctionAttributeConvention));
+                }
 
                 var modelBuilder = new ModelBuilder(conventionSet);
 
@@ -135,7 +138,7 @@ DROP PROCEDURE {MigrationsScript};
                         x.ToTable(TableName, TableSchema);
                     });
 
-                _model = Dependencies.ModelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), designTime: true, validationLogger: null);
+                _model = modelBuilder.FinalizeModel();
             }
 
             return _model;
@@ -155,15 +158,15 @@ DROP PROCEDURE {MigrationsScript};
         // Original implementation.
         protected override string MigrationIdColumnName
             => _migrationIdColumnName ??= EnsureModel()
-                .FindEntityType(typeof(HistoryRow))!
-                .FindProperty(nameof(HistoryRow.MigrationId))!
+                .FindEntityType(typeof(HistoryRow))
+                .FindProperty(nameof(HistoryRow.MigrationId))
                 .GetColumnBaseName();
 
         // Original implementation.
         protected override string ProductVersionColumnName
             => _productVersionColumnName ??= EnsureModel()
-                .FindEntityType(typeof(HistoryRow))!
-                .FindProperty(nameof(HistoryRow.ProductVersion))!
+                .FindEntityType(typeof(HistoryRow))
+                .FindProperty(nameof(HistoryRow.ProductVersion))
                 .GetColumnBaseName();
 
         #endregion Necessary implementation because we cannot directly override EnsureModel

--- a/test/EFCore.MySql.FunctionalTests/MigrationsInfrastructureMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsInfrastructureMySqlTest.cs
@@ -24,8 +24,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.Can_generate_migration_from_initial_database_to_initial();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -41,8 +40,7 @@ CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
             base.Can_generate_no_migration_script();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -58,8 +56,7 @@ CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
             base.Can_generate_up_scripts();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -141,8 +138,7 @@ COMMIT;
         {
             base.Can_generate_idempotent_up_scripts();
 
-            Assert.Equal(@"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+            Assert.Equal(@"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -405,8 +401,7 @@ COMMIT;
             base.Can_generate_up_scripts_noTransactions();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
@@ -439,8 +434,7 @@ VALUES ('00000000000003_Migration3', '7.0.0-test');
             base.Can_generate_idempotent_up_scripts_noTransactions();
 
             Assert.Equal(
-                @"ALTER DATABASE CHARACTER SET utf8mb4;
-CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                @"CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)


### PR DESCRIPTION
Backports #1452 to 5.0.

Fixes #1426