### PR TITLE
Add QueryBaselineUpdater tool for simple bulk replacement of AssertSql statements

### DIFF
--- a/Pomelo.EFCore.MySql.sln
+++ b/Pomelo.EFCore.MySql.sln
@@ -40,6 +40,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.MySql.Json.Microsoft
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.MySql.Json.Newtonsoft", "src\EFCore.MySql.Json.Newtonsoft\EFCore.MySql.Json.Newtonsoft.csproj", "{BBA0BB73-3D75-4F08-992F-A2CF9F52E7AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueryBaselineUpdater", "tools\QueryBaselineUpdater\QueryBaselineUpdater.csproj", "{57293669-2ADF-448F-AE22-B49BAC4A335E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{DD543966-92C7-4FE6-B953-3270E3E11D46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -74,6 +78,10 @@ Global
 		{BBA0BB73-3D75-4F08-992F-A2CF9F52E7AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BBA0BB73-3D75-4F08-992F-A2CF9F52E7AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BBA0BB73-3D75-4F08-992F-A2CF9F52E7AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57293669-2ADF-448F-AE22-B49BAC4A335E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57293669-2ADF-448F-AE22-B49BAC4A335E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57293669-2ADF-448F-AE22-B49BAC4A335E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57293669-2ADF-448F-AE22-B49BAC4A335E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,6 +94,7 @@ Global
 		{7A727AB9-38F0-40E5-B134-7AC830B8D1EC} = {7E8380DB-F015-407B-99C2-26404E551673}
 		{C27A301A-F47E-4584-88DB-0474AE446405} = {7E8380DB-F015-407B-99C2-26404E551673}
 		{BBA0BB73-3D75-4F08-992F-A2CF9F52E7AD} = {7E8380DB-F015-407B-99C2-26404E551673}
+		{57293669-2ADF-448F-AE22-B49BAC4A335E} = {DD543966-92C7-4FE6-B953-3270E3E11D46}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {48E34212-4B35-4A81-92F9-3C25D4E76D6C}

--- a/tools/QueryBaselineUpdater/Program.cs
+++ b/tools/QueryBaselineUpdater/Program.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace QueryBaselineUpdater
+{
+    internal static class Program
+    {
+        private static void Main(string[] args)
+        {
+            const string assertSqlPattern = @"\s*AssertSql\(\s*@"".*?""\);\r?\n";
+
+            var queryBaselineFilePath = args[0];
+            var testFilePath = args[1];
+
+            File.WriteAllText(
+                testFilePath,
+                Regex.Matches(
+                        File.ReadAllText(queryBaselineFilePath),
+                        $@"(?:^|\n)(?<Name>(?:Pomelo|EntityFrameworkCore|Microsoft)[^\r\n]*)\([^\r\n]*\) : (?<Line>\d+)\r?\n(?<AssertSql>{assertSqlPattern})\r?\n(?<Truncated>Output truncated.)?\r?\n--------------------(?=\r?\n)",
+                        RegexOptions.IgnoreCase | RegexOptions.Singleline)
+                    .Select(
+                        match => new
+                        {
+                            Line = int.Parse(match.Groups["Line"].Value),
+                            Name = match.Groups["Name"].Value,
+                            AssertSql = match.Groups["AssertSql"].Value,
+                            Truncated = match.Groups["Truncated"].Success,
+                        })
+                    .GroupBy(t => t.Line)
+                    .Select(g => g.First())
+                    .OrderByDescending(t => t.Line)
+                    .Aggregate(
+                        File.ReadAllText(testFilePath),
+                        (current, next) =>
+                        {
+                            var lines = Regex.Split(current, @"\r?\n");
+                            var before = lines.Take(next.Line - 1);
+                            var remaining = lines.Skip(next.Line - 1);
+                            var replaced = Regex.Split(
+                                Regex.Replace(
+                                    string.Join(Environment.NewLine, remaining),
+                                    $"^{assertSqlPattern}",
+                                    next.AssertSql,
+                                    RegexOptions.IgnoreCase | RegexOptions.Singleline),
+                                @"\r?\n")
+                                .AsEnumerable();
+
+                            if (next.Truncated)
+                            {
+                                replaced = replaced.Prepend("            #warning TRUNCATED: Add remaining baseline queries.");
+                            }
+
+                            return string.Join(Environment.NewLine, before.Concat(replaced));
+                        }));
+        }
+    }
+}

--- a/tools/QueryBaselineUpdater/QueryBaselineUpdater.csproj
+++ b/tools/QueryBaselineUpdater/QueryBaselineUpdater.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Adds a simple tool that can be used to replace existing `AssertSql(...)` statements in test classes with the actual output recorded in a `QueryBaseline.txt` file.

Useful for providing new test classes with an initial set of MySQL specific SQL, when the classes were copied from the SQL Server or Npgsql implementation.

The `QueryBaseline.txt` file should only contain output for a single test class/file, when using the tool.