### PR TITLE
Refine HAVING bug workaround

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlHavingExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlHavingExpressionVisitor.cs
@@ -37,49 +37,47 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             // MySQL & MariaDB currently do not support complex expressions in HAVING clauses (e.g. function calls).
             // Instead, they want you to reference SELECT aliases for those expressions in the HAVING clause.
             // See https://bugs.mysql.com/bug.php?id=103961
+            // This is only an issue for HAVING expressions that do not contain any aggregate functions.
             var havingExpression = selectExpression.Having;
-            if (havingExpression != null)
+            if (havingExpression is not null &&
+                havingExpression is not SqlConstantExpression)
             {
-                var alias = GetUniqueAlias(selectExpression.Projection);
-
-                // Hack around the fact, that EF Core does not allow us to add our own ProjectionExpression with an alias.
-                // We can however indirectly control the alias, by first setting a ColumnExpression, whose name is then used as the base
-                // for the alias, and then update it afterwards with the actual expression we are interested in, when it gets visited.
-                selectExpression.AddToProjection(
-                    new HatSwappingColumnExpression(
-                        havingExpression,
-                        alias,
-                        havingExpression.Type,
-                        havingExpression.TypeMapping));
-
-                var columnAliasReferenceExpression = _sqlExpressionFactory.ColumnAliasReference(
-                    alias,
-                    havingExpression,
-                    havingExpression.Type,
-                    havingExpression.TypeMapping);
-
-                // Having expressions, not containing an aggregate function, need to be part of the GROUP BY clause, because they now also
-                // appear as part of the SELECT clause.
-                var groupBy = selectExpression.GroupBy;
-
                 _containsAggregateFunctionExpressionVisitor ??= new MySqlContainsAggregateFunctionExpressionVisitor();
                 if (!_containsAggregateFunctionExpressionVisitor.Process(havingExpression))
                 {
-                    var mutableGroupBy = selectExpression.GroupBy.ToList();
-                    mutableGroupBy.Add(columnAliasReferenceExpression);
+                    var alias = GetUniqueAlias(selectExpression.Projection);
 
-                    groupBy = mutableGroupBy;
+                    // Hack around the fact, that EF Core does not allow us to add our own ProjectionExpression with an alias.
+                    // We can however indirectly control the alias, by first setting a ColumnExpression, whose name is then used as the base
+                    // for the alias, and then update it afterwards with the actual expression we are interested in, when it gets visited.
+                    selectExpression.AddToProjection(
+                        new HatSwappingColumnExpression(
+                            havingExpression,
+                            alias,
+                            havingExpression.Type,
+                            havingExpression.TypeMapping));
+
+                    var columnAliasReferenceExpression = _sqlExpressionFactory.ColumnAliasReference(
+                        alias,
+                        havingExpression,
+                        havingExpression.Type,
+                        havingExpression.TypeMapping);
+
+                    // Having expressions, not containing an aggregate function, need to be part of the GROUP BY clause, because they now also
+                    // appear as part of the SELECT clause.
+                    var groupBy = selectExpression.GroupBy.ToList();
+                    groupBy.Add(columnAliasReferenceExpression);
+
+                    selectExpression = selectExpression.Update(
+                        selectExpression.Projection,
+                        selectExpression.Tables,
+                        selectExpression.Predicate,
+                        groupBy,
+                        columnAliasReferenceExpression,
+                        selectExpression.Orderings,
+                        selectExpression.Limit,
+                        selectExpression.Offset);
                 }
-
-                selectExpression = selectExpression.Update(
-                    selectExpression.Projection,
-                    selectExpression.Tables,
-                    selectExpression.Predicate,
-                    groupBy,
-                    columnAliasReferenceExpression,
-                    selectExpression.Orderings,
-                    selectExpression.Limit,
-                    selectExpression.Offset);
             }
 
             return base.VisitExtension(selectExpression);

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQueryTranslationPostprocessor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQueryTranslationPostprocessor.cs
@@ -29,7 +29,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
         {
             query = base.Process(query);
 
-            query = new MySqlHavingExpressionVisitor(_sqlExpressionFactory).Visit(query);
             query = new MySqlJsonParameterExpressionVisitor(_sqlExpressionFactory, _options).Visit(query);
 
             if (_options.ServerVersion.Supports.MySqlBug96947Workaround)

--- a/src/EFCore.MySql/Query/Internal/MySqlParameterBasedSqlProcessor.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlParameterBasedSqlProcessor.cs
@@ -16,6 +16,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
     public class MySqlParameterBasedSqlProcessor : RelationalParameterBasedSqlProcessor
     {
         private readonly IMySqlOptions _options;
+        private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
         public MySqlParameterBasedSqlProcessor(
             [NotNull] RelationalParameterBasedSqlProcessorDependencies dependencies,
@@ -23,6 +24,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             IMySqlOptions options)
             : base(dependencies, useRelationalNulls)
         {
+            _sqlExpressionFactory = (MySqlSqlExpressionFactory)Dependencies.SqlExpressionFactory;
             _options = options;
         }
 
@@ -45,6 +47,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             {
                 selectExpression = (SelectExpression)new MySqlBoolOptimizingExpressionVisitor(Dependencies.SqlExpressionFactory).Visit(selectExpression);
             }
+
+            selectExpression = (SelectExpression)new MySqlHavingExpressionVisitor(_sqlExpressionFactory).Visit(selectExpression);
 
             // Run the compatibility checks as late in the query pipeline (before the actual SQL translation happens) as reasonable.
             selectExpression = (SelectExpression)new MySqlCompatibilityExpressionVisitor(_options).Visit(selectExpression);

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.MySql.cs
@@ -40,7 +40,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                 assertOrder: true);
 
             AssertSql(
-                @"SELECT EXTRACT(year FROM `o`.`OrderDate`) AS `Year`, COUNT(*) AS `Count`, (EXTRACT(year FROM `o`.`OrderDate`) = 1995) AND EXTRACT(year FROM `o`.`OrderDate`) IS NOT NULL AS `having`
+                @"SELECT EXTRACT(year FROM `o`.`OrderDate`) AS `Year`, COUNT(*) AS `Count`, EXTRACT(year FROM `o`.`OrderDate`) = 1995 AS `having`
 FROM `Orders` AS `o`
 WHERE (`o`.`CustomerID` = 'ALFKI') AND `o`.`OrderDate` IS NOT NULL
 GROUP BY `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`), `having`


### PR DESCRIPTION
Applies the workaround late in the query translation pipeline, instead of just after the main translation process.

Also limits the workaround to HAVING clauses _without_ aggregate functions.
HAVING clauses _with_ aggregate seems to work just fine without the workaround.

(The whole workaround does not work correctly for MySQL 5.6., but we just dropped support for it, since it reached its end-of-life in February, so it's fine.)