### PR TITLE
 Add support for table options

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlEntityTypeBuilderExtensions.cs
@@ -468,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore
             UpdateTableOption(name, value, options);
             var optionsString = MySqlEntityTypeExtensions.SerializeTableOptions(options);
 
-            return entityTypeBuilder.CanSetAnnotation(MySqlAnnotationNames.TableOptions, optionsString, fromDataAnnotation);
+            return entityTypeBuilder.CanSetAnnotation(MySqlAnnotationNames.StoreOptions, optionsString, fromDataAnnotation);
         }
 
         private static void UpdateTableOption(string key, string value, Dictionary<string, string> options)

--- a/src/EFCore.MySql/Extensions/MySqlEntityTypeExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlEntityTypeExtensions.cs
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion CollationDelegation
 
-        #region TableOptions
+        #region StoreOptions
 
         /// <summary>
         /// Gets the MySQL table options for the table associated with this entity.
@@ -280,7 +280,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> A dictionary of table options. </returns>
         public static Dictionary<string, string> GetTableOptions([NotNull] this IReadOnlyEntityType entityType)
-            => DeserializeTableOptions(entityType[MySqlAnnotationNames.TableOptions] as string);
+            => DeserializeTableOptions(entityType[MySqlAnnotationNames.StoreOptions] as string);
 
         /// <summary>
         /// Sets the MySQL table options for the table associated with this entity.
@@ -290,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore
         public static void SetTableOptions(
             [NotNull] this IMutableEntityType entityType,
             [CanBeNull] Dictionary<string, string> options)
-            => entityType.SetOrRemoveAnnotation(MySqlAnnotationNames.TableOptions, SerializeTableOptions(options));
+            => entityType.SetOrRemoveAnnotation(MySqlAnnotationNames.StoreOptions, SerializeTableOptions(options));
 
         /// <summary>
         /// Sets the MySQL table options for the table associated with this entity.
@@ -304,7 +304,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] Dictionary<string, string> options,
             bool fromDataAnnotation = false)
         {
-            entityType.SetOrRemoveAnnotation(MySqlAnnotationNames.TableOptions, SerializeTableOptions(options), fromDataAnnotation);
+            entityType.SetOrRemoveAnnotation(MySqlAnnotationNames.StoreOptions, SerializeTableOptions(options), fromDataAnnotation);
 
             return options;
         }
@@ -315,7 +315,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The configuration source. </returns>
         public static ConfigurationSource? GetTableOptionsConfigurationSource([NotNull] this IConventionEntityType entityType)
-            => entityType.FindAnnotation(MySqlAnnotationNames.TableOptions)?.GetConfigurationSource();
+            => entityType.FindAnnotation(MySqlAnnotationNames.StoreOptions)?.GetConfigurationSource();
 
         internal static string SerializeTableOptions(Dictionary<string, string> options)
         {
@@ -376,6 +376,6 @@ namespace Microsoft.EntityFrameworkCore
             return options;
         }
 
-        #endregion TableOptions
+        #endregion StoreOptions
     }
 }

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
@@ -34,6 +34,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
         public const string IndexPrefixLength = Prefix + "IndexPrefixLength";
         public const string SpatialReferenceSystemId = Prefix + "SpatialReferenceSystemId";
         public const string GuidCollation = Prefix + "GuidCollation";
+        public const string TableOptions = Prefix + "TableOptions";
 
         [Obsolete("Use '" + nameof(RelationalAnnotationNames) + "." + nameof(RelationalAnnotationNames.Collation) + "' instead.")]
         public const string Collation = Prefix + "Collation";

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationNames.cs
@@ -34,7 +34,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
         public const string IndexPrefixLength = Prefix + "IndexPrefixLength";
         public const string SpatialReferenceSystemId = Prefix + "SpatialReferenceSystemId";
         public const string GuidCollation = Prefix + "GuidCollation";
-        public const string TableOptions = Prefix + "TableOptions";
+        public const string StoreOptions = Prefix + "StoreOptions";
 
         [Obsolete("Use '" + nameof(RelationalAnnotationNames) + "." + nameof(RelationalAnnotationNames.Collation) + "' instead.")]
         public const string Collation = Prefix + "Collation";

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
@@ -84,7 +84,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
             foreach (var annotation in entityType.GetAnnotations()
                 .Where(a => a.Name is MySqlAnnotationNames.CharSetDelegation or
                                       MySqlAnnotationNames.CollationDelegation or
-                                      MySqlAnnotationNames.TableOptions))
+                                      MySqlAnnotationNames.StoreOptions))
             {
                 yield return annotation;
             }

--- a/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
+++ b/src/EFCore.MySql/Metadata/Internal/MySqlAnnotationProvider.cs
@@ -83,7 +83,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Internal
             // Handle other annotations (including the delegation annotations).
             foreach (var annotation in entityType.GetAnnotations()
                 .Where(a => a.Name is MySqlAnnotationNames.CharSetDelegation or
-                                      MySqlAnnotationNames.CollationDelegation))
+                                      MySqlAnnotationNames.CollationDelegation or
+                                      MySqlAnnotationNames.TableOptions))
             {
                 yield return annotation;
             }

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -352,7 +352,7 @@ DELIMITER ;";
             }
 
             tableOptions.AddRange(
-                MySqlEntityTypeExtensions.DeserializeTableOptions(operation[MySqlAnnotationNames.TableOptions] as string)
+                MySqlEntityTypeExtensions.DeserializeTableOptions(operation[MySqlAnnotationNames.StoreOptions] as string)
                     .Select(kvp => (kvp.Key, kvp.Value)));
 
             foreach (var (key, value) in tableOptions)
@@ -440,8 +440,8 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
                 EndStatement(builder);
             }
 
-            var oldTableOptions = MySqlEntityTypeExtensions.DeserializeTableOptions(operation.OldTable[MySqlAnnotationNames.TableOptions] as string);
-            var newTableOptions = MySqlEntityTypeExtensions.DeserializeTableOptions(operation[MySqlAnnotationNames.TableOptions] as string);
+            var oldTableOptions = MySqlEntityTypeExtensions.DeserializeTableOptions(operation.OldTable[MySqlAnnotationNames.StoreOptions] as string);
+            var newTableOptions = MySqlEntityTypeExtensions.DeserializeTableOptions(operation[MySqlAnnotationNames.StoreOptions] as string);
             var addedOrChangedTableOptions = newTableOptions.Except(oldTableOptions).ToArray();
 
             if (addedOrChangedTableOptions.Length > 0)

--- a/test/EFCore.MySql.FunctionalTests/MigrationsInfrastructureMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsInfrastructureMySqlTest.cs
@@ -27,7 +27,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
-) CHARACTER SET utf8mb4;
+) CHARACTER SET=utf8mb4;
 
 ",
                 Sql,
@@ -43,7 +43,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
-) CHARACTER SET utf8mb4;
+) CHARACTER SET=utf8mb4;
 
 ",
                 Sql,
@@ -59,7 +59,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
-) CHARACTER SET utf8mb4;
+) CHARACTER SET=utf8mb4;
 
 START TRANSACTION;
 
@@ -141,7 +141,7 @@ COMMIT;
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
-) CHARACTER SET utf8mb4;
+) CHARACTER SET=utf8mb4;
 
 START TRANSACTION;
 
@@ -404,7 +404,7 @@ COMMIT;
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
-) CHARACTER SET utf8mb4;
+) CHARACTER SET=utf8mb4;
 
 CREATE TABLE `Table1` (
     `Id` int NOT NULL,
@@ -437,7 +437,7 @@ VALUES ('00000000000003_Migration3', '7.0.0-test');
     `MigrationId` varchar(150) CHARACTER SET utf8mb4 NOT NULL,
     `ProductVersion` varchar(32) CHARACTER SET utf8mb4 NOT NULL,
     CONSTRAINT `PK___EFMigrationsHistory` PRIMARY KEY (`MigrationId`)
-) CHARACTER SET utf8mb4;
+) CHARACTER SET=utf8mb4;
 
 
 DROP PROCEDURE IF EXISTS MigrationsScript;

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -251,7 +251,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         //         {
         //             var table = Assert.Single(model.Tables);
         //             var options = (IDictionary<string, string>)MySqlEntityTypeExtensions.DeserializeTableOptions(
-        //                 table.FindAnnotation(MySqlAnnotationNames.TableOptions)?.Value as string);
+        //                 table.FindAnnotation(MySqlAnnotationNames.StoreOptions)?.Value as string);
         //
         //             Assert.Contains("CHECKSUM", options);
         //             Assert.Equal("1", options["CHECKSUM"]);

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -231,6 +232,36 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.GeneratedColumns))]
         public override Task Alter_column_change_computed()
             => base.Alter_column_change_computed();
+
+        // We currently do not scaffold table options.
+        //
+        // [ConditionalFact]
+        // public virtual async Task Create_table_with_table_options()
+        // {
+        //     await Test(
+        //         builder => { },
+        //         builder => builder.Entity(
+        //             "IceCream", e =>
+        //             {
+        //                 e.Property<int>("IceCreamId");
+        //                 e.HasTableOption("CHECKSUM", "1");
+        //                 e.HasTableOption("MAX_ROWS", "100");
+        //             }),
+        //         model =>
+        //         {
+        //             var table = Assert.Single(model.Tables);
+        //             var options = (IDictionary<string, string>)MySqlEntityTypeExtensions.DeserializeTableOptions(
+        //                 table.FindAnnotation(MySqlAnnotationNames.TableOptions)?.Value as string);
+        //
+        //             Assert.Contains("CHECKSUM", options);
+        //             Assert.Equal("1", options["CHECKSUM"]);
+        //
+        //             Assert.Contains("MAX_ROWS", options);
+        //             Assert.Equal("100", options["MAX_ROWS"]);
+        //         });
+        //
+        //     AssertSql(@"");
+        // }
 
         [ConditionalFact]
         public virtual async Task Add_columns_with_collations()

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -320,7 +320,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 //
                 $@"CREATE TABLE `IceCream` (
     `IceCreamId` char(36) COLLATE ascii_general_ci NOT NULL
-) COLLATE {DefaultCollation};");
+) COLLATE={DefaultCollation};");
         }
 
         [ConditionalFact]
@@ -348,7 +348,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 //
                 $@"CREATE TABLE `IceCream` (
     `IceCreamId` char(36) COLLATE {NonDefaultCollation} NOT NULL
-) COLLATE {DefaultCollation};");
+) COLLATE={DefaultCollation};");
         }
 
         [ConditionalFact]
@@ -376,7 +376,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 //
                 $@"CREATE TABLE `IceCream` (
     `IceCreamId` char(36) COLLATE {NonDefaultCollation} NOT NULL
-) COLLATE {DefaultCollation};");
+) COLLATE={DefaultCollation};");
         }
 
         [ConditionalFact]
@@ -404,7 +404,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 //
                 $@"CREATE TABLE `IceCream` (
     `IceCreamId` char(36) NOT NULL
-) COLLATE {DefaultCollation};");
+) COLLATE={DefaultCollation};");
         }
 
         [ConditionalFact]
@@ -487,7 +487,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 });
 
             AssertSql(
-                $"ALTER TABLE `IceCream` COLLATE {NonDefaultCollation2};",
+                $"ALTER TABLE `IceCream` COLLATE={NonDefaultCollation2};",
                 //
                 $@"ALTER TABLE `IceCream` MODIFY COLUMN `Name` longtext COLLATE {NonDefaultCollation} NULL;",
                 //
@@ -566,7 +566,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 result => { });
 
             AssertSql(
-                $@"ALTER TABLE `IceCream` COLLATE {DefaultCollation};",
+                $@"ALTER TABLE `IceCream` COLLATE={DefaultCollation};",
                 //
                 $@"ALTER TABLE `IceCream` MODIFY COLUMN `Name` longtext COLLATE {NonDefaultCollation} NULL;",
                 //
@@ -609,7 +609,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
     `Brand` longtext CHARACTER SET {NonDefaultCharSet} NULL,
     `IceCreamId` int NOT NULL,
     `Name` longtext COLLATE {DefaultCollation} NULL
-) COLLATE {DefaultCollation};");
+) COLLATE={DefaultCollation};");
         }
 
         [ConditionalFact]
@@ -648,7 +648,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
     `Brand` longtext COLLATE {NonDefaultCollation2} NULL,
     `IceCreamId` int NOT NULL,
     `Name` longtext CHARACTER SET {NonDefaultCharSet} NULL
-) CHARACTER SET {NonDefaultCharSet};");
+) CHARACTER SET={NonDefaultCharSet};");
         }
 
         [ConditionalFact]

--- a/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
@@ -1351,7 +1351,7 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;" + EOL,
                     {
                         Columns = new[] { "Name" }
                     },
-                    [MySqlAnnotationNames.TableOptions] = "CHECKSUM=1,MAX_ROWS=100",
+                    [MySqlAnnotationNames.StoreOptions] = "CHECKSUM=1,MAX_ROWS=100",
                 });
 
             Assert.Equal(
@@ -1385,8 +1385,8 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;" + EOL,
                 migrationBuilder =>
                 {
                     migrationBuilder.AlterTable("IceCreams")
-                        .OldAnnotation(MySqlAnnotationNames.TableOptions, "CHECKSUM=1,MAX_ROWS=100")
-                        .Annotation(MySqlAnnotationNames.TableOptions, "CHECKSUM=1,MIN_ROWS=20,MAX_ROWS=200");
+                        .OldAnnotation(MySqlAnnotationNames.StoreOptions, "CHECKSUM=1,MAX_ROWS=100")
+                        .Annotation(MySqlAnnotationNames.StoreOptions, "CHECKSUM=1,MIN_ROWS=20,MAX_ROWS=200");
                 });
 
             Assert.Equal(

--- a/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
@@ -1136,7 +1136,7 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
     `Brand` longtext COLLATE latin1_swedish_ci NOT NULL,
     `Name` varchar(255) NOT NULL,
     PRIMARY KEY (`Name`, `Brand`(20))
-) COLLATE latin1_general_ci;" + EOL,
+) COLLATE=latin1_general_ci;" + EOL,
                 Sql,
                 ignoreLineEndingDifferences: true);
         }
@@ -1169,7 +1169,7 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
                 });
 
             Assert.Equal(
-                @"ALTER TABLE `IceCreams` COLLATE latin1_general_cs;" + EOL,
+                @"ALTER TABLE `IceCreams` COLLATE=latin1_general_cs;" + EOL,
                 Sql,
                 ignoreLineEndingDifferences: true);
         }
@@ -1251,7 +1251,7 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;" + EOL,
     `Brand` longtext CHARACTER SET utf8mb4 NOT NULL,
     `Name` varchar(255) NOT NULL,
     PRIMARY KEY (`Name`, `Brand`(20))
-) CHARACTER SET latin1;" + EOL,
+) CHARACTER SET=latin1;" + EOL,
                 Sql,
                 ignoreLineEndingDifferences: true);
         }
@@ -1284,7 +1284,7 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;" + EOL,
                 });
 
             Assert.Equal(
-                @"ALTER TABLE `IceCreams` CHARACTER SET utf8mb4;" + EOL,
+                @"ALTER TABLE `IceCreams` CHARACTER SET=utf8mb4;" + EOL,
                 Sql,
                 ignoreLineEndingDifferences: true);
         }


### PR DESCRIPTION
This introduces the possibility to set table options for entities.
Use multipile `HasTableOption()` Fluent API calls for multiple table options.

They are supported in migrations, but are currently not scaffolded when reverse engineering from an existing database (deliberate choice).

This is more of a general purpose fallback mechanism, for missing Fluent API methods.
We might add warnings later, when using table options for which other Fluent API calls should be used (e.g. `CHARACTER SET`).

**Use it with care, and only for options you cannot set otherwise.**

Fixes #84
Fixes #217
Fixes #709
Fixes #777