### PR TITLE
Allow options initialization without available connection string

### DIFF
--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -208,19 +208,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
         }
 
         private static MySqlConnectionSettings GetConnectionSettings(MySqlOptionsExtension relationalOptions)
-        {
-            if (relationalOptions.Connection != null)
-            {
-                return new MySqlConnectionSettings(relationalOptions.Connection);
-            }
-
-            if (relationalOptions.ConnectionString != null)
-            {
-                return new MySqlConnectionSettings(relationalOptions.ConnectionString);
-            }
-
-            throw new InvalidOperationException(RelationalStrings.NoConnectionOrConnectionString);
-        }
+            => relationalOptions.Connection != null
+                ? new MySqlConnectionSettings(relationalOptions.Connection)
+                : new MySqlConnectionSettings(relationalOptions.ConnectionString);
 
         protected virtual bool Equals(MySqlOptions other)
         {

--- a/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlDbContextOptionsExtensionsTest.cs
@@ -340,5 +340,32 @@ namespace Pomelo.EntityFrameworkCore.MySql
             Assert.Equal(serverVersion.Type, mySqlOptions.ServerVersion.Type);
             Assert.Equal(serverVersion.TypeIdentifier, mySqlOptions.ServerVersion.TypeIdentifier);
         }
+
+        [Fact]
+        public void UseMySql_without_connection_string()
+        {
+            var builder = new DbContextOptionsBuilder();
+            var serverVersion = ServerVersion.AutoDetect(AppConfig.ConnectionString);
+
+            builder.UseMySql(serverVersion);
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+        }
+
+        [Fact]
+        public void UseMySql_without_connection_explicit_DefaultDataTypeMappings_is_applied()
+        {
+            var builder = new DbContextOptionsBuilder();
+
+            builder.UseMySql(
+                AppConfig.ServerVersion,
+                b => b.DefaultDataTypeMappings(m => m.WithClrBoolean(MySqlBooleanType.Bit1)));
+
+            var mySqlOptions = new MySqlOptions();
+            mySqlOptions.Initialize(builder.Options);
+
+            Assert.Equal(MySqlBooleanType.Bit1, mySqlOptions.DefaultDataTypeMappings.ClrBoolean);
+        }
     }
 }


### PR DESCRIPTION
This allows you to call the `UseMySql(ServerVersion, Action<MySqlDbContextOptionsBuilder>)`, that does not demand a connection string until a database connection actually needs to be opened.

Fixes #1464