### PR TITLE
Add ServerVersion.Create() method

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbContextOptionsBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Data.Common;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -36,11 +37,14 @@ namespace Microsoft.EntityFrameworkCore
         ///         The version of the database server.
         ///     </para>
         ///     <para>
-        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
-        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
-        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
-        ///         database server), or by parsing a version string using the static methods
-        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
         ///      </para>
         /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
@@ -72,11 +76,14 @@ namespace Microsoft.EntityFrameworkCore
         ///         The version of the database server.
         ///     </para>
         ///     <para>
-        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
-        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
-        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
-        ///         database server), or by parsing a version string using the static methods
-        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
         ///      </para>
         /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
@@ -123,11 +130,14 @@ namespace Microsoft.EntityFrameworkCore
         ///         The version of the database server.
         ///     </para>
         ///     <para>
-        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
-        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
-        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
-        ///         database server), or by parsing a version string using the static methods
-        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
         ///      </para>
         /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
@@ -190,11 +200,14 @@ namespace Microsoft.EntityFrameworkCore
         ///         The version of the database server.
         ///     </para>
         ///     <para>
-        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
-        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
-        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
-        ///         database server), or by parsing a version string using the static methods
-        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
         ///      </para>
         /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
@@ -218,11 +231,14 @@ namespace Microsoft.EntityFrameworkCore
         ///         The version of the database server.
         ///     </para>
         ///     <para>
-        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
-        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
-        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
-        ///         database server), or by parsing a version string using the static methods
-        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
         ///      </para>
         /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
@@ -251,11 +267,14 @@ namespace Microsoft.EntityFrameworkCore
         ///         The version of the database server.
         ///     </para>
         ///     <para>
-        ///         Create an object for this parameter from the classes <see cref="MySqlServerVersion"/> (for MySQL) and
-        ///         <see cref="MariaDbServerVersion"/> (for MariaDB), through a call to the static method
-        ///         <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly from the
-        ///         database server), or by parsing a version string using the static methods
-        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>.
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
         ///      </para>
         /// </param>
         /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>

--- a/src/EFCore.MySql/Infrastructure/ServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerVersion.cs
@@ -196,5 +196,40 @@ namespace Microsoft.EntityFrameworkCore
 
             return serverVersion != null;
         }
+
+        /// <summary>
+        /// Creates a <see cref="ServerVersion"/> object from a version and type.
+        /// </summary>
+        /// <param name="version">The <see cref="Version"/> of the database server.</param>
+        /// <param name="serverType">The <see cref="ServerType"/> of the database server.</param>
+        /// <returns>The <see cref="ServerVersion"/>.</returns>
+        /// <remarks>
+        /// Call this static method to obtain a <see cref="ServerVersion"/> object to use in a `UseMySql()` call.
+        /// Alternatively, directly instantiate an instance of the <see cref="MySqlServerVersion"/> or <see cref="MariaDbServerVersion"/>
+        /// classes using <see langword="new"/>, or call the static `Parse()`, `TryParse()` or `AutoDetect()` methods.
+        /// </remarks>
+        public static ServerVersion Create(Version version, ServerType serverType)
+            => serverType switch
+            {
+                ServerType.MySql => new MySqlServerVersion(version),
+                ServerType.MariaDb => new MariaDbServerVersion(version),
+                _ => throw new ArgumentOutOfRangeException(nameof(serverType), serverType, null)
+            };
+
+        /// <summary>
+        /// Creates a <see cref="ServerVersion"/> object from a version and type.
+        /// </summary>
+        /// <param name="major">The major version of the database server.</param>
+        /// <param name="minor">The minor version of the database server.</param>
+        /// <param name="patch">The patch level of the database server.</param>
+        /// <param name="serverType">The <see cref="ServerType"/> of the database server.</param>
+        /// <returns>The <see cref="ServerVersion"/>.</returns>
+        /// <remarks>
+        /// Call this static method to obtain a <see cref="ServerVersion"/> object to use in a `UseMySql()` call.
+        /// Alternatively, directly instantiate an instance of the <see cref="MySqlServerVersion"/> or <see cref="MariaDbServerVersion"/>
+        /// classes using <see langword="new"/>, or call the static `Parse()`, `TryParse()` or `AutoDetect()` methods.
+        /// </remarks>
+        public static ServerVersion Create(int major, int minor, int patch, ServerType serverType)
+            => Create(new Version(major, minor, patch), serverType);
     }
 }


### PR DESCRIPTION
Adds support for calls like the following, instead of newing-up an object from the `MySqlServerVersion` and `MariaDbServerVersion` classes directly:

```c#
var serverVersion1 = ServerVersion.Create(new Version(8, 0, 25), ServerType.MySql);
var serverVersion2 = ServerVersion.Create(10, 5, 11, ServerType.MariaDb);
```

Fixes #1262