### PR TITLE
Add workaround for MySQL bug 104294

### DIFF
--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -81,6 +81,7 @@ namespace Microsoft.EntityFrameworkCore
             public override bool ImplicitBoolCheckUsesIndex => ServerVersion.Version >= new Version(8, 0, 0); // Exact version has not been verified yet
             public override bool MySqlBug96947Workaround => ServerVersion.Version >= new Version(5, 7, 0) &&
                                                             ServerVersion.Version < new Version(8, 0, 25); // Exact version has not been verified yet, but it is 5.7.x and could very well be 5.7.0
+            public override bool MySqlBug104294Workaround => ServerVersion.Version >= new Version(8, 0, 0); // Exact version has not been determined yet
             public override bool FullTextParser => ServerVersion.Version >= new Version(5, 7, 3);
             public override bool InformationSchemaCheckConstraintsTable => ServerVersion.Version >= new Version(8, 0, 16); // MySQL is missing the explicit TABLE_NAME column that MariaDB supports, so always join the TABLE_CONSTRAINTS table when accessing CHECK_CONSTRAINTS for any database server that supports CHECK_CONSTRAINTS.
             public override bool MySqlBugLimit0Offset0ExistsWorkaround => true;

--- a/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerVersionSupport.cs
@@ -79,6 +79,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
         public virtual bool ImplicitBoolCheckUsesIndex => false;
         public virtual bool Sequences => false;
         public virtual bool MySqlBug96947Workaround => false;
+        public virtual bool MySqlBug104294Workaround => false;
         public virtual bool FullTextParser => false;
         public virtual bool InformationSchemaCheckConstraintsTable => false;
         public virtual bool IdentifyJsonColumsByCheckConstraints => false;

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/MySqlDatabaseModelFactoryTest.cs
@@ -676,6 +676,29 @@ CREATE TABLE `ComputedValues` (
                 @"DROP TABLE IF EXISTS `ComputedValues`");
 
         [ConditionalFact]
+        [SupportedServerVersionCondition(nameof(ServerVersionSupport.GeneratedColumns))]
+        public void Computed_value_virtual_using_constant_string()
+            => Test(@"
+CREATE TABLE `Users` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `FirstName` varchar(150) NOT NULL,
+  `LastName` varchar(150) NOT NULL,
+  `FullName` varchar(301) GENERATED ALWAYS AS (concat(`FirstName`, _utf8mb4' ', `LastName`)) VIRTUAL,
+  PRIMARY KEY (`id`)
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single().Columns;
+
+                    var column = columns.Single(c => c.Name == "FullName");
+                    Assert.Equal(@"concat(`FirstName`,_utf8mb4' ',`LastName`)", column.ComputedColumnSql);
+                    Assert.False(column.IsStored);
+                },
+                @"DROP TABLE IF EXISTS `Users`");
+
+        [ConditionalFact]
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.AlternativeDefaultExpression))]
         public void Default_value_curdate_mariadb()
         {


### PR DESCRIPTION
Removes one level of string escaping from generated/computed columns for MySQL 8+ when scaffolding.

The exact version of MySQL, where this issue appeared first, has not been determined yet.
It is not an issue in MySQL 5.7 though (an also not in any MariaDB version).

Fixes #1472