### PR TITLE
Add support for default value expression syntax

### DIFF
--- a/src/EFCore.MySql/Diagnostics/Internal/MySqlLoggingDefinitions.cs
+++ b/src/EFCore.MySql/Diagnostics/Internal/MySqlLoggingDefinitions.cs
@@ -38,5 +38,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Diagnostics.Internal
         public EventDefinitionBase LogPrincipalColumnNotFound;
 
         public EventDefinitionBase LogReflexiveConstraintIgnored;
+
+        public EventDefinitionBase LogDefaultValueNotSupported;
     }
 }

--- a/src/EFCore.MySql/Diagnostics/MySqlEventId.cs
+++ b/src/EFCore.MySql/Diagnostics/MySqlEventId.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Logging;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
+    // CHECK: Ensure usage of Events/warnings.
+
     /// <summary>
     ///     <para>
     ///         Event IDs for MySql events that correspond to messages logged to an <see cref="ILogger" />
@@ -29,37 +31,38 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DecimalTypeDefaultWarning = CoreEventId.ProviderBaseId,
             ByteIdentityColumnWarning,
 
-            // Scaffolding events
-            ColumnFound = CoreEventId.ProviderDesignBaseId,
-            ColumnNotNamedWarning,
-            ColumnSkipped,
-            DefaultSchemaFound,
-            ForeignKeyColumnFound,
-            ForeignKeyColumnMissingWarning,
-            ForeignKeyColumnNotNamedWarning,
-            ForeignKeyColumnsNotMappedWarning,
-            ForeignKeyNotNamedWarning,
-            ForeignKeyReferencesMissingPrincipalTableWarning,
-            IndexColumnFound,
-            IndexColumnNotNamedWarning,
-            IndexColumnSkipped,
-            IndexColumnsNotMappedWarning,
-            IndexNotNamedWarning,
-            IndexTableMissingWarning,
-            MissingSchemaWarning,
-            MissingTableWarning,
-            SequenceFound,
-            SequenceNotNamedWarning,
-            TableFound,
-            TableSkipped,
-            TypeAliasFound,
-            ForeignKeyTableMissingWarning,
-            PrimaryKeyFound,
-            UniqueConstraintFound,
-            IndexFound,
-            ForeignKeyFound,
-            ForeignKeyPrincipalColumnMissingWarning,
-            ReflexiveConstraintIgnored
+            // Design events
+            ColumnFound = CoreEventId.ProviderDesignBaseId, // scaffolding
+            ColumnNotNamedWarning, // scaffolding
+            ColumnSkipped, // scaffolding
+            DefaultSchemaFound, // scaffolding
+            ForeignKeyColumnFound, // scaffolding
+            ForeignKeyColumnMissingWarning, // scaffolding
+            ForeignKeyColumnNotNamedWarning, // scaffolding
+            ForeignKeyColumnsNotMappedWarning, // scaffolding
+            ForeignKeyNotNamedWarning, // scaffolding
+            ForeignKeyReferencesMissingPrincipalTableWarning, // scaffolding
+            IndexColumnFound, // scaffolding
+            IndexColumnNotNamedWarning, // scaffolding
+            IndexColumnSkipped, // scaffolding
+            IndexColumnsNotMappedWarning, // scaffolding
+            IndexNotNamedWarning, // scaffolding
+            IndexTableMissingWarning, // scaffolding
+            MissingSchemaWarning, // scaffolding
+            MissingTableWarning, // scaffolding
+            SequenceFound, // scaffolding
+            SequenceNotNamedWarning, // scaffolding
+            TableFound, // scaffolding
+            TableSkipped, // scaffolding
+            TypeAliasFound, // scaffolding
+            ForeignKeyTableMissingWarning, // scaffolding
+            PrimaryKeyFound, // scaffolding
+            UniqueConstraintFound, // scaffolding
+            IndexFound, // scaffolding
+            ForeignKeyFound, // scaffolding
+            ForeignKeyPrincipalColumnMissingWarning, // scaffolding
+            ReflexiveConstraintIgnored, // scaffolding
+            DefaultValueExpressionNotSupportedWarning, // migrations
         }
 
         private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
@@ -93,6 +96,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
         private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
+
+        private static readonly string _migrationsPrefix = DbLoggerCategory.Migrations.Name + ".";
+        private static EventId MakeMigrationsId(Id id) => new EventId((int)id, _migrationsPrefix + id);
 
         /// <summary>
         ///     A column was found.
@@ -289,5 +295,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ReflexiveConstraintIgnored = MakeScaffoldingId(Id.ReflexiveConstraintIgnored);
+
+        /// <summary>
+        ///     A default value expression was used in conjunction wiht a column type and database server version that is not supported.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        /// </summary>
+        public static readonly EventId DefaultValueNotSupportedWarning = MakeMigrationsId(Id.DefaultValueExpressionNotSupportedWarning);
     }
 }

--- a/src/EFCore.MySql/Internal/MySqlLoggerExtensions.cs
+++ b/src/EFCore.MySql/Internal/MySqlLoggerExtensions.cs
@@ -417,5 +417,27 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
 
             // No DiagnosticsSource events because these are purely design-time messages
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static void DefaultValueNotSupportedWarning(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] string defaultValue,
+            [NotNull] ServerVersion serverVersion,
+            [NotNull] string columnType)
+        {
+            var definition = MySqlResources.LogDefaultValueNotSupported(diagnostics);
+
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics, defaultValue, serverVersion.ToString(), columnType);
+            }
+
+            // No DiagnosticsSource events because these are purely design-time messages
+        }
     }
 }

--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
@@ -122,8 +122,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
                 {
                     alterColumnOperation.DefaultValue = null;
 
-                    yield return alterColumnOperation;
-
                     yield return new UpdateDataOperation
                     {
                         IsDestructiveChange = true,
@@ -136,6 +134,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
                         ColumnTypes = new[] { alterColumnOperation.ColumnType },
                         Values = new object[,] { { string.Empty } }
                     };
+
+                    yield return alterColumnOperation;
                 }
                 else
                 {

--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
@@ -23,6 +23,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
 {
     public class MySqlMigrationsModelDiffer : MigrationsModelDiffer
     {
+        // CHECK: Might be a good use case for runtime annotations.
+        protected static class InternalLocalAnnotationNames
+        {
+            public const string InternalLocalPrefix = MySqlAnnotationNames.Prefix + "Internal:MigrationsModelDiffer:";
+
+            public const string ExecuteBefore = InternalLocalPrefix + "ExecuteBefore";
+        }
+
         public MySqlMigrationsModelDiffer(
             [NotNull] IRelationalTypeMappingSource typeMappingSource,
             [NotNull] IMigrationsAnnotationProvider migrationsAnnotations,
@@ -36,6 +44,52 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
                 updateAdapterFactory,
                 commandBatchPreparerDependencies)
         {
+        }
+
+        public override IReadOnlyList<MigrationOperation> GetDifferences(IRelationalModel source, IRelationalModel target)
+        {
+            var operations = base.GetDifferences(source, target);
+
+            // Ensure that we don't leak internal local annotations.
+            AssertInternalLocalAnnotations(operations);
+
+            return operations;
+        }
+
+        protected override IReadOnlyList<MigrationOperation> Sort(IEnumerable<MigrationOperation> operations, DiffContext diffContext)
+        {
+            // EF Core sorts all migration operations in a predefined order.
+            // So because we want to execute certain operations in specific relation to one another, we anchor those operations via an
+            // internal annotation to each other and relocate them after EF Core is done sorting.
+
+            var sortedOperations = base.Sort(operations, diffContext);
+
+            var anchoredOperations = new List<MigrationOperation>();
+            var finalOperations = new List<MigrationOperation>();
+
+            foreach (var operation in sortedOperations)
+            {
+                if (operation[InternalLocalAnnotationNames.ExecuteBefore] is MigrationOperation)
+                {
+                    anchoredOperations.Add(operation);
+                }
+                else
+                {
+                    finalOperations.Add(operation);
+                }
+            }
+
+            foreach (var anchoredOperation in anchoredOperations)
+            {
+                var targetOperation = (MigrationOperation)anchoredOperation[InternalLocalAnnotationNames.ExecuteBefore];
+                var targetOperationIndex = finalOperations.IndexOf(targetOperation);
+
+                finalOperations.Insert(targetOperationIndex, anchoredOperation);
+
+                anchoredOperation[InternalLocalAnnotationNames.ExecuteBefore] = null;
+            }
+
+            return finalOperations;
         }
 
         protected override IEnumerable<MigrationOperation> Add(IRelationalModel target, DiffContext diffContext)
@@ -132,7 +186,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
                         KeyValues = new object[,] { { null } },
                         Columns = new[] { alterColumnOperation.Name },
                         ColumnTypes = new[] { alterColumnOperation.ColumnType },
-                        Values = new object[,] { { string.Empty } }
+                        Values = new object[,] { { string.Empty } },
+                        [InternalLocalAnnotationNames.ExecuteBefore] = alterColumnOperation,
                     };
 
                     yield return alterColumnOperation;
@@ -319,7 +374,23 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
                 .FirstOrDefault() is string unexpectedProperty)
             {
                 throw new InvalidOperationException(
-                    $"The 'MigrationOperation' of type '{operation.GetType().Name}' contains an unexpected property '{unexpectedProperty}'.");
+                    $"The migration operation of type '{operation.GetType().Name}' contains an unexpected property '{unexpectedProperty}'.");
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void AssertInternalLocalAnnotations(IReadOnlyList<MigrationOperation> operations)
+        {
+            foreach (var operation in operations)
+            {
+                foreach (var annotation in operation.GetAnnotations())
+                {
+                    if (annotation.Name.StartsWith(InternalLocalAnnotationNames.InternalLocalPrefix))
+                    {
+                        throw new InvalidOperationException(
+                            $"The migration operation of type '{operation.GetType().Name}' leaked the internal local annotation '{annotation.Name}'.");
+                    }
+                }
             }
         }
     }

--- a/src/EFCore.MySql/Properties/MySqlStrings.Designer.cs
+++ b/src/EFCore.MySql/Properties/MySqlStrings.Designer.cs
@@ -532,5 +532,30 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
 
             return (EventDefinition<string, string, string, string>)definition;
         }
+
+        /// <summary>
+        ///     The default value '{defaultValue}' is being ignored, because the database server version {version} does not support constant
+        ///     default values for type '{type}' and does not support default value expressions in general.
+        /// </summary>
+        public static EventDefinition<string, string, string> LogDefaultValueNotSupported([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((Diagnostics.Internal.MySqlLoggingDefinitions)logger.Definitions).LogDefaultValueNotSupported;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((Diagnostics.Internal.MySqlLoggingDefinitions)logger.Definitions).LogDefaultValueNotSupported,
+                    () => new EventDefinition<string, string, string>(
+                        logger.Options,
+                        MySqlEventId.DefaultValueNotSupportedWarning,
+                        LogLevel.Warning,
+                        "MySqlEventId.DefaultValueNotSupportedWarning",
+                        level => LoggerMessage.Define<string, string, string>(
+                            level,
+                            MySqlEventId.DefaultValueNotSupportedWarning,
+                            _resourceManager.GetString("LogDefaultValueNotSupported"))));
+            }
+
+            return (EventDefinition<string, string, string>)definition;
+        }
     }
 }

--- a/src/EFCore.MySql/Properties/MySqlStrings.resx
+++ b/src/EFCore.MySql/Properties/MySqlStrings.resx
@@ -231,4 +231,7 @@
   <data name="QueryUnableToTranslateMethodWithStringComparison" xml:space="preserve">
     <value>Translation of the '{declaringTypeName}.{methodName}' overload with a 'StringComparison' parameter is not supported by default. To opt-in to translations of methods with a 'StringComparison' parameter, call `{optionName}` on your MySQL specific 'DbContext' options. For general EF Core information about this error, see https://go.microsoft.com/fwlink/?linkid=2129535 for more information.</value>
   </data>
+  <data name="LogDefaultValueNotSupported" xml:space="preserve">
+    <value>The default value '{defaultValue}' is being ignored, because the database server version {version} does not support constant default values for type '{type}' and does not support default value expressions in general.</value>
+  </data>
 </root>

--- a/test/EFCore.MySql.FunctionalTests/DefaultValuesTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/DefaultValuesTest.cs
@@ -23,8 +23,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                 context.Database.EnsureDeleted();
                 context.Database.EnsureCreated();
 
-                var honeyDijon = context.Add(new KettleChips { Name = "Honey Dijon" }).Entity;
-                var buffaloBleu = context.Add(new KettleChips { Name = "Buffalo Bleu", BestBuyDate = new DateTime(2111, 1, 11) }).Entity;
+                var honeyDijon = context.Add(new KettleChips { Name = "Honey Dijon", AllergenLabeling = "Mustard" }).Entity;
+                var buffaloBleu = context.Add(new KettleChips { Name = "Buffalo Bleu", AllergenLabeling = "None", BestBuyDate = new DateTime(2111, 1, 11) }).Entity;
 
                 context.SaveChanges();
 
@@ -36,6 +36,50 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             {
                 Assert.Equal(new DateTime(2035, 9, 25), context.Chips.Single(c => c.Name == "Honey Dijon").BestBuyDate);
                 Assert.Equal(new DateTime(2111, 1, 11), context.Chips.Single(c => c.Name == "Buffalo Bleu").BestBuyDate);
+            }
+        }
+
+        [Fact]
+        public void Can_use_MySql_default_values_depending_on_expression_syntax()
+        {
+            using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                var seaSalt = context.Add(new KettleChips()).Entity;
+
+                context.SaveChanges();
+
+                if (AppConfig.ServerVersion.Supports.DefaultExpression ||
+                    AppConfig.ServerVersion.Supports.AlternativeDefaultExpression)
+                {
+                    Assert.Equal("Sea Salt", seaSalt.Name);
+                    Assert.Equal("None", seaSalt.AllergenLabeling);
+                }
+                else
+                {
+                    Assert.Null(seaSalt.Name);
+                    Assert.Null(seaSalt.AllergenLabeling);
+                }
+
+                Assert.Equal(new DateTime(2035, 9, 25), seaSalt.BestBuyDate);
+            }
+
+            using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
+            {
+                if (AppConfig.ServerVersion.Supports.DefaultExpression ||
+                    AppConfig.ServerVersion.Supports.AlternativeDefaultExpression)
+                {
+                    Assert.Equal("Sea Salt", context.Chips.Single().Name);
+                    Assert.Equal("None", context.Chips.Single().AllergenLabeling);
+                }
+                else
+                {
+                    Assert.Null(context.Chips.Single().Name);
+                    Assert.Null(context.Chips.Single().AllergenLabeling);
+                }
+                Assert.Equal(new DateTime(2035, 9, 25), context.Chips.Single().BestBuyDate);
             }
         }
 
@@ -66,16 +110,26 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
                     .UseInternalServiceProvider(_serviceProvider);
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<KettleChips>()
-                    .Property(e => e.BestBuyDate)
-                    .ValueGeneratedOnAdd()
-                    .HasDefaultValue(new DateTime(2035, 9, 25));
+                => modelBuilder.Entity<KettleChips>(
+                    entity =>
+                    {
+                        entity.Property(e => e.Name)
+                            .HasDefaultValue("Sea Salt");
+
+                        entity.Property(e => e.AllergenLabeling)
+                            .HasDefaultValueSql("('None')");
+
+                        entity.Property(e => e.BestBuyDate)
+                            .ValueGeneratedOnAdd()
+                            .HasDefaultValue(new DateTime(2035, 9, 25));
+                    });
         }
 
         private class KettleChips
         {
             public int Id { get; set; }
             public string Name { get; set; }
+            public string AllergenLabeling { get; set; }
             public DateTime BestBuyDate { get; set; }
         }
     }

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -65,11 +65,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             await base.Alter_column_make_required();
 
             AssertSql(
-                @"ALTER TABLE `People` MODIFY COLUMN `SomeColumn` longtext CHARACTER SET utf8mb4 NOT NULL;",
-                //
                 @"UPDATE `People` SET `SomeColumn` = ''
 WHERE `SomeColumn` IS NULL;
-SELECT ROW_COUNT();");
+SELECT ROW_COUNT();",
+                //
+                @"ALTER TABLE `People` MODIFY COLUMN `SomeColumn` longtext CHARACTER SET utf8mb4 NOT NULL;");
         }
 
         [ConditionalFact]
@@ -93,11 +93,11 @@ SELECT ROW_COUNT();");
                 });
 
             AssertSql(
-                @"ALTER TABLE `People` MODIFY COLUMN `SomeColumn` longtext CHARACTER SET utf8mb4 NOT NULL;",
-                //
                 @"UPDATE `People` SET `SomeColumn` = ''
 WHERE `SomeColumn` IS NULL;
-SELECT ROW_COUNT();");
+SELECT ROW_COUNT();",
+                //
+                @"ALTER TABLE `People` MODIFY COLUMN `SomeColumn` longtext CHARACTER SET utf8mb4 NOT NULL;");
         }
 
         [ConditionalFact]

--- a/test/EFCore.MySql.FunctionalTests/Query/ManyToManyFieldsLoadMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ManyToManyFieldsLoadMySqlTest.cs
@@ -34,11 +34,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                 modelBuilder
                     .SharedTypeEntity<Dictionary<string, object>>("JoinOneToThreePayloadFullShared")
                     .IndexerProperty<string>("Payload")
+                        .HasMaxLength(255)
                     .HasDefaultValue("Generated");
 
                 modelBuilder
                     .Entity<JoinOneToThreePayloadFull>()
                     .Property(e => e.Payload)
+                        .HasMaxLength(255)
                     .HasDefaultValue("Generated");
             }
         }


### PR DESCRIPTION
Improves the default value support in general by automatically switching to default value expression syntax where necessary, if supported by the underlying database server version.

Fixes #1476