### PR TITLE
Upgrade to EF Core 6.0.0-preview6

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -12,7 +12,7 @@
     <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
 
-    <PackageReference Update="MySqlConnector" Version="1.3.10" />
+    <PackageReference Update="MySqlConnector" Version="1.4.0-beta.1" />
 
     <PackageReference Update="NetTopologySuite" Version="2.3.0" />
     <PackageReference Update="System.Text.Json" Version="$(DependencyPreviewVersion)" />

--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup Label="Common Versions">
-    <DotnetRuntimeVersion>6.0.0-preview.5.21301.5</DotnetRuntimeVersion>
-    <EFCoreVersion>6.0.0-preview.5.21301.9</EFCoreVersion> <!-- [$(DotnetRuntimeVersion), 7.0.0) -->
+    <DotnetRuntimeVersion>6.0.0-preview.6.21352.12</DotnetRuntimeVersion>
+    <EFCoreVersion>6.0.0-preview.6.21352.1</EFCoreVersion> <!-- [$(DotnetRuntimeVersion), 7.0.0) -->
     <DependencyPreviewVersion>$(DotnetRuntimeVersion)</DependencyPreviewVersion>
-    <AspNetCoreVersion>6.0.0-preview.5.21301.17</AspNetCoreVersion>
+    <AspNetCoreVersion>6.0.0-preview.6.21355.2</AspNetCoreVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Dependencies">
@@ -14,7 +14,7 @@
 
     <PackageReference Update="MySqlConnector" Version="1.3.10" />
 
-    <PackageReference Update="NetTopologySuite" Version="2.2.0" />
+    <PackageReference Update="NetTopologySuite" Version="2.3.0" />
     <PackageReference Update="System.Text.Json" Version="$(DependencyPreviewVersion)" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,9 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
-    <DefaultNetCoreLegacyTargetFramework>net6.0</DefaultNetCoreLegacyTargetFramework>
-    <DefaultNetStandardTargetFramework>netstandard2.1</DefaultNetStandardTargetFramework>
+    <DefaultNetCoreTargetFramework>net6.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,37 +30,43 @@ jobs:
       MySQL 8.0 (Windows):
         vmImageName: 'windows-latest'
         databaseServerType: 'mysql'
-        databaseServerVersion: '8.0.25'
+        databaseServerVersion: '8.0.26'
         sqlMode: $(mysqlCurrentSqlMode)
         skipTests: $(skipWindowsTests)
       MySQL 8.0 (Linux):
         vmImageName: 'ubuntu-latest'
         databaseServerType: 'mysql'
-        databaseServerVersion: '8.0.25'
+        databaseServerVersion: '8.0.26'
         sqlMode: $(mysqlCurrentSqlMode)
         skipTests: false
       MySQL 5.7 (Linux):
         vmImageName: 'ubuntu-latest'
         databaseServerType: 'mysql'
-        databaseServerVersion: '5.7.34'
+        databaseServerVersion: '5.7.35'
         sqlMode: $(mysqlLegacySqlMode)
+        skipTests: false
+      MariaDB 10.6 (Linux):
+        vmImageName: 'ubuntu-latest'
+        databaseServerType: 'mariadb'
+        databaseServerVersion: '10.6.4'
+        sqlMode: $(mariadbSqlMode)
         skipTests: false
       MariaDB 10.5 (Linux):
         vmImageName: 'ubuntu-latest'
         databaseServerType: 'mariadb'
-        databaseServerVersion: '10.5.11'
+        databaseServerVersion: '10.5.12'
         sqlMode: $(mariadbSqlMode)
         skipTests: false
       MariaDB 10.4 (Linux):
         vmImageName: 'ubuntu-latest'
         databaseServerType: 'mariadb'
-        databaseServerVersion: '10.4.20'
+        databaseServerVersion: '10.4.21'
         sqlMode: $(mariadbSqlMode)
         skipTests: false
       MariaDB 10.3 (Linux):
         vmImageName: 'ubuntu-latest'
         databaseServerType: 'mariadb'
-        databaseServerVersion: '10.3.30'
+        databaseServerVersion: '10.3.31'
         sqlMode: $(mariadbSqlMode)
         skipTests: false
   pool:

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "6.0.0-preview.5.21301.9",
+      "version": "6.0.0-preview.6.21352.1",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/EFCore.MySql/EFCore.MySql.csproj
+++ b/src/EFCore.MySql/EFCore.MySql.csproj
@@ -14,6 +14,8 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\*.cs" />
+    <Compile Remove="Storage\Internal\MySqlTimeSpanTypeMapping.cs" />
+    <Compile Remove="Storage\Internal\TimeSpanToMicrosecondsConverter.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(LocalEFCoreRepository)' == ''">

--- a/src/EFCore.MySql/Infrastructure/MySqlDefaultDataTypeMappings.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlDefaultDataTypeMappings.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
+
 namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
 {
     public class MySqlDefaultDataTypeMappings
@@ -15,12 +17,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
             ClrDateTime = copyFrom.ClrDateTime;
             ClrDateTimeOffset = copyFrom.ClrDateTimeOffset;
             ClrTimeSpan = copyFrom.ClrTimeSpan;
+            ClrTimeOnlyPrecision = copyFrom.ClrTimeOnlyPrecision;
         }
 
         public virtual MySqlBooleanType ClrBoolean { get; private set; }
         public virtual MySqlDateTimeType ClrDateTime { get; private set; }
         public virtual MySqlDateTimeType ClrDateTimeOffset { get; private set; }
         public virtual MySqlTimeSpanType ClrTimeSpan { get; private set; }
+        public virtual int ClrTimeOnlyPrecision { get; private set; } = -1;
 
         public virtual MySqlDefaultDataTypeMappings WithClrBoolean(MySqlBooleanType mysqlBooleanType)
         {
@@ -43,10 +47,30 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
             return clone;
         }
 
+        // TODO: Remove Time6, add optional precision parameter for Time types.
         public virtual MySqlDefaultDataTypeMappings WithClrTimeSpan(MySqlTimeSpanType mysqlTimeSpanType)
         {
             var clone = Clone();
             clone.ClrTimeSpan = mysqlTimeSpanType;
+            return clone;
+        }
+
+        /// <summary>
+        /// Set the default precision for `TimeOnly` CLR type mapping to a MySQL TIME type.
+        /// Set <paramref name="precision"/> to <see langword="null"/>, to use the highest supported precision.
+        /// Otherwise, set <paramref name="precision"/> to a valid value between `0` and `6`.
+        /// </summary>
+        /// <param name="precision">The precision used for the MySQL TIME type.</param>
+        /// <returns>The same instance, to allow chained method calls.</returns>
+        public virtual MySqlDefaultDataTypeMappings WithClrTimeOnly(int? precision = null)
+        {
+            if (precision is < 0 or > 6)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision));
+            }
+
+            var clone = Clone();
+            clone.ClrTimeOnlyPrecision = precision ?? -1;
             return clone;
         }
 
@@ -57,7 +81,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure
             return ClrBoolean == other.ClrBoolean &&
                    ClrDateTime == other.ClrDateTime &&
                    ClrDateTimeOffset == other.ClrDateTimeOffset &&
-                   ClrTimeSpan == other.ClrTimeSpan;
+                   ClrTimeSpan == other.ClrTimeSpan &&
+                   ClrTimeOnlyPrecision == other.ClrTimeOnlyPrecision;
         }
 
         public override bool Equals(object obj)

--- a/src/EFCore.MySql/Internal/MySqlOptions.cs
+++ b/src/EFCore.MySql/Internal/MySqlOptions.cs
@@ -204,6 +204,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
                         : MySqlTimeSpanType.Time);
             }
 
+            if (defaultDataTypeMappings.ClrTimeOnlyPrecision < 0)
+            {
+                defaultDataTypeMappings = defaultDataTypeMappings.WithClrTimeOnly(
+                    ServerVersion.Supports.DateTime6
+                        ? 6
+                        : 0);
+            }
+
             return defaultDataTypeMappings;
         }
 

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -350,17 +350,8 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
                         Name = operation.Name
                     }, model, builder);
 
-                    var createIndexOperation = new CreateIndexOperation
-                    {
-                        Schema = operation.Schema,
-                        Table = operation.Table,
-                        Name = operation.NewName,
-                        Columns = index.Columns.Select(c => c.Name).ToArray(),
-                        IsUnique = index.IsUnique,
-                        Filter = index.Filter,
-                    };
-                    createIndexOperation.AddAnnotations(_annotationProvider.For(index, true)); // CHECK: necessary?
-                    createIndexOperation.AddAnnotations(operation.GetAnnotations());
+                    var createIndexOperation = CreateIndexOperation.CreateFrom(index);
+                    createIndexOperation.Name = operation.NewName;
 
                     Generate(createIndexOperation, model, builder);
                 }

--- a/src/EFCore.MySql/Query/Internal/MySqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlDateTimeMemberTranslator.cs
@@ -40,7 +40,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             var declaringType = member.DeclaringType;
 
             if (declaringType == typeof(DateTime)
-                || declaringType == typeof(DateTimeOffset))
+                || declaringType == typeof(DateTimeOffset)
+                || declaringType == typeof(DateOnly)
+                || declaringType == typeof(TimeOnly))
             {
                 var memberName = member.Name;
 
@@ -114,6 +116,15 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                                 : "CURDATE",
                             Array.Empty<SqlExpression>(),
                             returnType);
+
+                    case nameof(DateTime.DayOfWeek):
+                        return _sqlExpressionFactory.Subtract(
+                            _sqlExpressionFactory.NullableFunction(
+                                "DAYOFWEEK",
+                                new[] { instance },
+                                returnType,
+                                false),
+                            _sqlExpressionFactory.Constant(1));
                 }
             }
 

--- a/src/EFCore.MySql/Query/Internal/MySqlMathMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlMathMethodTranslator.cs
@@ -21,36 +21,68 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(int) }), ("ABS", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(long) }), ("ABS", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(short) }), ("ABS", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Abs), new[] { typeof(float) }), ("ABS", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Acos), new[] { typeof(double) }), ("ACOS", false) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Acos), new[] { typeof(float) }), ("ACOS", false) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Asin), new[] { typeof(double) }), ("ASIN", false) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Asin), new[] { typeof(float) }), ("ASIN", false) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Atan), new[] { typeof(double) }), ("ATAN", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Atan), new[] { typeof(float) }), ("ATAN", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Atan2), new[] { typeof(double), typeof(double) }), ("ATAN2", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Atan2), new[] { typeof(float), typeof(float) }), ("ATAN2", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(decimal) }), ("CEILING", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(double) }), ("CEILING", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Ceiling), new[] { typeof(float) }), ("CEILING", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Cos), new[] { typeof(double) }), ("COS", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Cos), new[] { typeof(float) }), ("COS", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Exp), new[] { typeof(double) }), ("EXP", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Exp), new[] { typeof(float) }), ("EXP", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Floor), new[] { typeof(decimal) }), ("FLOOR", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Floor), new[] { typeof(double) }), ("FLOOR", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Floor), new[] { typeof(float) }), ("FLOOR", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Log), new[] { typeof(double) }), ("LOG", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Log), new[] { typeof(double), typeof(double) }), ("LOG", false) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Log), new[] { typeof(float) }), ("LOG", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Log), new[] { typeof(float), typeof(float) }), ("LOG", false) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Log10), new[] { typeof(double) }), ("LOG10", false) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Log10), new[] { typeof(float) }), ("LOG10", false) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(decimal), typeof(decimal) }), ("GREATEST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(double), typeof(double) }), ("GREATEST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(float), typeof(float) }), ("GREATEST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(int), typeof(int) }), ("GREATEST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(long), typeof(long) }), ("GREATEST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Max), new[] { typeof(short), typeof(short) }), ("GREATEST", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Max), new[] { typeof(float), typeof(float) }), ("GREATEST", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(decimal), typeof(decimal) }), ("LEAST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(double), typeof(double) }), ("LEAST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(float), typeof(float) }), ("LEAST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(int), typeof(int) }), ("LEAST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(long), typeof(long) }), ("LEAST", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Min), new[] { typeof(short), typeof(short) }), ("LEAST", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Min), new[] { typeof(float), typeof(float) }), ("LEAST", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) }), ("POWER", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Pow), new[] { typeof(float), typeof(float) }), ("POWER", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(double) }), ("ROUND", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(double), typeof(int) }), ("ROUND", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal) }), ("ROUND", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal), typeof(int) }), ("ROUND", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Round), new[] { typeof(float) }), ("ROUND", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Round), new[] { typeof(float), typeof(int) }), ("ROUND", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(decimal) }), ("SIGN", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(double) }), ("SIGN", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(float) }), ("SIGN", true) },
@@ -58,11 +90,20 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
             { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(long) }), ("SIGN", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(sbyte) }), ("SIGN", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(short) }), ("SIGN", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Sign), new[] { typeof(float) }), ("SIGN", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Sin), new[] { typeof(double) }), ("SIN", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Sin), new[] { typeof(float) }), ("SIN", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Sqrt), new[] { typeof(double) }), ("SQRT", false) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Sqrt), new[] { typeof(float) }), ("SQRT", false) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Tan), new[] { typeof(double) }), ("TAN", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Tan), new[] { typeof(float) }), ("TAN", true) },
+
             { typeof(Math).GetRuntimeMethod(nameof(Math.Truncate), new[] { typeof(double) }), ("TRUNCATE", true) },
             { typeof(Math).GetRuntimeMethod(nameof(Math.Truncate), new[] { typeof(decimal) }), ("TRUNCATE", true) },
+            { typeof(MathF).GetRuntimeMethod(nameof(MathF.Truncate), new[] { typeof(float) }), ("TRUNCATE", true) },
         };
 
         private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTypeMapping.cs
@@ -16,7 +16,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     ///         not used in application code.
     ///     </para>
     /// </summary>
-    public class MySqlDateTypeMapping : DateTimeTypeMapping, IDefaultValueCompatibilityAware
+    public class MySqlDateTypeMapping : RelationalTypeMapping, IDefaultValueCompatibilityAware
     {
         private readonly bool _isDefaultValueCompatible;
 
@@ -26,10 +26,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public MySqlDateTypeMapping([NotNull] string storeType, bool isDefaultValueCompatible = false)
+        public MySqlDateTypeMapping([NotNull] string storeType, Type clrType, bool isDefaultValueCompatible = false)
             : this(
                 new RelationalTypeMappingParameters(
-                    new CoreTypeMappingParameters(typeof(DateTime)),
+                    new CoreTypeMappingParameters(clrType),
                     storeType,
                     dbType: System.Data.DbType.Date),
                 isDefaultValueCompatible)
@@ -65,6 +65,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.
         /// </summary>
-        protected override string SqlLiteralFormatString => $@"{(_isDefaultValueCompatible ? null : "DATE ")}'{0:yyyy-MM-dd}'";
+        protected override string SqlLiteralFormatString => $@"{(_isDefaultValueCompatible ? null : "DATE ")}'{{0:yyyy-MM-dd}}'";
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -61,8 +61,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         // DateTime
         private readonly MySqlYearTypeMapping _year = new MySqlYearTypeMapping("year");
-        private readonly MySqlDateTypeMapping _date = new MySqlDateTypeMapping("date");
-        private readonly MySqlTimeSpanTypeMapping _time = new MySqlTimeSpanTypeMapping("time");
+        private readonly MySqlDateTypeMapping _dateDateOnly = new MySqlDateTypeMapping("date", typeof(DateOnly));
+        private readonly MySqlDateTypeMapping _dateDateTime = new MySqlDateTypeMapping("date", typeof(DateTime));
+        private readonly MySqlTimeTypeMapping _timeTimeOnly = new MySqlTimeTypeMapping("time", typeof(TimeOnly));
+        private readonly MySqlTimeTypeMapping _timeTimeSpan = new MySqlTimeTypeMapping("time", typeof(TimeSpan));
         private readonly MySqlDateTimeTypeMapping _dateTime = new MySqlDateTimeTypeMapping("datetime");
         private readonly MySqlDateTimeTypeMapping _timeStamp = new MySqlDateTimeTypeMapping("timestamp");
         private readonly MySqlDateTimeOffsetTypeMapping _dateTimeOffset = new MySqlDateTimeOffsetTypeMapping("datetime");
@@ -196,8 +198,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
                     // DateTime
                     { "year",                      new[] { _year } },
-                    { "date",                      new[] { _date } },
-                    { "time",                      new[] { _time } },
+                    { "date",                      new RelationalTypeMapping[] { _dateDateOnly, _dateDateTime } },
+                    { "time",                      new RelationalTypeMapping[] { _timeTimeOnly, _timeTimeSpan } },
                     { "datetime",                  new RelationalTypeMapping[] { _dateTime, _dateTimeOffset } },
                     { "timestamp",                 new RelationalTypeMapping[] { _timeStamp, _timeStampOffset } },
                 };
@@ -206,26 +208,31 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                 = new Dictionary<Type, RelationalTypeMapping>
                 {
 	                // integers
-	                { typeof(short),   _smallint },
-                    { typeof(ushort),  _usmallint },
-                    { typeof(int),     _int },
-                    { typeof(uint),    _uint },
-                    { typeof(long),    _bigint },
-                    { typeof(ulong),   _ubigint },
+	                { typeof(short),    _smallint },
+                    { typeof(ushort),   _usmallint },
+                    { typeof(int),      _int },
+                    { typeof(uint),     _uint },
+                    { typeof(long),     _bigint },
+                    { typeof(ulong),    _ubigint },
 
 	                // decimals
-	                { typeof(decimal), _decimal },
-                    { typeof(float),   _float },
-                    { typeof(double),  _double },
+	                { typeof(decimal),  _decimal },
+                    { typeof(float),    _float },
+                    { typeof(double),   _double },
 
 	                // byte / char
-	                { typeof(sbyte),   _tinyint },
-                    { typeof(byte),    _utinyint },
+	                { typeof(sbyte),    _tinyint },
+                    { typeof(byte),     _utinyint },
 
                     // datetimes
-                    { typeof(TimeSpan), _options.DefaultDataTypeMappings.ClrTimeSpan == MySqlTimeSpanType.Time6
-                        ? _time.Clone(6, null)
-                        : _time },
+                    { typeof(DateOnly), _dateDateOnly },
+                    { typeof(TimeOnly), _timeTimeOnly.Clone(_options.DefaultDataTypeMappings.ClrTimeOnlyPrecision, null) },
+                    { typeof(TimeSpan), _options.DefaultDataTypeMappings.ClrTimeSpan switch
+                        {
+                            MySqlTimeSpanType.Time6 => _timeTimeSpan.Clone(6, null),
+                            MySqlTimeSpanType.Time => _timeTimeSpan,
+                            _ => _timeTimeSpan
+                        }},
                     { typeof(DateTime), _options.DefaultDataTypeMappings.ClrDateTime switch
                         {
                             MySqlDateTimeType.DateTime6 =>_dateTime.Clone(6, null),

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -243,8 +243,10 @@ namespace System
 #pragma warning disable IDE0034 // Simplify 'default' expression - default causes default(object)
             { typeof(int), default(int) },
             { typeof(Guid), default(Guid) },
+            { typeof(DateOnly), default(DateOnly) },
             { typeof(DateTime), default(DateTime) },
             { typeof(DateTimeOffset), default(DateTimeOffset) },
+            { typeof(TimeOnly), default(TimeOnly) },
             { typeof(long), default(long) },
             { typeof(bool), default(bool) },
             { typeof(double), default(double) },

--- a/test/EFCore.MySql.FunctionalTests/EFCore.MySql.FunctionalTests.csproj
+++ b/test/EFCore.MySql.FunctionalTests/EFCore.MySql.FunctionalTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreLegacyTargetFramework)</TargetFramework>
-    <LegacyTargetFramework>$(DefaultNetCoreLegacyTargetFramework)</LegacyTargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Pomelo.EntityFrameworkCore.MySql.FunctionalTests</AssemblyName>
     <RootNamespace>Pomelo.EntityFrameworkCore.MySql.FunctionalTests</RootNamespace>
     <DefaultItemExcludes>$(DefaultItemExcludes);*.trx</DefaultItemExcludes>
@@ -36,28 +35,28 @@
 
   <ItemGroup Condition="'$(LocalEFCoreRepository)' != ''">
     <Reference Include="Microsoft.EntityFrameworkCore">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Abstractions">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Abstractions.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Analyzers">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Analyzers.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Analyzers.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Proxies">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Proxies.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Proxies.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Relational">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Relational.Specification.Tests.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Relational.Specification.Tests.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Specification.Tests">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Specification.Tests.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Specification.Tests.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Design">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Design.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Design.dll</HintPath>
     </Reference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="NetTopologySuite" />
@@ -68,7 +67,7 @@
 
   <ItemGroup Condition="'$(LocalMySqlConnectorRepository)' != ''">
     <Reference Include="MySqlConnector">
-      <HintPath>$(LocalMySqlConnectorRepository)\src\MySqlConnector\bin\Debug\$(DefaultNetCoreTargetFramework)\MySqlConnector.dll</HintPath>
+      <HintPath>$(LocalMySqlConnectorRepository)\src\MySqlConnector\bin\Debug\$(TargetFramework)\MySqlConnector.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
@@ -595,6 +595,8 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
                     modelBuilder.Entity(
                         "Person", eb =>
                         {
+                            eb.Property<int>("Id");
+
                             var pb = eb.Property<string>("Name");
 
                             if (isUnicode.HasValue)
@@ -853,6 +855,7 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
                     ((Model)builder.Model).SetProductVersion("2.1.0");
                     builder.Entity("People", eb =>
                     {
+                        eb.Property<int>("Id");
                         eb.Property<string>("Blob");
                         eb.HasIndex("Blob");
                     });
@@ -884,6 +887,7 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
                     ((Model)builder.Model).SetProductVersion("2.1.0");
                     builder.Entity("People", eb =>
                     {
+                        eb.Property<int>("Id");
                         eb.Property<string>("Blob");
                         eb.HasIndex("Blob");
                     });
@@ -1038,6 +1042,7 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
                     "Person",
                     x =>
                     {
+                        x.Property<int>("Id");
                         x.Property<string>("FullName");
                         x.HasIndex("FullName").IsUnique().HasFilter("`Id` > 2");
                     }),
@@ -1086,7 +1091,11 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
             Generate(
                 modelBuilder => modelBuilder.Entity(
                     "Person",
-                    x => { x.Property<string>("FullName"); }),
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("FullName");
+                    }),
                 migrationBuilder.Operations.ToArray());
 
             Assert.Equal(
@@ -1209,6 +1218,8 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
                         "IceCreams",
                         entity =>
                         {
+                            entity.Property<int>("Id");
+
                             entity.Property<string>("Brand")
                                 .HasColumnType("longtext")
                                 .UseCollation("latin1_swedish_ci");
@@ -1242,6 +1253,8 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
                         "IceCreams",
                         entity =>
                         {
+                            entity.Property<int>("Id");
+
                             entity.Property<string>("Brand")
                                 .HasColumnType("longtext")
                                 .UseCollation("latin1_swedish_ci");
@@ -1324,6 +1337,8 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;" + EOL,
                         "IceCreams",
                         entity =>
                         {
+                            entity.Property<int>("Id");
+
                             entity.Property<string>("Brand")
                                 .HasColumnType("longtext")
                                 .HasCharSet("utf8mb4");
@@ -1357,6 +1372,8 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;" + EOL,
                         "IceCreams",
                         entity =>
                         {
+                            entity.Property<int>("Id");
+
                             entity.Property<string>("Brand")
                                 .HasColumnType("longtext")
                                 .HasCharSet("utf8mb4");

--- a/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
@@ -1035,32 +1035,6 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
         }
 
         [ConditionalFact]
-        public virtual void RenameIndexOperation_with_model()
-        {
-            Generate(
-                modelBuilder => modelBuilder.Entity(
-                    "Person",
-                    x =>
-                    {
-                        x.Property<int>("Id");
-                        x.Property<string>("FullName");
-                        x.HasIndex("FullName").IsUnique().HasFilter("`Id` > 2");
-                    }),
-                new RenameIndexOperation
-                {
-                    Table = "Person",
-                    Name = "IX_Person_Name",
-                    NewName = "IX_Person_FullName"
-                });
-
-            Assert.Equal(
-                AppConfig.ServerVersion.Supports.RenameIndex
-                ? @"ALTER TABLE `Person` RENAME INDEX `IX_Person_Name` TO `IX_Person_FullName`;" + EOL
-                : @"ALTER TABLE `Person` DROP INDEX `IX_Person_Name`;" + EOL + EOL + "CREATE UNIQUE INDEX `IX_Person_FullName` ON `Person` (`FullName`);" + EOL,
-                Sql);
-        }
-
-        [ConditionalFact]
         [SupportedServerVersionCondition(nameof(ServerVersionSupport.RenameColumn))]
         public virtual void RenameColumnOperation()
         {

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.cs
@@ -298,6 +298,12 @@ FROM `Orders` AS `o`");
             return base.Take_on_top_level_and_on_collection_projection_with_outer_apply(async);
         }
 
+        [ConditionalTheory(Skip = "Needs proper TimeSpan support, with a wider range than the current TIME mapping can provide.")]
+        public override Task Projection_containing_DateTime_subtraction(bool async)
+        {
+            return base.Projection_containing_DateTime_subtraction(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.MySql.IntegrationTests/EFCore.MySql.IntegrationTests.csproj
+++ b/test/EFCore.MySql.IntegrationTests/EFCore.MySql.IntegrationTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreLegacyTargetFramework)</TargetFramework>
-    <LegacyTargetFramework>$(DefaultNetCoreLegacyTargetFramework)</LegacyTargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Pomelo.EntityFrameworkCore.MySql.IntegrationTests</AssemblyName>
     <StartupObject>Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Program</StartupObject>
     <OutputType>Exe</OutputType>
@@ -48,28 +47,28 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" ExcludeAssets="all" />
 
     <Reference Include="Microsoft.EntityFrameworkCore">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Abstractions">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Abstractions.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Analyzers">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Analyzers.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Analyzers.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Design">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Design.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Design.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Relational">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Specification.Tests">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Specification.Tests.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Specification.Tests.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(LocalMySqlConnectorRepository)' != ''">
     <Reference Include="MySqlConnector">
-      <HintPath>$(LocalMySqlConnectorRepository)\src\MySqlConnector\bin\Debug\$(DefaultNetCoreTargetFramework)\MySqlConnector.dll</HintPath>
+      <HintPath>$(LocalMySqlConnectorRepository)\src\MySqlConnector\bin\Debug\$(TargetFramework)\MySqlConnector.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/test/EFCore.MySql.Tests/EFCore.MySql.Tests.csproj
+++ b/test/EFCore.MySql.Tests/EFCore.MySql.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreLegacyTargetFramework)</TargetFramework>
-    <LegacyTargetFramework>$(DefaultNetCoreLegacyTargetFramework)</LegacyTargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Pomelo.EntityFrameworkCore.MySql.Tests</AssemblyName>
     <RootNamespace>Pomelo.EntityFrameworkCore.MySql</RootNamespace>
@@ -46,34 +45,34 @@
 
   <ItemGroup Condition="'$(LocalEFCoreRepository)' != ''">
     <Reference Include="Microsoft.EntityFrameworkCore">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Abstractions">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Abstractions.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Analyzers">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Analyzers.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Analyzers.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Design">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Design.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Design.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Design.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Proxies">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Proxies.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Proxies.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Relational">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Relational.Specification.Tests.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Relational.Specification.Tests.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore.Specification.Tests">
-      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(LegacyTargetFramework)\Microsoft.EntityFrameworkCore.Specification.Tests.dll</HintPath>
+      <HintPath>$(LocalEFCoreRepository)\artifacts\bin\EFCore.Relational.Tests\Debug\$(TargetFramework)\Microsoft.EntityFrameworkCore.Specification.Tests.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(LocalMySqlConnectorRepository)' != ''">
     <Reference Include="MySqlConnector">
-      <HintPath>$(LocalMySqlConnectorRepository)\src\MySqlConnector\bin\Debug\$(DefaultNetCoreTargetFramework)\MySqlConnector.dll</HintPath>
+      <HintPath>$(LocalMySqlConnectorRepository)\src\MySqlConnector\bin\Debug\$(TargetFramework)\MySqlConnector.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Adds support for `DateOnly` and `TimeOnly` types.
Adds translations for `MathF` and the date related `DayOfWeek` property.

Addresses #1413