### PR TITLE
Fix leaking delegation annotations in old objects of migration operations

### DIFF
--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
@@ -273,10 +273,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
         protected virtual AlterDatabaseOperation PostFilterOperation(AlterDatabaseOperation operation)
         {
             HandleCharSetDelegation(operation, DelegationModes.ApplyToDatabases);
+            HandleCharSetDelegation(operation.OldDatabase, DelegationModes.ApplyToDatabases);
 
             ApplyCollationAnnotation(operation, (operation, collation) => operation.Collation ??= collation);
             ApplyCollationAnnotation(operation.OldDatabase, (operation, collation) => operation.Collation ??= collation);
+
             HandleCollationDelegation(operation, DelegationModes.ApplyToDatabases, o => o.Collation = null);
+            HandleCollationDelegation(operation.OldDatabase, DelegationModes.ApplyToDatabases, o => o.Collation = null);
 
             // Ensure, that this hasn't become an empty operation.
             // Depends on AssertMigrationOperationProperties check.
@@ -309,7 +312,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
         protected virtual AlterTableOperation PostFilterOperation(AlterTableOperation operation)
         {
             HandleCharSetDelegation(operation, DelegationModes.ApplyToTables);
+            HandleCharSetDelegation(operation.OldTable, DelegationModes.ApplyToTables);
+
             HandleCollationDelegation(operation, DelegationModes.ApplyToTables);
+            HandleCollationDelegation(operation.OldTable, DelegationModes.ApplyToTables);
 
             // Ensure, that this hasn't become an empty operation.
             // We do not check Name and Schema, because changes would have resulted in a RenameTableOperation already.
@@ -331,7 +337,26 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
         {
             ApplyCollationAnnotation(operation, (operation, collation) => operation.Collation ??= collation);
 
-            return operation;
+            // Ensure, that this hasn't become an empty operation.
+            // Depends on AssertMigrationOperationProperties check.
+            return !Equals(operation.ClrType, operation.OldColumn.ClrType) ||
+                   !Equals(operation.ColumnType, operation.OldColumn.ColumnType) ||
+                   !Equals(operation.IsUnicode, operation.OldColumn.IsUnicode) ||
+                   !Equals(operation.IsFixedLength, operation.OldColumn.IsFixedLength) ||
+                   !Equals(operation.MaxLength, operation.OldColumn.MaxLength) ||
+                   !Equals(operation.Precision, operation.OldColumn.Precision) ||
+                   !Equals(operation.Scale, operation.OldColumn.Scale) ||
+                   !Equals(operation.IsRowVersion, operation.OldColumn.IsRowVersion) ||
+                   !Equals(operation.IsNullable, operation.OldColumn.IsNullable) ||
+                   !Equals(operation.DefaultValue, operation.OldColumn.DefaultValue) ||
+                   !Equals(operation.DefaultValueSql, operation.OldColumn.DefaultValueSql) ||
+                   !Equals(operation.ComputedColumnSql, operation.OldColumn.ComputedColumnSql) ||
+                   !Equals(operation.IsStored, operation.OldColumn.IsStored) ||
+                   !Equals(operation.Comment, operation.OldColumn.Comment) ||
+                   !Equals(operation.Collation, operation.OldColumn.Collation) ||
+                   HasDifferences(operation.GetAnnotations(), operation.OldColumn.GetAnnotations())
+                ? operation
+                : null;
         }
 
         private static void ApplyCollationAnnotation<TOperation>(TOperation operation, Action<TOperation, string> applyCollation)


### PR DESCRIPTION
While testing #1508, I came across an independent issue, where delegation mode annotations ended up in the generated `Up()`/`Down()` methods.

This was only the case for the old state (e.g. `OldColum` or `OldTable`) of the operation, because we did not clear those annotations in `MySqlMigrationsModelDiffer`.

We do now.