### PR TITLE
[BACKPORT] Skip redundant AlterColumn call generation for migrations

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
@@ -546,47 +546,39 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         {
             var context = MySqlTestHelpers.Instance.CreateContext();
 
-            var sourceModel = context.GetService<IModelRuntimeInitializer>()
-                .Initialize(
-                    new ModelBuilder()
-                        .Entity(
-                            "IssueConsoleTemplate.IceCream", b =>
-                            {
-                                b.Property<int>("IceCreamId")
-                                    .HasColumnType("int");
+            var sourceModel = CreateConventionlessModelBuilder()
+                .Entity(
+                    "IssueConsoleTemplate.IceCream", b =>
+                    {
+                        b.Property<int>("IceCreamId")
+                            .HasColumnType("int");
 
-                                b.Property<string>("Name")
-                                    .HasColumnType("longtext CHARACTER SET utf8mb4");
+                        b.Property<string>("Name")
+                            .HasColumnType("longtext CHARACTER SET utf8mb4");
 
-                                b.HasKey("IceCreamId");
+                        b.HasKey("IceCreamId");
 
-                                b.ToTable("IceCreams");
-                            })
-                        .Model
-                        .FinalizeModel(),
-                    designTime: true,
-                    validationLogger: null);
+                        b.ToTable("IceCreams");
+                    })
+                .Model
+                .FinalizeModel();
 
-            var targetModel = context.GetService<IModelRuntimeInitializer>()
-                .Initialize(
-                    new ModelBuilder()
-                        .Entity(
-                            "IssueConsoleTemplate.IceCream", b =>
-                            {
-                                b.Property<int>("IceCreamId")
-                                    .HasColumnType("int");
+            var targetModel = CreateConventionlessModelBuilder()
+                .Entity(
+                    "IssueConsoleTemplate.IceCream", b =>
+                    {
+                        b.Property<int>("IceCreamId")
+                            .HasColumnType("int");
 
-                                b.Property<string>("Name")
-                                    .HasColumnType("longtext");
+                        b.Property<string>("Name")
+                            .HasColumnType("longtext");
 
-                                b.HasKey("IceCreamId");
+                        b.HasKey("IceCreamId");
 
-                                b.ToTable("IceCreams");
-                            })
-                        .Model
-                        .FinalizeModel(),
-                    designTime: true,
-                    validationLogger: null);
+                        b.ToTable("IceCreams");
+                    })
+                .Model
+                .FinalizeModel();
 
             var modelDiffer = context.GetService<IMigrationsModelDiffer>();
 

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -542,6 +542,62 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual void Upgrade_legacy_charset_to_annotation_charset_only_does_not_generate_alter_column_operations()
+        {
+            var context = MySqlTestHelpers.Instance.CreateContext();
+
+            var sourceModel = context.GetService<IModelRuntimeInitializer>()
+                .Initialize(
+                    new ModelBuilder()
+                        .Entity(
+                            "IssueConsoleTemplate.IceCream", b =>
+                            {
+                                b.Property<int>("IceCreamId")
+                                    .HasColumnType("int");
+
+                                b.Property<string>("Name")
+                                    .HasColumnType("longtext CHARACTER SET utf8mb4");
+
+                                b.HasKey("IceCreamId");
+
+                                b.ToTable("IceCreams");
+                            })
+                        .Model
+                        .FinalizeModel(),
+                    designTime: true,
+                    validationLogger: null);
+
+            var targetModel = context.GetService<IModelRuntimeInitializer>()
+                .Initialize(
+                    new ModelBuilder()
+                        .Entity(
+                            "IssueConsoleTemplate.IceCream", b =>
+                            {
+                                b.Property<int>("IceCreamId")
+                                    .HasColumnType("int");
+
+                                b.Property<string>("Name")
+                                    .HasColumnType("longtext");
+
+                                b.HasKey("IceCreamId");
+
+                                b.ToTable("IceCreams");
+                            })
+                        .Model
+                        .FinalizeModel(),
+                    designTime: true,
+                    validationLogger: null);
+
+            var modelDiffer = context.GetService<IMigrationsModelDiffer>();
+
+            var operations = modelDiffer.GetDifferences(
+                sourceModel.GetRelationalModel(),
+                targetModel.GetRelationalModel());
+
+            Assert.Empty(operations);
+        }
+
+        [ConditionalFact]
         public virtual async Task Create_table_explicit_column_charset_takes_precedence_over_inherited_collation()
         {
             await Test(


### PR DESCRIPTION
Backports #1507 to 5.0.

Fixes #1507.