### PR TITLE
Skip NorthwindSplitIncludeQueryMySqlTest tests for MariaDB and MySQ < 8.0

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSplitIncludeQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSplitIncludeQueryMySqlTest.cs
@@ -4,11 +4,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Pomelo.EntityFrameworkCore.MySql.Tests.TestUtilities.Attributes;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 {
+    [SupportedServerVersionCondition("8.0.0-mysql", Skip = "The way some of the test queries have been implemented upstream relies on a specific way of implicit ordering and can be non-deterministic on MariaDB and MySQL < 8.0. We therefore skip them for now in these cases, so our CI tests don't non-deterministically fail (false positive).")]
     public class NorthwindSplitIncludeQueryMySqlTest : NorthwindSplitIncludeQueryTestBase<NorthwindQueryMySqlFixture<NoopModelCustomizer>>
     {
         public NorthwindSplitIncludeQueryMySqlTest(NorthwindQueryMySqlFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)


### PR DESCRIPTION
The way some of the test queries have been implemented upstream relies on a specific way of _implicit_ ordering of the `OrderDetails` entities that can be non-deterministic on MariaDB and MySQL < 8.0.

This is not an issue with MySQL or MariaDB, but with the way the queries have been implemented by the EF Core team.

We therefore skip them for now in these cases (because indirectly manipulating the order in theses cases is a pain), so our CI tests won't fail (false positive) in a non-deterministically fashion.