### PR TITLE
Prepare 6.0.0 GA release

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -12,7 +12,7 @@
     <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
 
-    <PackageReference Update="MySqlConnector" Version="2.0.0-rc.1" />
+    <PackageReference Update="MySqlConnector" Version="2.0.0" />
 
     <PackageReference Update="NetTopologySuite" Version="2.3.0" />
     <PackageReference Update="System.Text.Json" Version="$(DependencyPreviewVersion)" />

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTypeMapping.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -67,29 +66,5 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         ///     Gets the string format to be used to generate SQL literals of this type.
         /// </summary>
         protected override string SqlLiteralFormatString => $@"{(_isDefaultValueCompatible ? null : "DATE ")}'{{0:yyyy-MM-dd}}'";
-
-        /// <summary>
-        /// Workaround https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1513.
-        /// CHECK: Remove once fixed upstream in EF Core.
-        /// </summary>
-        public override Expression GenerateCodeLiteral(object value)
-        {
-            if (value is not DateOnly dateOnlyValue)
-            {
-                return base.GenerateCodeLiteral(value);
-            }
-
-            return Expression.New(
-                typeof(DateOnly).GetConstructor(
-                    new[]
-                    {
-                        typeof(int),
-                        typeof(int),
-                        typeof(int),
-                    })!,
-                Expression.Constant(dateOnlyValue.Year),
-                Expression.Constant(dateOnlyValue.Month),
-                Expression.Constant(dateOnlyValue.Day));
-        }
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlTimeTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTimeTypeMapping.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -100,36 +99,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             return validPrecision > 0
                 ? $@"{format}\.{new string('F', validPrecision)}"
                 : format;
-        }
-
-        /// <summary>
-        /// Workaround https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1513.
-        /// CHECK: Remove once fixed upstream in EF Core.
-        /// </summary>
-        public override Expression GenerateCodeLiteral(object value)
-        {
-            if (value is not TimeOnly timeOnlyValue)
-            {
-                return base.GenerateCodeLiteral(value);
-            }
-
-            return timeOnlyValue.Ticks % 10000 > 0
-                ? Expression.New(
-                    typeof(TimeOnly).GetConstructor(new[] { typeof(long) })!,
-                    Expression.Constant(timeOnlyValue.Ticks))
-                : Expression.New(
-                    typeof(TimeOnly).GetConstructor(
-                        new[]
-                        {
-                            typeof(int),
-                            typeof(int),
-                            typeof(int),
-                            typeof(int),
-                        })!,
-                    Expression.Constant(timeOnlyValue.Hour),
-                    Expression.Constant(timeOnlyValue.Minute),
-                    Expression.Constant(timeOnlyValue.Second),
-                    Expression.Constant(timeOnlyValue.Millisecond));
         }
     }
 }


### PR DESCRIPTION
Removes a temporary workaround for an issue that got fixed upstream.
References MySqlConnector `2.0.0`.

Fixes #1524
Addresses #1413