### PR TITLE
Fix column type recognition from non-lowercased type names

### DIFF
--- a/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
+++ b/src/EFCore.MySql/Migrations/Internal/MySqlMigrationsModelDiffer.cs
@@ -121,14 +121,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Migrations.Internal
                         // Ensure that null will be set for the columns default value, if CURRENT_TIMESTAMP has been required,
                         // or when the store type of the column does not support default values at all.
                         inline = inline ||
-                                 (storeType.StoreTypeNameBase == "datetime" ||
-                                  storeType.StoreTypeNameBase == "timestamp") &&
+                                 (storeType.StoreTypeNameBase.Equals("datetime", StringComparison.OrdinalIgnoreCase) ||
+                                  storeType.StoreTypeNameBase.Equals("timestamp", StringComparison.OrdinalIgnoreCase)) &&
                                  (valueGenerationStrategy == MySqlValueGenerationStrategy.IdentityColumn ||
                                   valueGenerationStrategy == MySqlValueGenerationStrategy.ComputedColumn) ||
-                                 storeType.StoreTypeNameBase.Contains("text") ||
-                                 storeType.StoreTypeNameBase.Contains("blob") ||
-                                 storeType.StoreTypeNameBase == "geometry" ||
-                                 storeType.StoreTypeNameBase == "json";
+                                 storeType.StoreTypeNameBase.Contains("text", StringComparison.OrdinalIgnoreCase) ||
+                                 storeType.StoreTypeNameBase.Contains("blob", StringComparison.OrdinalIgnoreCase) ||
+                                 storeType.StoreTypeNameBase.Equals("geometry", StringComparison.OrdinalIgnoreCase) ||
+                                 storeType.StoreTypeNameBase.Equals("json", StringComparison.OrdinalIgnoreCase);
 
                         if (inline)
                         {

--- a/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlStringTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Data.Common;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -26,7 +27,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         public virtual bool IsUnquoted { get; }
         public virtual bool IsNationalChar
-            => StoreTypeNameBase.StartsWith("n") && StoreTypeNameBase.Contains("char");
+            => StoreTypeNameBase.StartsWith("n", StringComparison.OrdinalIgnoreCase) &&
+               StoreTypeNameBase.Contains("char", StringComparison.OrdinalIgnoreCase);
 
         public MySqlStringTypeMapping(
             [NotNull] string storeType,

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -494,6 +495,37 @@ SELECT ROW_COUNT();",
                 $@"ALTER TABLE `IceCream` ADD `Brand` longtext COLLATE {NonDefaultCollation} NULL;",
                 //
                 $@"ALTER TABLE `IceCream` ADD `Name` longtext COLLATE {DefaultCollation} NULL;");
+        }
+
+        [ConditionalFact]
+        public virtual async Task Create_table_NVARCHAR_UPPERCASE_column()
+        {
+            await Test(
+                common => { },
+                source => { },
+                target => target.Entity(
+                    "IceCream",
+                    e =>
+                    {
+                        e.Property<int>("IceCreamId");
+                        e.Property<string>("Name")
+                            .HasColumnType("NVARCHAR") // UPPERCASE
+                            .HasMaxLength(45);
+                    }),
+                result =>
+                {
+                    var table = Assert.Single(result.Tables);
+                    var nameColumn = Assert.Single(table.Columns.Where(c => c.Name == "Name"));
+
+                    Assert.True(nameColumn[MySqlAnnotationNames.CharSet] is "utf8mb3"
+                        or "utf8");
+                });
+
+            AssertSql(
+                $@"CREATE TABLE `IceCream` (
+    `IceCreamId` int NOT NULL,
+    `Name` NVARCHAR(45) NULL
+) CHARACTER SET=utf8mb4;");
         }
 
         [ConditionalFact]


### PR DESCRIPTION
The `nvarchar` and `nchar` datatypes was not recognized as a national char type (a character type with a fixed charset, currently `utf8mb3`/`utf8`) when it was written as anything else as in lower case characters.

So `NVARCHAR` was recognized as a string, just not as a national character one.

Fixes #1565