### PR TITLE
Fix JSON value projections, so they are cast to the expected type.

### DIFF
--- a/src/EFCore.MySql/Query/Expressions/Internal/MySqlJsonTraversalExpression.cs
+++ b/src/EFCore.MySql/Query/Expressions/Internal/MySqlJsonTraversalExpression.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -52,8 +51,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal
             [CanBeNull] RelationalTypeMapping typeMapping)
             : base(type, typeMapping)
         {
-            if (returnsText && type != typeof(string))
-                throw new ArgumentException($"{nameof(type)} must be string", nameof(type));
+            if (returnsText && !TypeReturnsText(type))
+                throw new ArgumentException($"{nameof(type)} is not a type that returns text", nameof(type));
 
             Expression = expression;
             Path = path;
@@ -114,5 +113,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal
         }
 
         public override string ToString() => $"{Expression}{(ReturnsText ? "->>" : "->")}{Path}";
+
+        public static bool TypeReturnsText(Type type)
+            => type == typeof(string) ||
+               type == typeof(Guid);
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/IJsonSpecificTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/IJsonSpecificTypeMapping.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+
+public interface IJsonSpecificTypeMapping
+{
+    RelationalTypeMapping CloneAsJsonCompatible();
+}

--- a/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
@@ -8,7 +8,7 @@ using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {
-    public class MySqlGuidTypeMapping : GuidTypeMapping
+    public class MySqlGuidTypeMapping : GuidTypeMapping, IJsonSpecificTypeMapping
     {
         private readonly MySqlGuidFormat _guidFormat;
 
@@ -121,5 +121,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
             return bytes;
         }
+
+        /// <summary>
+        /// For JSON values, we will always use the 36 character string representation.
+        /// </summary>
+        public virtual RelationalTypeMapping CloneAsJsonCompatible()
+            => new MySqlGuidTypeMapping(MySqlGuidFormat.Char36);
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/Query/JsonPocoQueryTestBase.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/JsonPocoQueryTestBase.cs
@@ -115,7 +115,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT `j`.`Id`, `j`.`Customer`, `j`.`ToplevelArray`
 FROM `JsonEntities` AS `j`
-WHERE JSON_EXTRACT(`j`.`Customer`, '$.Age') < 30
+WHERE CAST(JSON_EXTRACT(`j`.`Customer`, '$.Age') AS signed) < 30
 LIMIT 2");
         }
 
@@ -129,7 +129,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT `j`.`Id`, `j`.`Customer`, `j`.`ToplevelArray`
 FROM `JsonEntities` AS `j`
-WHERE JSON_EXTRACT(`j`.`Customer`, '$.ID') = '00000000-0000-0000-0000-000000000000'
+WHERE CAST(JSON_UNQUOTE(JSON_EXTRACT(`j`.`Customer`, '$.ID')) AS char) = '00000000-0000-0000-0000-000000000000'
 LIMIT 2");
         }
 
@@ -561,7 +561,11 @@ WHERE JSON_TYPE(JSON_EXTRACT(`j`.`Customer`, '$.Statistics.Visits')) = 'INTEGER'
         public class JsonPocoQueryFixtureBase : SharedStoreFixtureBase<JsonPocoQueryContext>
         {
             protected override string StoreName => "JsonPocoQueryTest";
-            protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.Instance;
+
+            // We explicitly setup MySqlGuidFormat.Binary16 here, to ensure that this is being ignored for JSON values, and instead
+            // MySqlGuidFormat.Char36 is being used.
+            protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.GuidBinary16Instance;
+
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
             protected override void Seed(JsonPocoQueryContext context) => JsonPocoQueryContext.Seed(context);
         }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStore.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStore.cs
@@ -28,17 +28,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
         protected override string OpenDelimiter => "`";
         protected override string CloseDelimiter => "`";
 
-        public static MySqlTestStore GetOrCreate(string name, bool useConnectionString = false, bool noBackslashEscapes = false, string databaseCollation = null)
-            => new MySqlTestStore(name, useConnectionString: useConnectionString, shared: true, noBackslashEscapes: noBackslashEscapes, databaseCollation: databaseCollation);
+        public static MySqlTestStore GetOrCreate(string name, bool useConnectionString = false, bool noBackslashEscapes = false, string databaseCollation = null, MySqlGuidFormat guidFormat = MySqlGuidFormat.Default)
+            => new MySqlTestStore(name, useConnectionString: useConnectionString, shared: true, noBackslashEscapes: noBackslashEscapes, databaseCollation: databaseCollation, guidFormat: guidFormat);
 
-        public static MySqlTestStore GetOrCreate(string name, string scriptPath, bool noBackslashEscapes = false, string databaseCollation = null)
-            => new MySqlTestStore(name, scriptPath: scriptPath, noBackslashEscapes: noBackslashEscapes, databaseCollation: databaseCollation);
+        public static MySqlTestStore GetOrCreate(string name, string scriptPath, bool noBackslashEscapes = false, string databaseCollation = null, MySqlGuidFormat guidFormat = MySqlGuidFormat.Default)
+            => new MySqlTestStore(name, scriptPath: scriptPath, noBackslashEscapes: noBackslashEscapes, databaseCollation: databaseCollation, guidFormat: guidFormat);
 
         public static MySqlTestStore GetOrCreateInitialized(string name)
             => new MySqlTestStore(name, shared: true).InitializeMySql(null, (Func<DbContext>)null, null);
 
-        public static MySqlTestStore Create(string name, bool useConnectionString = false, bool noBackslashEscapes = false, string databaseCollation = null)
-            => new MySqlTestStore(name, useConnectionString: useConnectionString, shared: false, noBackslashEscapes: noBackslashEscapes, databaseCollation: databaseCollation);
+        public static MySqlTestStore Create(string name, bool useConnectionString = false, bool noBackslashEscapes = false, string databaseCollation = null, MySqlGuidFormat guidFormat = MySqlGuidFormat.Default)
+            => new MySqlTestStore(name, useConnectionString: useConnectionString, shared: false, noBackslashEscapes: noBackslashEscapes, databaseCollation: databaseCollation, guidFormat: guidFormat);
 
         public static MySqlTestStore CreateInitialized(string name)
             => new MySqlTestStore(name, shared: false).InitializeMySql(null, null, null);
@@ -62,7 +62,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
             bool useConnectionString = false,
             string scriptPath = null,
             bool shared = true,
-            bool noBackslashEscapes = false)
+            bool noBackslashEscapes = false,
+            MySqlGuidFormat guidFormat = MySqlGuidFormat.Default)
             : base(name, shared)
         {
             DatabaseCharSet = databaseCharSet ?? "utf8mb4";
@@ -78,7 +79,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
                             .Assembly.Location), scriptPath);
             }
 
-            ConnectionString = CreateConnectionString(name, _noBackslashEscapes);
+            ConnectionString = CreateConnectionString(name, _noBackslashEscapes, guidFormat);
             Connection = new MySqlConnection(ConnectionString);
             ServerVersion = new Lazy<ServerVersion>(() => Microsoft.EntityFrameworkCore.ServerVersion.AutoDetect((MySqlConnection)Connection));
         }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStoreFactory.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStoreFactory.cs
@@ -1,27 +1,34 @@
 ﻿using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using MySqlConnector;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
 {
     public class MySqlTestStoreFactory : RelationalTestStoreFactory
     {
         public static MySqlTestStoreFactory Instance { get; } = new MySqlTestStoreFactory();
-        public static MySqlTestStoreFactory NoBackslashEscapesInstance { get; } = new MySqlTestStoreFactory(true);
+        public static MySqlTestStoreFactory NoBackslashEscapesInstance { get; } = new MySqlTestStoreFactory(noBackslashEscapes: true);
+        public static MySqlTestStoreFactory GuidBinary16Instance { get; } = new MySqlTestStoreFactory(guidFormat: MySqlGuidFormat.Binary16);
 
         protected bool NoBackslashEscapes { get; }
         protected string DatabaseCollation { get; }
+        protected MySqlGuidFormat GuidFormat { get; }
 
-        protected MySqlTestStoreFactory(bool noBackslashEscapes = false, string databaseCollation = null)
+        protected MySqlTestStoreFactory(
+            bool noBackslashEscapes = false,
+            string databaseCollation = null,
+            MySqlGuidFormat guidFormat = MySqlGuidFormat.Default)
         {
             NoBackslashEscapes = noBackslashEscapes;
             DatabaseCollation = databaseCollation;
+            GuidFormat = guidFormat;
         }
 
         public override TestStore Create(string storeName)
-            => MySqlTestStore.Create(storeName, noBackslashEscapes: NoBackslashEscapes, databaseCollation: DatabaseCollation);
+            => MySqlTestStore.Create(storeName, noBackslashEscapes: NoBackslashEscapes, databaseCollation: DatabaseCollation, guidFormat: GuidFormat);
 
         public override TestStore GetOrCreate(string storeName)
-            => MySqlTestStore.GetOrCreate(storeName, noBackslashEscapes: NoBackslashEscapes, databaseCollation: DatabaseCollation);
+            => MySqlTestStore.GetOrCreate(storeName, noBackslashEscapes: NoBackslashEscapes, databaseCollation: DatabaseCollation, guidFormat: GuidFormat);
 
         public override IServiceCollection AddProviderServices(IServiceCollection serviceCollection)
             => serviceCollection.AddEntityFrameworkMySql();


### PR DESCRIPTION
This handles cases, where a value from a JSON POCO object is being projected into another object (e.g. a view model) from inside of the query.

We also ensure now, that JSON `Guid` values are always represented as a 36 character string, regardless of the specified `GuidFormat` connection string option that is used for other database operations.

Fixes #1638