### PR TITLE
Fix issue, where changes to a connection string did not affect an internal master connection.

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/ConnectionMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/ConnectionMySqlTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MySqlConnector;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
+using Pomelo.EntityFrameworkCore.MySql.Tests;
+using Xunit;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
+{
+    public class ConnectionMySqlTest
+    {
+        [ConditionalFact]
+        public virtual void SetConnectionString()
+        {
+            var correctConnectionString = MySqlTestStore.CreateConnectionString("ConnectionTest");
+
+            var csb = new MySqlConnectionStringBuilder(correctConnectionString);
+            var correctPort = csb.Port;
+
+            // Set an incorrect port, where no database server is listening.
+            csb.Port = 65123;
+
+            var incorrectConnectionString = csb.ConnectionString;
+            using var context = CreateContext(incorrectConnectionString);
+
+            context.Database.SetConnectionString(correctConnectionString);
+
+            var connection = (MySqlConnection)context.Database.GetDbConnection();
+            csb = new MySqlConnectionStringBuilder(connection.ConnectionString);
+
+            Assert.Equal(csb.Port, correctPort);
+        }
+
+        [ConditionalFact]
+        public virtual void SetConnectionString_affects_master_connection()
+        {
+            var correctConnectionString = MySqlTestStore.CreateConnectionString("ConnectionTest");
+
+            // Set an incorrect port, where no database server is listening.
+            var csb = new MySqlConnectionStringBuilder(correctConnectionString) { Port = 65123 };
+
+            var incorrectConnectionString = csb.ConnectionString;
+            using var context = CreateContext(incorrectConnectionString);
+
+            context.Database.SetConnectionString(correctConnectionString);
+
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+        }
+
+        private readonly IServiceProvider _serviceProvider = new ServiceCollection()
+            .AddEntityFrameworkMySql()
+            .BuildServiceProvider();
+
+        protected ConnectionMysqlContext CreateContext(string connectionString)
+            => new ConnectionMysqlContext(_serviceProvider, connectionString);
+    }
+
+    public class ConnectionMysqlContext : DbContext
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly string _connectionString;
+
+        public ConnectionMysqlContext(IServiceProvider serviceProvider, string connectionString)
+        {
+            _serviceProvider = serviceProvider;
+            _connectionString = connectionString;
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseMySql(_connectionString, AppConfig.ServerVersion)
+                .UseInternalServiceProvider(_serviceProvider);
+    }
+}


### PR DESCRIPTION
When a connection string was set after the context was created, the newly set connection string was not used for internally created master/admin connections (that are used for operations like creating databases etc.). Instead, the initially set connection string from the `UseMySql()` call was used, which is unexpected.

This also had a negative effect on migration bundles, which first create a context, then trigger a call to `DbContext.OnConfiguring()` and finally set a connection string, if one was provided via the `--connection` command line parameter, which could result in using the wrong connection string. 

Fixes #1626