### PR TITLE
Disable TLS usage for local database server connections in CI test runs.

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/config.json.example
+++ b/test/EFCore.MySql.FunctionalTests/config.json.example
@@ -1,6 +1,6 @@
 ﻿{
   "Data": {
-    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;",
+    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;sslmode=none;",
     "ServerVersion": "auto",
     "CommandTimeout": "600"
   }

--- a/test/EFCore.MySql.IntegrationTests/config.json.example
+++ b/test/EFCore.MySql.IntegrationTests/config.json.example
@@ -1,6 +1,6 @@
 ﻿{
   "Data": {
-    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;database=pomelo_test;",
+    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;sslmode=none;database=pomelo_test;",
     "ServerVersion": "auto",
     "CommandTimeout": "600"
   }

--- a/test/EFCore.MySql.Tests/config.json.example
+++ b/test/EFCore.MySql.Tests/config.json.example
@@ -1,6 +1,6 @@
 ﻿{
   "Data": {
-    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;",
+    "ConnectionString": "server=127.0.0.1;user id=root;password=Password12!;port=3306;sslmode=none;",
     "ServerVersion": "auto",
     "CommandTimeout": "600"
   }


### PR DESCRIPTION
Since AZDO disabled its legacy TLS version support, non-deterministic exceptions are being thrown in test executions on windows (`windows-latest`):

```log
2022-05-16T06:56:09.7377983Z [xUnit.net 00:02:09.48]     Pomelo.EntityFrameworkCore.MySql.FunctionalTests.MigrationsInfrastructureMySqlTest.Can_apply_all_migrations_async [FAIL]
2022-05-16T06:56:09.7755732Z   Failed Pomelo.EntityFrameworkCore.MySql.FunctionalTests.MigrationsInfrastructureMySqlTest.Can_apply_all_migrations_async [26 s]
2022-05-16T06:56:09.7757006Z   Error Message:
2022-05-16T06:56:09.7758081Z    MySqlConnector.MySqlException : SSL Authentication Error
2022-05-16T06:56:09.7759014Z ---- System.Security.Authentication.AuthenticationException : Authentication failed because the remote party sent a TLS alert: 'IllegalParameter'.
2022-05-16T06:56:09.7760797Z -------- System.ComponentModel.Win32Exception : The message received was unexpected or badly formatted.
2022-05-16T06:56:09.7761868Z   Stack Trace:
2022-05-16T06:56:09.7762791Z      at MySqlConnector.Core.ServerSession.InitSslAsync(ProtocolCapabilities serverCapabilities, ConnectionSettings cs, MySqlConnection connection, SslProtocols sslProtocols, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/ServerSession.cs:line 1507
2022-05-16T06:56:09.7765418Z    at MySqlConnector.Core.ServerSession.ConnectAsync(ConnectionSettings cs, MySqlConnection connection, Int32 startTickCount, ILoadBalancer loadBalancer, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/ServerSession.cs:line 516
2022-05-16T06:56:09.7768033Z    at MySqlConnector.MySqlConnection.CreateSessionAsync(ConnectionPool pool, Int32 startTickCount, Nullable`1 ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlConnection.cs:line 944
2022-05-16T06:56:09.7769405Z    at MySqlConnector.MySqlConnection.OpenAsync(Nullable`1 ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlConnection.cs:line 451
2022-05-16T06:56:09.7770393Z    at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenInternalAsync(Boolean errorsExpected, CancellationToken cancellationToken)
2022-05-16T06:56:09.7771234Z    at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenInternalAsync(Boolean errorsExpected, CancellationToken cancellationToken)
2022-05-16T06:56:09.7772167Z    at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenAsync(CancellationToken cancellationToken, Boolean errorsExpected)
2022-05-16T06:56:09.7773203Z    at Pomelo.EntityFrameworkCore.MySql.Storage.Internal.MySqlRelationalConnection.OpenAsync(CancellationToken cancellationToken, Boolean errorsExpected) in D:\a\1\s\src\EFCore.MySql\Storage\Internal\MySqlRelationalConnection.cs:line 151
2022-05-16T06:56:09.7775021Z    at Microsoft.EntityFrameworkCore.Migrations.Internal.MigrationCommandExecutor.ExecuteNonQueryAsync(IEnumerable`1 migrationCommands, IRelationalConnection connection, CancellationToken cancellationToken)
2022-05-16T06:56:09.7776725Z    at Microsoft.EntityFrameworkCore.Migrations.Internal.MigrationCommandExecutor.ExecuteNonQueryAsync(IEnumerable`1 migrationCommands, IRelationalConnection connection, CancellationToken cancellationToken)
2022-05-16T06:56:09.7777905Z    at Pomelo.EntityFrameworkCore.MySql.Storage.Internal.MySqlDatabaseCreator.CreateAsync(CancellationToken cancellationToken) in D:\a\1\s\src\EFCore.MySql\Storage\Internal\MySqlDatabaseCreator.cs:line 80
2022-05-16T06:56:09.7779347Z    at Microsoft.EntityFrameworkCore.Migrations.Internal.Migrator.MigrateAsync(String targetMigration, CancellationToken cancellationToken)
2022-05-16T06:56:09.7780627Z    at Microsoft.EntityFrameworkCore.Migrations.MigrationsInfrastructureTestBase`1.Can_apply_all_migrations_async()
2022-05-16T06:56:09.7781468Z --- End of stack trace from previous location ---
2022-05-16T06:56:09.7782491Z ----- Inner Stack Trace -----
2022-05-16T06:56:09.7783120Z    at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](TIOAdapter adapter, Boolean receiveFirst, Byte[] reAuthenticationData, Boolean isApm)
2022-05-16T06:56:09.7784653Z    at MySqlConnector.Core.ServerSession.InitSslAsync(ProtocolCapabilities serverCapabilities, ConnectionSettings cs, MySqlConnection connection, SslProtocols sslProtocols, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/ServerSession.cs:line 1464
```

In one test run, it happened `1688` times, in the next one, it only happened _once_.

Since we do not need TLS support for local connections, we disable it for now. We probably could have also just specified a TLS version like 1.2, but in earlier MySQL Community executable versions that use yaSSL, like MySQL 5.7, the highest supported TLS version is 1.1 (bad decision by Oracle to only use OpenSSL with TLS 1.2 support in their enterprise product, that that's how it is).

Because we are also testing MySQL 5.7 (though currently not on Windows), we will disable TLS for all of our local database server connections when testing for now.