### PR TITLE
Optimize `string.IndexOf(string, int)` translation

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
@@ -622,9 +622,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 
         private SqlExpression Locate(SqlExpression sub, SqlExpression str, SqlExpression startIndex = null)
         {
-            var args = startIndex is null
-                ? new SqlExpression[] { sub, str }
-                : new SqlExpression[] { sub, str, _sqlExpressionFactory.Add(startIndex, _sqlExpressionFactory.Constant(1)) };
+            var args = startIndex switch
+            {
+                null => new SqlExpression[] { sub, str },
+                SqlConstantExpression { Value:int idx } => new SqlExpression[] { sub, str, _sqlExpressionFactory.Constant(idx + 1) },
+                _ => new SqlExpression[] { sub, str, _sqlExpressionFactory.Add(startIndex, _sqlExpressionFactory.Constant(1)) }
+            };
             return _sqlExpressionFactory.NullableFunction("LOCATE", args, typeof(int));
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindFunctionsQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindFunctionsQueryMySqlTest.MySql.cs
@@ -706,11 +706,26 @@ END = 1");
         }
 
         [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task StringIndexOf_with_constant_start_index(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.IndexOf("nt", 0, StringComparison.OrdinalIgnoreCase) == 1),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
+FROM `Customers` AS `c`
+WHERE (LOCATE(CONVERT(LCASE('nt') USING utf8mb4) COLLATE utf8mb4_bin, LCASE(`c`.`CustomerID`), 1) - 1) = 1");
+        }
+
+        [ConditionalTheory]
         [InlineData(0, 1, false)]
         [InlineData(2, 0, false)]
         [InlineData(0, 1, true)]
         [InlineData(2, 0, true)]
-        public async Task StringIndexOf_with_start_index(int startIndex, int expected, bool async)
+        public async Task StringIndexOf_with_parameter_start_index(int startIndex, int expected, bool async)
         {
             await AssertQuery(
                 async,


### PR DESCRIPTION
Based on [PR for efcore](https://github.com/dotnet/efcore/pull/28031) from @roji, the SQL translation can be optimized when `startIndex` is a constant. 
It's also a small enhancement for my previous PR #1645 .