### PR TITLE
Fix legacy rename column implementation in regards to required string properties without default value

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
@@ -1080,6 +1080,35 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
         }
 
         [ConditionalFact]
+        public virtual void RenameColumnOperation_with_model_required_without_default_value()
+        {
+            var migrationBuilder = new MigrationBuilder("MySql");
+
+            migrationBuilder.RenameColumn(
+                table: "Person",
+                name: "Name",
+                newName: "FullName");
+
+            Generate(
+                modelBuilder => modelBuilder.Entity(
+                    "Person",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("FullName")
+                            .HasMaxLength(64)
+                            .IsRequired();
+                    }),
+                migrationBuilder.Operations.ToArray());
+
+            Assert.Equal(
+                AppConfig.ServerVersion.Supports.RenameColumn
+                    ? "ALTER TABLE `Person` RENAME COLUMN `Name` TO `FullName`;" + EOL
+                    : "ALTER TABLE `Person` CHANGE `Name` `FullName` varchar(64) NOT NULL;" + EOL,
+                Sql);
+        }
+
+        [ConditionalFact]
         public override void SqlOperation()
         {
             base.SqlOperation();


### PR DESCRIPTION
When generating migrations for MySQL 5.7, that does not yet support the `RENAME COLUMN` syntax, renaming a required entity string property would result in a  `DEFAULT ''` clause being added to the `ALTER TABLE ... CHANGE` statement, even if no default value was previously defined.

This behavior has now been corrected.

Fixes #1659