### PR TITLE
Throw on rename or drop index migration operations without table name

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -315,6 +315,11 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
+            if (string.IsNullOrEmpty(operation.Table))
+            {
+                throw new InvalidOperationException(MySqlStrings.IndexTableRequired);
+            }
+
             if (operation.NewName != null)
             {
                 if (_options.ServerVersion.Supports.RenameIndex)
@@ -638,6 +643,11 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
         {
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
+
+            if (string.IsNullOrEmpty(operation.Table))
+            {
+                throw new InvalidOperationException(MySqlStrings.IndexTableRequired);
+            }
 
             builder
                 .Append("ALTER TABLE ")

--- a/src/EFCore.MySql/Properties/MySqlStrings.resx
+++ b/src/EFCore.MySql/Properties/MySqlStrings.resx
@@ -130,7 +130,7 @@
     <value>MySQL sequences cannot be used to generate values for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Sequences can only be used with integer properties.</value>
   </data>
   <data name="IndexTableRequired" xml:space="preserve">
-    <value>MySQL requires the table name to be specified for rename index operations. Specify table name in the call to MigrationBuilder.RenameIndex.</value>
+    <value>MySQL requires the table name to be specified for index operations. Specify table name in calls to 'MigrationBuilder.RenameIndex' and 'DropIndex'.</value>
   </data>
   <data name="AlterMemoryOptimizedTable" xml:space="preserve">
     <value>To set memory-optimized on a table on or off the table needs to be dropped and recreated.</value>

--- a/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlMigrationsSqlGeneratorTest.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Tests;
 using Pomelo.EntityFrameworkCore.MySql.Tests.TestUtilities.Attributes;
@@ -1032,6 +1033,35 @@ ALTER DATABASE COLLATE latin1_swedish_ci;" + EOL,
             Assert.Equal(
                 @"ALTER TABLE `Person` RENAME INDEX `IX_Person_Name` TO `IX_Person_FullName`;" + EOL,
                 Sql);
+        }
+
+        [ConditionalFact]
+        public virtual void RenameIndexOperations_throws_when_no_table()
+        {
+            var migrationBuilder = new MigrationBuilder("MySql");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_OldIndex",
+                newName: "IX_NewIndex");
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => Generate(migrationBuilder.Operations.ToArray()));
+
+            Assert.Equal(MySqlStrings.IndexTableRequired, ex.Message);
+        }
+
+        [ConditionalFact]
+        public virtual void DropIndexOperations_throws_when_no_table()
+        {
+            var migrationBuilder = new MigrationBuilder("MySql");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Name");
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => Generate(migrationBuilder.Operations.ToArray()));
+
+            Assert.Equal(MySqlStrings.IndexTableRequired, ex.Message);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Add throw an exception with a meaningful error message, when someone tries to execute a drop or rename index operation without specifying a table name.

Fixes #1663