### PR TITLE
Remove legacy rename column operation hack and replace it with exception

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -830,23 +830,11 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                 .Append(" ");
 
-            var column = model?.GetRelationalModel().FindTable(operation.Table, operation.Schema).FindColumn(operation.NewName);
-            if (column == null)
+            var column = model?.GetRelationalModel().FindTable(operation.Table, operation.Schema)?.FindColumn(operation.NewName);
+            if (column is null)
             {
-                if (!(operation[RelationalAnnotationNames.ColumnType] is string type))
-                {
-                    throw new InvalidOperationException(
-                        $"Could not find the column: {Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema)}.{Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName)}. Specify the column type explicitly on 'RenameColumn' using the \"{RelationalAnnotationNames.ColumnType}\" annotation");
-                }
-
-                builder
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName))
-                    .Append(" ")
-                    .Append(type)
-                    .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
-
-                EndStatement(builder);
-                return;
+                throw new InvalidOperationException(
+                    $"The column '{Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema)}.{Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName)}' could not be found in the target model. Make sure the table name exists in the target model and check the order of all migration operations. Generally, rename tables first, then columns.");
             }
 
             var typeMapping = column.PropertyMappings.FirstOrDefault()?.TypeMapping;


### PR DESCRIPTION
There was a hack in the generation of column rename statements, that basically allowed to misuse the `Relational:ColumnType` annotation (by not just supplying it with the actual column type, but also additional information like nullability, default values etc.) to workaround renaming limitations for older MySQL versions, that do not support the `ALTER TABLE ... RENAME COLUMN` syntax and have to `change` the whole column definition instead.

We now remove this hack and replace it with an exception that contains a hopefully helpful error message.

See https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1658#issuecomment-1147322522 about how to handle issues in regards renaming columns and tables as part of the same migration.

(And it is always possible to fallback to a custom SQL statement.)

Fixes #1658