### PR TITLE
Let EF Core assign unique aliases for specific HAVING clauses

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQueryMySqlTest.cs
@@ -2179,10 +2179,10 @@ ORDER BY `t`.`Name`, `t0`.`Id`");
 FROM (
     SELECT `t`.`Name`
     FROM (
-        SELECT `l`.`Name`, (`l`.`Name` <> 'Foo') OR `l`.`Name` IS NULL AS `having`
+        SELECT `l`.`Name`, (`l`.`Name` <> 'Foo') OR `l`.`Name` IS NULL AS `c`
         FROM `LevelOne` AS `l`
-        GROUP BY `l`.`Name`, `having`
-        HAVING `having`
+        GROUP BY `l`.`Name`, `c`
+        HAVING `c`
     ) AS `t`
 ) AS `t`
 LEFT JOIN (
@@ -2199,10 +2199,10 @@ ORDER BY `t`.`Name`, `t0`.`Id`",
 FROM (
     SELECT `t`.`Name`
     FROM (
-        SELECT `l`.`Name`, (`l`.`Name` <> 'Foo') OR `l`.`Name` IS NULL AS `having`
+        SELECT `l`.`Name`, (`l`.`Name` <> 'Foo') OR `l`.`Name` IS NULL AS `c`
         FROM `LevelOne` AS `l`
-        GROUP BY `l`.`Name`, `having`
-        HAVING `having`
+        GROUP BY `l`.`Name`, `c`
+        HAVING `c`
     ) AS `t`
 ) AS `t`
 LEFT JOIN (

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSelectQueryMySqlTest.MySql.cs
@@ -42,11 +42,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
             AssertSql(
                 @"SELECT `t`.`Year`, `t`.`Count`
 FROM (
-    SELECT EXTRACT(year FROM `o`.`OrderDate`) AS `Year`, COUNT(*) AS `Count`, `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`) = 1995 AS `having`
+    SELECT EXTRACT(year FROM `o`.`OrderDate`) AS `Year`, COUNT(*) AS `Count`, `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`) = 1995 AS `c`
     FROM `Orders` AS `o`
     WHERE (`o`.`CustomerID` = 'ALFKI') AND `o`.`OrderDate` IS NOT NULL
-    GROUP BY `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`), `having`
-    HAVING `having`
+    GROUP BY `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`), `c`
+    HAVING `c`
 ) AS `t`
 ORDER BY `t`.`Year`");
         }
@@ -75,11 +75,11 @@ ORDER BY `t`.`Year`");
             AssertSql(
                 @"SELECT `t`.`c`
 FROM (
-    SELECT EXTRACT(year FROM `o`.`OrderDate`) AS `c`, `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`) = 1995 AS `having`
+    SELECT EXTRACT(year FROM `o`.`OrderDate`) AS `c`, `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`) = 1995 AS `c0`
     FROM `Orders` AS `o`
     WHERE (`o`.`CustomerID` = 'ALFKI') AND `o`.`OrderDate` IS NOT NULL
-    GROUP BY `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`), `having`
-    HAVING `having`
+    GROUP BY `o`.`CustomerID`, EXTRACT(year FROM `o`.`OrderDate`), `c0`
+    HAVING `c0`
 ) AS `t`
 UNION ALL
 SELECT EXTRACT(year FROM `o0`.`OrderDate`) AS `c`


### PR DESCRIPTION
As mentioned in #1531, we can actually let EntityFramework Core assign an alias. This probably didn't work always without `.PushdownIntoSubquery()`, as the `SelectExpression` itself needs an alias for EF Core to add column-aliases, but sub-queries always need an alias and so this works now.