### PR TITLE
Change `Match` extension methods and introduce `IsMatch` ones

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
@@ -662,10 +662,54 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="property">The property of entity that is to be matched.</param>
         /// <param name="pattern">The pattern against which Full Text search is performed</param>
-        /// <param name="searchMode">Mode in which search is performed</param>
+        /// <param name="searchMode">The mode to performed the search with.</param>
         /// <returns>true if there is a match.</returns>
         /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
-        public static bool Match(
+        public static bool IsMatch(
+            [CanBeNull] this DbFunctions _,
+            [CanBeNull] string property,
+            [CanBeNull] string pattern,
+            MySqlMatchSearchMode searchMode)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(IsMatch)));
+
+        /// <summary>
+        ///     <para>
+        ///         An implementation of the SQL MATCH operation for Full Text search.
+        ///     </para>
+        ///     <para>
+        ///         The semantics of the comparison will depend on the database configuration.
+        ///         In particular, it may be either case-sensitive or case-insensitive.
+        ///     </para>
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="properties">The propertys of entity that is to be matched.</param>
+        /// <param name="pattern">The pattern against which Full Text search is performed</param>
+        /// <param name="searchMode">The mode to performed the search with.</param>
+        /// <returns>true if there is a match.</returns>
+        /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
+        public static bool IsMatch(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] string[] properties,
+            [CanBeNull] string pattern,
+            MySqlMatchSearchMode searchMode)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(IsMatch)));
+
+        /// <summary>
+        ///     <para>
+        ///         An implementation of the SQL MATCH operation for Full Text search.
+        ///     </para>
+        ///     <para>
+        ///         The semantics of the comparison will depend on the database configuration.
+        ///         In particular, it may be either case-sensitive or case-insensitive.
+        ///     </para>
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="property">The property of entity that is to be matched.</param>
+        /// <param name="pattern">The pattern against which Full Text search is performed</param>
+        /// <param name="searchMode">The mode to performed the search with. Needs to be a constant value or throws otherwise.</param>
+        /// <returns>The relevance value of the match.</returns>
+        /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
+        public static double Match(
             [CanBeNull] this DbFunctions _,
             [CanBeNull] string property,
             [CanBeNull] string pattern,
@@ -684,10 +728,10 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="properties">The propertys of entity that is to be matched.</param>
         /// <param name="pattern">The pattern against which Full Text search is performed</param>
-        /// <param name="searchMode">Mode in which search is performed</param>
-        /// <returns>true if there is a match.</returns>
+        /// <param name="searchMode">The mode to performed the search with. Needs to be a constant value or throws otherwise.</param>
+        /// <returns>The relevance value of the match.</returns>
         /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
-        public static bool Match(
+        public static double Match(
             [CanBeNull] this DbFunctions _,
             [NotNull] string[] properties,
             [CanBeNull] string pattern,

--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
@@ -662,7 +662,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="property">The property of entity that is to be matched.</param>
         /// <param name="pattern">The pattern against which Full Text search is performed</param>
-        /// <param name="searchMode">The mode to performed the search with.</param>
+        /// <param name="searchMode">The mode to perform the search with.</param>
         /// <returns>true if there is a match.</returns>
         /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
         public static bool IsMatch(
@@ -684,7 +684,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="properties">The propertys of entity that is to be matched.</param>
         /// <param name="pattern">The pattern against which Full Text search is performed</param>
-        /// <param name="searchMode">The mode to performed the search with.</param>
+        /// <param name="searchMode">The mode to perform the search with.</param>
         /// <returns>true if there is a match.</returns>
         /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
         public static bool IsMatch(
@@ -706,7 +706,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="property">The property of entity that is to be matched.</param>
         /// <param name="pattern">The pattern against which Full Text search is performed</param>
-        /// <param name="searchMode">The mode to performed the search with. Needs to be a constant value or throws otherwise.</param>
+        /// <param name="searchMode">The mode to perform the search with. Needs to be a constant value or throws otherwise.</param>
         /// <returns>The relevance value of the match.</returns>
         /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
         public static double Match(
@@ -728,7 +728,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="properties">The propertys of entity that is to be matched.</param>
         /// <param name="pattern">The pattern against which Full Text search is performed</param>
-        /// <param name="searchMode">The mode to performed the search with. Needs to be a constant value or throws otherwise.</param>
+        /// <param name="searchMode">The mode to perform the search with. Needs to be a constant value or throws otherwise.</param>
         /// <returns>The relevance value of the match.</returns>
         /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
         public static double Match(

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlSqlTranslatingExpressionVisitor.cs
@@ -29,7 +29,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
         private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
 
         protected static readonly MethodInfo[] NewArrayExpressionSupportMethodInfos = Array.Empty<MethodInfo>()
-            .Concat(typeof(MySqlDbFunctionsExtensions).GetRuntimeMethods().Where(m => m.Name == nameof(MySqlDbFunctionsExtensions.Match)))
+            .Concat(typeof(MySqlDbFunctionsExtensions).GetRuntimeMethods().Where(m => m.Name is nameof(MySqlDbFunctionsExtensions.Match)
+                                                                                             or nameof(MySqlDbFunctionsExtensions.IsMatch)))
             .Concat(typeof(string).GetRuntimeMethods().Where(m => m.Name == nameof(string.Concat)))
             .Where(m => m.GetParameters().Any(p => p.ParameterType.IsArray))
             .ToArray();

--- a/src/EFCore.MySql/Query/Expressions/Internal/MySqlMatchExpression.cs
+++ b/src/EFCore.MySql/Query/Expressions/Internal/MySqlMatchExpression.cs
@@ -19,7 +19,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal
             SqlExpression against,
             MySqlMatchSearchMode searchMode,
             RelationalTypeMapping typeMapping)
-            : base(typeof(bool), typeMapping)
+            : base(typeof(double), typeMapping)
         {
             Check.NotNull(match, nameof(match));
             Check.NotNull(against, nameof(against));

--- a/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlSqlExpressionFactory.cs
@@ -20,12 +20,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
     {
         private readonly IRelationalTypeMappingSource _typeMappingSource;
         private readonly RelationalTypeMapping _boolTypeMapping;
+        private readonly RelationalTypeMapping _doubleTypeMapping;
 
         public MySqlSqlExpressionFactory(SqlExpressionFactoryDependencies dependencies)
             : base(dependencies)
         {
             _typeMappingSource = dependencies.TypeMappingSource;
             _boolTypeMapping = _typeMappingSource.FindMapping(typeof(bool));
+            _doubleTypeMapping = _typeMappingSource.FindMapping(typeof(double));
         }
 
         public virtual RelationalTypeMapping FindMapping(
@@ -385,7 +387,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 ApplyTypeMapping(matchExpression.Match, inferredTypeMapping),
                 ApplyTypeMapping(matchExpression.Against, inferredTypeMapping),
                 matchExpression.SearchMode,
-                _boolTypeMapping);
+                _doubleTypeMapping);
         }
 
         private SqlExpression ApplyTypeMappingOnRegexp(MySqlRegexpExpression regexpExpression)

--- a/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
@@ -18,133 +18,281 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
         }
 
         [ConditionalFact]
-        public virtual void Match_in_natural_language_mode()
+        public virtual void IsMatch_in_natural_language_mode()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.NaturalLanguage));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "First", MySqlMatchSearchMode.NaturalLanguage));
 
             Assert.Equal(3, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`) AGAINST ('First')");
+WHERE MATCH (`h`.`Name`) AGAINST ('First') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_in_natural_language_mode()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.NaturalLanguage) > 0);
+
+            Assert.Equal(3, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_natural_language_mode_multiple_columns()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "First", MySqlMatchSearchMode.NaturalLanguage));
+
+            Assert.Equal(5, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First') > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_natural_language_mode_multiple_columns()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First", MySqlMatchSearchMode.NaturalLanguage));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First", MySqlMatchSearchMode.NaturalLanguage) > 0);
 
             Assert.Equal(5, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First')");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_natural_language_mode_keywords_separated()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
+
+            Assert.Equal(6, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First, Second') > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_natural_language_mode_keywords_separated()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.NaturalLanguage) > 0);
 
             Assert.Equal(6, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`) AGAINST ('First, Second')");
+WHERE MATCH (`h`.`Name`) AGAINST ('First, Second') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_natural_language_mode_keywords_separated_multiple_columns()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
+
+            Assert.Equal(8, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First, Second') > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_natural_language_mode_keywords_separated_multiple_columns()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First, Second", MySqlMatchSearchMode.NaturalLanguage) > 0);
 
             Assert.Equal(8, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First, Second')");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First, Second') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_natural_language_mode_multiple_keywords()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "First Herb", MySqlMatchSearchMode.NaturalLanguage));
+
+            Assert.Equal(9, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First Herb') > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_natural_language_mode_multiple_keywords()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First Herb", MySqlMatchSearchMode.NaturalLanguage));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First Herb", MySqlMatchSearchMode.NaturalLanguage) > 0);
 
             Assert.Equal(9, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`) AGAINST ('First Herb')");
+WHERE MATCH (`h`.`Name`) AGAINST ('First Herb') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_natural_language_mode_multiple_keywords_multiple_columns()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "First Herb", MySqlMatchSearchMode.NaturalLanguage));
+
+            Assert.Equal(9, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First Herb') > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_natural_language_mode_multiple_keywords_multiple_columns()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First Herb", MySqlMatchSearchMode.NaturalLanguage));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First Herb", MySqlMatchSearchMode.NaturalLanguage) > 0);
 
             Assert.Equal(9, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First Herb')");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First Herb') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_natural_language_mode_multiple_keywords_separated()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
+
+            Assert.Equal(6, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First, Second') > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_natural_language_mode_multiple_keywords_separated()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.NaturalLanguage) > 0);
 
             Assert.Equal(6, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`) AGAINST ('First, Second')");
+WHERE MATCH (`h`.`Name`) AGAINST ('First, Second') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_natural_language_mode_multiple_keywords_separated_multiple_columns()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
+
+            Assert.Equal(8, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First, Second') > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_natural_language_mode_multiple_keywords_separated_multiple_columns()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First, Second", MySqlMatchSearchMode.NaturalLanguage));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First, Second", MySqlMatchSearchMode.NaturalLanguage) > 0);
 
             Assert.Equal(8, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First, Second')");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First, Second') > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_boolean_mode()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "First*", MySqlMatchSearchMode.Boolean));
+
+            Assert.Equal(3, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE) > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_boolean_mode()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", MySqlMatchSearchMode.Boolean));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", MySqlMatchSearchMode.Boolean) > 0);
 
             Assert.Equal(3, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE)");
+WHERE MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE) > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_boolean_mode_multiple_columns()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "First*", MySqlMatchSearchMode.Boolean));
+
+            Assert.Equal(5, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*' IN BOOLEAN MODE) > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_boolean_mode_multiple_columns()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First*", MySqlMatchSearchMode.Boolean));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First*", MySqlMatchSearchMode.Boolean) > 0);
 
             Assert.Equal(5, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*' IN BOOLEAN MODE)");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*' IN BOOLEAN MODE) > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_boolean_mode_with_search_mode_parameter()
+        {
+            using var context = CreateContext();
+
+            var searchMode = MySqlMatchSearchMode.Boolean;
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "First*", searchMode));
+
+            Assert.Equal(3, count);
+
+            AssertSql(
+                @"@__searchMode_1='2'
+
+SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE ((@__searchMode_1 = 0) AND (MATCH (`h`.`Name`) AGAINST ('First*') > 0.0)) OR (((@__searchMode_1 = 1) AND (MATCH (`h`.`Name`) AGAINST ('First*' WITH QUERY EXPANSION) > 0.0)) OR ((@__searchMode_1 = 2) AND (MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE) > 0.0)))");
         }
 
         [ConditionalFact]
@@ -153,25 +301,18 @@ WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*' IN BOOLEAN MODE)");
             using var context = CreateContext();
 
             var searchMode = MySqlMatchSearchMode.Boolean;
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", searchMode));
 
-            Assert.Equal(3, count);
-
-            AssertSql(
-                @"@__searchMode_1='2'
-
-SELECT COUNT(*)
-FROM `Herb` AS `h`
-WHERE ((@__searchMode_1 = 0) AND MATCH (`h`.`Name`) AGAINST ('First*')) OR (((@__searchMode_1 = 1) AND MATCH (`h`.`Name`) AGAINST ('First*' WITH QUERY EXPANSION)) OR ((@__searchMode_1 = 2) AND MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE)))");
+            Assert.Throws<InvalidOperationException>(
+                () => context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", searchMode) > 0));
         }
 
         [ConditionalFact]
-        public virtual void Match_in_boolean_mode_with_search_mode_parameter_multiple_columns()
+        public virtual void IsMatch_in_boolean_mode_with_search_mode_parameter_multiple_columns()
         {
             using var context = CreateContext();
 
             var searchMode = MySqlMatchSearchMode.Boolean;
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First*", searchMode));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "First*", searchMode));
 
             Assert.Equal(5, count);
 
@@ -180,85 +321,191 @@ WHERE ((@__searchMode_1 = 0) AND MATCH (`h`.`Name`) AGAINST ('First*')) OR (((@_
 
 SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE ((@__searchMode_1 = 0) AND MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*')) OR (((@__searchMode_1 = 1) AND MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*' WITH QUERY EXPANSION)) OR ((@__searchMode_1 = 2) AND MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*' IN BOOLEAN MODE)))");
+WHERE ((@__searchMode_1 = 0) AND (MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*') > 0.0)) OR (((@__searchMode_1 = 1) AND (MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*' WITH QUERY EXPANSION) > 0.0)) OR ((@__searchMode_1 = 2) AND (MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First*' IN BOOLEAN MODE) > 0.0)))");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_in_boolean_mode_with_search_mode_parameter_multiple_columns()
+        {
+            using var context = CreateContext();
+
+            var searchMode = MySqlMatchSearchMode.Boolean;
+
+            Assert.Throws<InvalidOperationException>(
+                () => context.Set<Herb>().Count(herb => EF.Functions.Match(new[] { herb.Name, herb.Garden }, "First*", searchMode) > 0));
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_boolean_mode_keywords()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "+First +Herb", MySqlMatchSearchMode.Boolean));
+
+            Assert.Equal(3, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('+First +Herb' IN BOOLEAN MODE) > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_boolean_mode_keywords()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First* Herb*", MySqlMatchSearchMode.Boolean));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "+First +Herb", MySqlMatchSearchMode.Boolean) > 0);
+
+            Assert.Equal(3, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('+First +Herb' IN BOOLEAN MODE) > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_in_boolean_mode_keywords_evaluate_score()
+        {
+            var minScore = 0.2;
+
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First* Herb*", MySqlMatchSearchMode.Boolean) > minScore);
+
+            Assert.Equal(3, count);
+
+            AssertSql(@"@__minScore_1='0.2'
+
+SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First* Herb*' IN BOOLEAN MODE) > @__minScore_1");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_boolean_mode_keywords_multiple_columns()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "First* Herb*", MySqlMatchSearchMode.Boolean));
 
             Assert.Equal(9, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`) AGAINST ('First* Herb*' IN BOOLEAN MODE)");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First* Herb*' IN BOOLEAN MODE) > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_boolean_mode_keywords_multiple_columns()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First* Herb*", MySqlMatchSearchMode.Boolean));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First* Herb*", MySqlMatchSearchMode.Boolean) > 0);
 
             Assert.Equal(9, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First* Herb*' IN BOOLEAN MODE)");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First* Herb*' IN BOOLEAN MODE) > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_boolean_mode_keyword_excluded()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "Herb* -Second", MySqlMatchSearchMode.Boolean));
+
+            Assert.Equal(6, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('Herb* -Second' IN BOOLEAN MODE) > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_boolean_mode_keyword_excluded()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "Herb* -Second", MySqlMatchSearchMode.Boolean));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "Herb* -Second", MySqlMatchSearchMode.Boolean) > 0);
 
             Assert.Equal(6, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`) AGAINST ('Herb* -Second' IN BOOLEAN MODE)");
+WHERE MATCH (`h`.`Name`) AGAINST ('Herb* -Second' IN BOOLEAN MODE) > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_in_boolean_mode_keyword_excluded_multiple_columns()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "Herb* -Second", MySqlMatchSearchMode.Boolean));
+
+            Assert.Equal(4, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('Herb* -Second' IN BOOLEAN MODE) > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_in_boolean_mode_keyword_excluded_multiple_columns()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "Herb* -Second", MySqlMatchSearchMode.Boolean));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "Herb* -Second", MySqlMatchSearchMode.Boolean) > 0);
 
             Assert.Equal(4, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('Herb* -Second' IN BOOLEAN MODE)");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('Herb* -Second' IN BOOLEAN MODE) > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_with_query_expansion()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(herb.Name, "First", MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion));
+
+            Assert.Equal(9, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First' WITH QUERY EXPANSION) > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_with_query_expansion()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion) > 0);
 
             Assert.Equal(9, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`) AGAINST ('First' WITH QUERY EXPANSION)");
+WHERE MATCH (`h`.`Name`) AGAINST ('First' WITH QUERY EXPANSION) > 0.0");
+        }
+
+        [ConditionalFact]
+        public virtual void IsMatch_with_query_expansion_multiple_columns()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.IsMatch(new []{herb.Name, herb.Garden}, "First", MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion));
+
+            Assert.Equal(9, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First' WITH QUERY EXPANSION) > 0.0");
         }
 
         [ConditionalFact]
         public virtual void Match_with_query_expansion_multiple_columns()
         {
             using var context = CreateContext();
-            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First", MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion));
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(new []{herb.Name, herb.Garden}, "First", MySqlMatchSearchMode.NaturalLanguageWithQueryExpansion) > 0);
 
             Assert.Equal(9, count);
 
             AssertSql(@"SELECT COUNT(*)
 FROM `Herb` AS `h`
-WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First' WITH QUERY EXPANSION)");
+WHERE MATCH (`h`.`Name`, `h`.`Garden`) AGAINST ('First' WITH QUERY EXPANSION) > 0.0");
         }
 
         private void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
The `Match()` methods should return the relevance value of the match in the same way as the `MATCH...AGAINST` clause does in MySQL.

For convenience, we keep the previous functionality to just return `true` or `false` around, but rename those methods to `IsMatch()`, that just translate to `MATCH() ... AGAINST() > 0.0`.

Fixes #1679