### PR TITLE
Add support for AddMySql() method

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Migrations.Internal;
@@ -8,6 +9,7 @@ using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Update.Internal;
 using Pomelo.EntityFrameworkCore.MySql.ValueGeneration.Internal;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -20,6 +22,7 @@ using Microsoft.EntityFrameworkCore.Query;
 using Pomelo.EntityFrameworkCore.MySql.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Migrations;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal;
@@ -30,6 +33,65 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class MySqlServiceCollectionExtensions
     {
+        /// <summary>
+        ///     <para>
+        ///         Registers the given Entity Framework context as a service in the <see cref="IServiceCollection" />
+        ///         and configures it to connect to a MySQL compatible database.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure the Pomelo.EntityFrameworkCore.MySql provider and connection string.
+        ///     </para>
+        ///     <para>
+        ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or supply
+        ///         an optional action to configure the <see cref="DbContextOptions" /> for the context.
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of context to be registered. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
+        ///      </para>
+        /// </param>
+        /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
+        /// <param name="optionsAction"> An optional action to configure the <see cref="DbContextOptions" /> for the context. </param>
+        /// <returns> The same service collection so that multiple calls can be chained. </returns>
+        public static IServiceCollection AddMySql<TContext>(
+            this IServiceCollection serviceCollection,
+            string connectionString,
+            ServerVersion serverVersion,
+            Action<MySqlDbContextOptionsBuilder> mySqlOptionsAction = null,
+            Action<DbContextOptionsBuilder> optionsAction = null)
+            where TContext : DbContext
+        {
+            Check.NotNull(serviceCollection, nameof(serviceCollection));
+
+            return serviceCollection.AddDbContext<TContext>((_, options) =>
+            {
+                optionsAction?.Invoke(options);
+                options.UseMySql(connectionString, serverVersion, mySqlOptionsAction);
+            });
+        }
+
         public static IServiceCollection AddEntityFrameworkMySql([NotNull] this IServiceCollection serviceCollection)
         {
             Check.NotNull(serviceCollection, nameof(serviceCollection));

--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -72,7 +72,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             set => base.DbConnection = value;
         }
 
-        private MySqlConnectionStringBuilder AddConnectionStringOptions(MySqlConnectionStringBuilder builder)
+        protected virtual MySqlConnectionStringBuilder AddConnectionStringOptions(MySqlConnectionStringBuilder builder)
         {
             if (CommandTimeout != null)
             {


### PR DESCRIPTION
* Add missing AddMySql() method.
* Improve support for null connection strings.

For 7.0, we should set our mandatory connection string options in overridable methods of `MySqlRelationalConnection`, instead of `MySqlDbContextOptionsBuilderExtensions`.

Fixes #1692