### PR TITLE
Fix ComplexNavigationsQueryMySqlTest.SelectMany_subquery_with_custom_projection test

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/ComplexNavigationsQueryMySqlTest.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Tests.TestUtilities.Attributes;
 using Xunit.Abstractions;
@@ -23,5 +25,31 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
         {
             return base.Contains_with_subquery_optional_navigation_and_constant_item(async);
         }
+
+        public override async Task SelectMany_subquery_with_custom_projection(bool async)
+        {
+            // TODO: Fix test in EF Core upstream.
+            //           ORDER BY `l`.`Id`
+            //       is ambiguous, since all 5 queried rows have an `Id` of `1`.
+            await AssertQuery(
+                async,
+                ss => ss.Set<Level1>()/*.OrderBy(l1 => l1.Id)*/.SelectMany( // <-- has no effect anymore
+                    l1 => l1.OneToMany_Optional1.Select(
+                        l2 => new { l2.Name }))
+                    .OrderBy(l0 => l0.Name) // <-- fix
+                    .Take(1));
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT `l0`.`Name`
+FROM `LevelOne` AS `l`
+INNER JOIN `LevelTwo` AS `l0` ON `l`.`Id` = `l0`.`OneToMany_Optional_Inverse2Id`
+ORDER BY `l0`.`Name`
+LIMIT @__p_0");
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }


### PR DESCRIPTION
As with many other EF Core tests, this one relies on implicit database engine internal ordering behavior.
We make it explicit here.