### PR TITLE
Adjust syntax of log fragment

### DIFF
--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -204,7 +204,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
 
                         if (Extension.ServerVersion != null)
                         {
-                            builder.Append("ServerVersion ")
+                            builder.Append("ServerVersion=")
                                 .Append(Extension.ServerVersion)
                                 .Append(" ");
                         }


### PR DESCRIPTION
This is just small adjust regarding the log output of the options extension.

I am using a custom extension that also adds to the log. The missing `=` on the server version makes the output harder to read. It seems that Microsoft uses the format `option=value` as a convention.

This is how it looks for me right now:
`Entity Framework Core 6.0.1 initialized 'IdentityDbContext' using provider 'Pomelo.EntityFrameworkCore.MySql:6.0.1' with options: SensitiveDataLoggingEnabled DetailedErrorsEnabled MaxPoolSize=1024 ServerVersion 10.8.3-mariadb ScopedPrefix=Identity
`


This is how it would look like after merging:
`Entity Framework Core 6.0.1 initialized 'IdentityDbContext' using provider 'Pomelo.EntityFrameworkCore.MySql:6.0.1' with options: SensitiveDataLoggingEnabled DetailedErrorsEnabled MaxPoolSize=1024 ServerVersion=10.8.3-mariadb ScopedPrefix=Identity
`