### PR TITLE
Ensure AUTOCOMMIT is set to 1 where needed

### DIFF
--- a/src/EFCore.MySql/Update/Internal/MySqlUpdateSqlGenerator.cs
+++ b/src/EFCore.MySql/Update/Internal/MySqlUpdateSqlGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
@@ -343,6 +344,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Update.Internal
 
             return isIdentityOperation;
         }
+
+        public override void PrependEnsureAutocommit(StringBuilder commandStringBuilder)
+            => commandStringBuilder.Insert(0, $"SET AUTOCOMMIT = 1{SqlGenerationHelper.StatementTerminator}{Environment.NewLine}");
 
         private static (string tableName, string schema) GetTableNameAndSchema(IColumnModification modification, IProperty property)
         {

--- a/test/EFCore.MySql.FunctionalTests/DataAnnotationMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/DataAnnotationMySqlTest.cs
@@ -114,33 +114,43 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             base.ConcurrencyCheckAttribute_throws_if_value_in_database_changed();
 
             AssertSql(
-                @"SELECT `s`.`Unique_No`, `s`.`MaxLengthProperty`, `s`.`Name`, `s`.`RowVersion`, `s`.`AdditionalDetails_Name`, `s`.`AdditionalDetails_Value`, `s`.`Details_Name`, `s`.`Details_Value`
+                """
+SELECT `s`.`Unique_No`, `s`.`MaxLengthProperty`, `s`.`Name`, `s`.`RowVersion`, `s`.`AdditionalDetails_Name`, `s`.`AdditionalDetails_Value`, `s`.`Details_Name`, `s`.`Details_Value`
 FROM `Sample` AS `s`
 WHERE `s`.`Unique_No` = 1
-LIMIT 1",
+LIMIT 1
+""",
                 //
-                @"SELECT `s`.`Unique_No`, `s`.`MaxLengthProperty`, `s`.`Name`, `s`.`RowVersion`, `s`.`AdditionalDetails_Name`, `s`.`AdditionalDetails_Value`, `s`.`Details_Name`, `s`.`Details_Value`
+                """
+SELECT `s`.`Unique_No`, `s`.`MaxLengthProperty`, `s`.`Name`, `s`.`RowVersion`, `s`.`AdditionalDetails_Name`, `s`.`AdditionalDetails_Value`, `s`.`Details_Name`, `s`.`Details_Value`
 FROM `Sample` AS `s`
 WHERE `s`.`Unique_No` = 1
-LIMIT 1",
+LIMIT 1
+""",
                 //
-                @"@p2='1'
+                """
+@p2='1'
 @p0='ModifiedData' (Nullable = false) (Size = 4000)
 @p1='00000000-0000-0000-0003-000000000001'
 @p3='00000001-0000-0000-0000-000000000001'
 
+SET AUTOCOMMIT = 1;
 UPDATE `Sample` SET `Name` = @p0, `RowVersion` = @p1
 WHERE `Unique_No` = @p2 AND `RowVersion` = @p3;
-SELECT ROW_COUNT();",
+SELECT ROW_COUNT();
+""",
                 //
-                @"@p2='1'
+                """
+@p2='1'
 @p0='ChangedData' (Nullable = false) (Size = 4000)
 @p1='00000000-0000-0000-0002-000000000001'
 @p3='00000001-0000-0000-0000-000000000001'
 
+SET AUTOCOMMIT = 1;
 UPDATE `Sample` SET `Name` = @p0, `RowVersion` = @p1
 WHERE `Unique_No` = @p2 AND `RowVersion` = @p3;
-SELECT ROW_COUNT();");
+SELECT ROW_COUNT();
+""");
         }
 
         public override void DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity()
@@ -159,6 +169,7 @@ SELECT ROW_COUNT();");
 @p5='Third Name' (Size = 4000)
 @p6='0' (Nullable = true)
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `Sample` (`MaxLengthProperty`, `Name`, `RowVersion`, `AdditionalDetails_Name`, `AdditionalDetails_Value`, `Details_Name`, `Details_Value`)
 VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6)
 RETURNING `Unique_No`;

--- a/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlNoBackslashesTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlNoBackslashesTest.cs
@@ -25,6 +25,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                 AssertSql(
                     @"@p0='Back\slash's Garden Party' (Nullable = false) (Size = 4000)
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `Artists` (`Name`)
 VALUES (@p0)
 RETURNING `ArtistId`;",

--- a/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/EscapesMySqlTest.cs
@@ -25,6 +25,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                 AssertSql(
                     @"@p0='Back\slash's Garden Party' (Nullable = false) (Size = 4000)
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `Artists` (`Name`)
 VALUES (@p0)
 RETURNING `ArtistId`;",

--- a/test/EFCore.MySql.FunctionalTests/Update/NonSharedModelUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Update/NonSharedModelUpdatesMySqlTest.cs
@@ -15,9 +15,10 @@ public class NonSharedModelUpdatesMySqlTest : NonSharedModelUpdatesTestBase
         if (AppConfig.ServerVersion.Supports.Returning)
         {
             AssertSql(
-"""
+                """
 @p0='AC South' (Size = 4000)
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `AuthorsClub` (`Name`)
 VALUES (@p0)
 RETURNING `Id`;
@@ -27,6 +28,7 @@ RETURNING `Id`;
 @p1='1'
 @p2='Alice' (Size = 4000)
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `Author` (`AuthorsClubId`, `Name`)
 VALUES (@p1, @p2)
 RETURNING `Id`;
@@ -36,6 +38,7 @@ RETURNING `Id`;
 @p3='1'
 @p4=NULL (Size = 4000)
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `Book` (`AuthorId`, `Title`)
 VALUES (@p3, @p4)
 RETURNING `Id`;
@@ -51,6 +54,7 @@ LIMIT 2
                 """
 @p0='AC North' (Size = 4000)
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `AuthorsClub` (`Name`)
 VALUES (@p0)
 RETURNING `Id`;
@@ -60,6 +64,7 @@ RETURNING `Id`;
 @p1='2'
 @p2='Author of the year 2023' (Size = 4000)
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `Author` (`AuthorsClubId`, `Name`)
 VALUES (@p1, @p2)
 RETURNING `Id`;

--- a/test/EFCore.MySql.FunctionalTests/Update/StoreValueGenerationMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Update/StoreValueGenerationMySqlTest.cs
@@ -61,6 +61,7 @@ public class StoreValueGenerationMySqlTest : StoreValueGenerationTestBase<
                 """
 @p0='1000'
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `WithSomeDatabaseGenerated` (`Data2`)
 VALUES (@p0)
 RETURNING `Id`, `Data1`;
@@ -91,6 +92,7 @@ WHERE ROW_COUNT() = 1 AND `Id` = LAST_INSERT_ID();
 @p1='1000'
 @p2='1000'
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `WithNoDatabaseGenerated` (`Id`, `Data1`, `Data2`)
 VALUES (@p0, @p1, @p2);
 """);
@@ -104,6 +106,7 @@ VALUES (@p0, @p1, @p2);
         {
             AssertSql(
                 """
+SET AUTOCOMMIT = 1;
 INSERT INTO `WithAllDatabaseGenerated` ()
 VALUES ()
 RETURNING `Id`, `Data1`, `Data2`;
@@ -149,6 +152,7 @@ WHERE ROW_COUNT() = 1 AND `Id` = @p1;
 @p0='1000'
 @p1='1000'
 
+SET AUTOCOMMIT = 1;
 UPDATE `WithNoDatabaseGenerated` SET `Data1` = @p0, `Data2` = @p1
 WHERE `Id` = @p2;
 SELECT ROW_COUNT();
@@ -165,6 +169,7 @@ SELECT ROW_COUNT();
 """
 @p0='1'
 
+SET AUTOCOMMIT = 1;
 DELETE FROM `WithSomeDatabaseGenerated`
 WHERE `Id` = @p0
 RETURNING 1;
@@ -176,6 +181,7 @@ RETURNING 1;
 """
 @p0='1'
 
+SET AUTOCOMMIT = 1;
 DELETE FROM `WithSomeDatabaseGenerated`
 WHERE `Id` = @p0;
 SELECT ROW_COUNT();
@@ -241,6 +247,7 @@ WHERE ROW_COUNT() = 1 AND `Id` = LAST_INSERT_ID();
 @p4='1001'
 @p5='1001'
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `WithNoDatabaseGenerated` (`Id`, `Data1`, `Data2`)
 VALUES (@p0, @p1, @p2),
 (@p3, @p4, @p5);

--- a/test/EFCore.MySql.FunctionalTests/Update/StoredProcedureUpdateMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Update/StoredProcedureUpdateMySqlTest.cs
@@ -518,6 +518,7 @@ SELECT @_out_p0;
 @p2='1'
 @p3='8'
 
+SET AUTOCOMMIT = 1;
 INSERT INTO `Child1` (`Id`, `Child1Property`)
 VALUES (@p2, @p3);
 """);


### PR DESCRIPTION
Similar to SQL Server, we force a `SET AUTOCOMMIT = 1;` statement before statements, that are executed without explicit transaction, just in case the server or session default was previously changed to `AUTOCOMMIT = 0`.

Fixes #1740