### PR TITLE
Add nuget.org targeted README files to NuGet packages

### DIFF
--- a/src/EFCore.MySql.Json.Microsoft/EFCore.MySql.Json.Microsoft.csproj
+++ b/src/EFCore.MySql.Json.Microsoft/EFCore.MySql.Json.Microsoft.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Pomelo.EntityFrameworkCore.MySql.Json.Microsoft</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageTags>$(PackageTags);json;system.text.json;microsoft</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -77,6 +78,10 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="System.Collections.Immutable" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="docs\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/EFCore.MySql.Json.Microsoft/docs/README.md
+++ b/src/EFCore.MySql.Json.Microsoft/docs/README.md
@@ -1,0 +1,25 @@
+﻿## About
+
+_Pomelo.EntityFrameworkCore.MySql.Json.Microsoft_ adds JSON support for `System.Text.Json` (the Microsoft JSON stack) to [Pomelo.EntityFrameworkCore.MySql](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql).
+
+## How to Use
+
+```csharp
+optionsBuilder.UseMySql(
+    connectionString,
+    serverVersion,
+    options => options.UseMicrosoftJson())
+```
+
+## Related Packages
+
+* [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql)
+* [System.Text.Json](https://www.nuget.org/packages/System.Text.Json)
+
+## License
+
+_Pomelo.EntityFrameworkCore.MySql.Json.Microsoft_ is released as open source under the [MIT license](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/blob/master/LICENSE).
+
+## Feedback
+
+Bug reports and contributions are welcome at our [GitHub repository](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql).

--- a/src/EFCore.MySql.Json.Newtonsoft/EFCore.MySql.Json.Newtonsoft.csproj
+++ b/src/EFCore.MySql.Json.Newtonsoft/EFCore.MySql.Json.Newtonsoft.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageTags>$(PackageTags);json;newtonsoft.json;json.net;newtonsoft</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -78,6 +79,10 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="System.Collections.Immutable" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="docs\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/EFCore.MySql.Json.Newtonsoft/docs/README.md
+++ b/src/EFCore.MySql.Json.Newtonsoft/docs/README.md
@@ -1,0 +1,25 @@
+﻿## About
+
+_Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft_ adds JSON support for `Newtonsoft.Json` (the Newtonsoft JSON/Json.NET stack) to [Pomelo.EntityFrameworkCore.MySql](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql).
+
+## How to Use
+
+```csharp
+optionsBuilder.UseMySql(
+    connectionString,
+    serverVersion,
+    options => options.UseNewtonsoftJson())
+```
+
+## Related Packages
+
+* [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql)
+* [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json)
+
+## License
+
+_Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft_ is released as open source under the [MIT license](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/blob/master/LICENSE).
+
+## Feedback
+
+Bug reports and contributions are welcome at our [GitHub repository](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql).

--- a/src/EFCore.MySql.NTS/EFCore.MySql.NTS.csproj
+++ b/src/EFCore.MySql.NTS/EFCore.MySql.NTS.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Pomelo.EntityFrameworkCore.MySql</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageTags>$(PackageTags);gis;opengis;nts;ogc;spatial</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -103,6 +104,10 @@
     <EmbeddedResource Update="Properties\MySqlNTSStrings.resx">
       <CustomToolNamespace>Pomelo.EntityFrameworkCore.MySql.Internal</CustomToolNamespace>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="docs\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/EFCore.MySql.NTS/docs/README.md
+++ b/src/EFCore.MySql.NTS/docs/README.md
@@ -1,0 +1,25 @@
+﻿## About
+
+_Pomelo.EntityFrameworkCore.MySql.NetTopologySuite_ adds spatial support for [NetTopologySuite](https://github.com/NetTopologySuite/NetTopologySuite) to [Pomelo.EntityFrameworkCore.MySql](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql).
+
+## How to Use
+
+```csharp
+optionsBuilder.UseMySql(
+    connectionString,
+    serverVersion,
+    options => options.UseNetTopologySuite())
+```
+
+## Related Packages
+
+* [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql)
+* [NetTopologySuite](https://www.nuget.org/packages/NetTopologySuite)
+
+## License
+
+_Pomelo.EntityFrameworkCore.MySql.NetTopologySuite_ is released as open source under the [MIT license](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/blob/master/LICENSE).
+
+## Feedback
+
+Bug reports and contributions are welcome at our [GitHub repository](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql).

--- a/src/EFCore.MySql/EFCore.MySql.csproj
+++ b/src/EFCore.MySql/EFCore.MySql.csproj
@@ -6,6 +6,7 @@
     <MinClientVersion>3.6</MinClientVersion>
     <AssemblyName>Pomelo.EntityFrameworkCore.MySql</AssemblyName>
     <RootNamespace>Pomelo.EntityFrameworkCore.MySql</RootNamespace>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -90,6 +91,10 @@
     <EmbeddedResource Update="Properties\MySqlStrings.resx">
       <CustomToolNamespace>Pomelo.EntityFrameworkCore.MySql.Internal</CustomToolNamespace>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="docs\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/EFCore.MySql/docs/README.md
+++ b/src/EFCore.MySql/docs/README.md
@@ -1,0 +1,60 @@
+﻿## About
+
+_Pomelo.EntityFrameworkCore.MySql_ is the Entity Framework Core (EF Core) provider for [MySQL](https://www.mysql.com), [MariaDB](https://mariadb.org), [Amazon Aurora](https://aws.amazon.com/rds/aurora), [Azure Database for MySQL](https://azure.microsoft.com/en-us/services/mysql) and other MySQL-compatible databases.
+
+It is build on top of [MySqlConnector](https://github.com/mysql-net/MySqlConnector).
+
+## How to Use
+
+```csharp
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Replace with your connection string.
+        var connectionString = "server=localhost;user=root;password=1234;database=ef";
+
+        // Replace with your server version and type.
+        // Use 'MariaDbServerVersion' for MariaDB.
+        // Alternatively, use 'ServerVersion.AutoDetect(connectionString)'.
+        // For common usages, see pull request #1233.
+        var serverVersion = new MySqlServerVersion(new Version(8, 0, 29));
+
+        // Replace 'YourDbContext' with the name of your own DbContext derived class.
+        services.AddDbContext<YourDbContext>(
+            dbContextOptions => dbContextOptions
+                .UseMySql(connectionString, serverVersion)
+                // The following three options help with debugging, but should
+                // be changed or removed for production.
+                .LogTo(Console.WriteLine, LogLevel.Information)
+                .EnableSensitiveDataLogging()
+                .EnableDetailedErrors()
+        );
+    }
+}
+```
+
+## Key Features
+
+* JSON support (both `Newtonsoft.Json` and `System.Text.Json`)
+* Spatial support
+* High performance
+
+## Related Packages
+
+* JSON support
+  * [Pomelo.EntityFrameworkCore.MySql.Json.Microsoft](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql.Json.Microsoft)
+  * [Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft)
+* Spatial support
+  * [Pomelo.EntityFrameworkCore.MySql.NetTopologySuite](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql.NetTopologySuite)
+* Other Packages
+  * [MySqlConnector](https://www.nuget.org/packages/MySqlConnector)
+  * [Microsoft.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore)
+
+## License
+
+_Pomelo.EntityFrameworkCore.MySql_ is released as open source under the [MIT license](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/blob/master/LICENSE).
+
+## Feedback
+
+Bug reports and contributions are welcome at our [GitHub repository](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql).


### PR DESCRIPTION
Adds a README.md file to each of the 4 NuGet packages to be displayed under the _README_ tab on [nuget.org](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql#readme-body-tab).

Fixes #1724 