### PR TITLE
Add RenameIndex support for MariaDB versions >= 10.5.2

### DIFF
--- a/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore
             public override bool DateTimeCurrentTimestamp => ServerVersion.Version >= new Version(10, 0, 1);
             public override bool DateTime6 => ServerVersion.Version >= new Version(10, 1, 2);
             public override bool LargerKeyLength => ServerVersion.Version >= new Version(10, 2, 2);
-            public override bool RenameIndex => false;
+            public override bool RenameIndex => ServerVersion.Version >= new Version(10, 5, 2);
             public override bool RenameColumn => ServerVersion.Version >= new Version(10, 5, 2);
             public override bool WindowFunctions => ServerVersion.Version >= new Version(10, 2, 0);
             public override bool FloatCast => false; // The implemented support drops some decimal places and rounds.


### PR DESCRIPTION
Rename index support was added by the following MariaDB issue: https://jira.mariadb.org/browse/MDEV-7318

As far as I can see it is the exact same syntax, that MySQL supports. This syntax is already supported by this library and tests exist as well.

Changing this makes migrations for MariaDB easier, because you can't run into the "Cannot drop index needed in a foreign key constraint" problem.

Fixes: #1793
