### PR TITLE
Update MySqlConnector to 2.3.1

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -9,7 +9,7 @@
     <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
 
-    <PackageReference Update="MySqlConnector" Version="2.3.0" />
+    <PackageReference Update="MySqlConnector" Version="2.3.1" />
 
     <PackageReference Update="NetTopologySuite" Version="2.5.0" />
     <PackageReference Update="System.Text.Json" Version="8.0.0" />


### PR DESCRIPTION
This is the latest published version, and brings metrics collection more in line with OTel standards. 