### PR TITLE
Bump mariadb releases + 11.2.2 now GA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,14 @@ jobs:
         dbVersion:
           - 8.0.34-mysql
           - 5.7.43-mysql
-          - 11.1.2-mariadb
-          - 11.0.3-mariadb
-          - 10.11.5-mariadb
-          - 10.10.6-mariadb
-          - 10.6.15-mariadb
-          - 10.5.22-mariadb
-          - 10.4.31-mariadb
+          - 11.2.2-mariadb
+          - 11.1.3-mariadb
+          - 11.0.4-mariadb
+          - 10.11.6-mariadb
+          - 10.10.7-mariadb
+          - 10.6.16-mariadb
+          - 10.5.23-mariadb
+          - 10.4.32-mariadb
         os:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION

slightly pre-emptive of https://github.com/docker-library/official-images/pull/15757 being merged and its build process generating an image.