### PR TITLE
Add `DbDataSource`/`MySqlDataSource` support

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -10,6 +10,7 @@
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
 
     <PackageReference Update="MySqlConnector" Version="2.3.1" />
+    <PackageReference Update="MySqlConnector.DependencyInjection" Version="2.3.1" />
 
     <PackageReference Update="NetTopologySuite" Version="2.5.0" />
     <PackageReference Update="System.Text.Json" Version="8.0.0" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,7 @@
     <EfCoreTargetFramework>net8.0</EfCoreTargetFramework>
     <EfCoreTestTargetFramework>net8.0</EfCoreTestTargetFramework>
     <MySqlConnectorTargetFramework>net8.0</MySqlConnectorTargetFramework>
+    <MySqlConnectorDependencyInjectionTargetFramework>net7.0</MySqlConnectorDependencyInjectionTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/EFCore.MySql/Extensions/MySqlDatabaseFacadeExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDatabaseFacadeExtensions.cs
@@ -2,10 +2,14 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
+using System.Data.Common;
 using System.Reflection;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 //ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -32,5 +36,33 @@ namespace Microsoft.EntityFrameworkCore
             => database.ProviderName.Equals(
                 typeof(MySqlOptionsExtension).GetTypeInfo().Assembly.GetName().Name,
                 StringComparison.Ordinal);
+
+        /// <summary>
+        ///     Uses a <see cref="DbDataSource" /> for this <see cref="DbContext" /> as the underlying database provider.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         It may not be possible to change the data source if an existing connection is open.
+        ///     </para>
+        ///     <para>
+        ///         See <see href="https://aka.ms/efcore-docs-connections">Connections and connection strings</see> for more information and examples.
+        ///     </para>
+        /// </remarks>
+        /// <param name="databaseFacade">The <see cref="DatabaseFacade" /> for the context.</param>
+        /// <param name="dataSource">The data source.</param>
+        public static void SetDbDataSource(this DatabaseFacade databaseFacade, DbDataSource dataSource)
+            => ((MySqlRelationalConnection)GetFacadeDependencies(databaseFacade).RelationalConnection).DbDataSource = dataSource;
+
+        private static IRelationalDatabaseFacadeDependencies GetFacadeDependencies(DatabaseFacade databaseFacade)
+        {
+            var dependencies = ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Dependencies;
+
+            if (dependencies is IRelationalDatabaseFacadeDependencies relationalDependencies)
+            {
+                return relationalDependencies;
+            }
+
+            throw new InvalidOperationException(RelationalStrings.RelationalNotInUse);
+        }
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbContextOptionsBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using MySqlConnector;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -98,16 +99,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
             Check.NullButNotEmpty(connectionString, nameof(connectionString));
 
-            if (connectionString is not null)
-            {
-                var resolvedConnectionString = new NamedConnectionStringResolver(optionsBuilder.Options)
-                    .ResolveConnectionString(connectionString);
-
-                // TODO: Move to MySqlRelationalConnection.
-                var csb = new MySqlConnectionStringBuilder(resolvedConnectionString) { AllowUserVariables = true, UseAffectedRows = false };
-
-                connectionString = csb.ConnectionString;
-            }
+            MySqlConnectionStringOptionsValidator.Instance.EnsureMandatoryOptions(ref connectionString, optionsBuilder.Options);
 
             var extension = (MySqlOptionsExtension)GetOrCreateExtension(optionsBuilder)
                 .WithServerVersion(serverVersion)
@@ -155,35 +147,56 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
             Check.NotNull(connection, nameof(connection));
 
-            var resolvedConnectionString = connection.ConnectionString is not null
-                ? new NamedConnectionStringResolver(optionsBuilder.Options)
-                    .ResolveConnectionString(connection.ConnectionString)
-                : null;
-
-            // TODO: Move to MySqlRelationalConnection.
-            var csb = new MySqlConnectionStringBuilder(resolvedConnectionString);
-
-            if (!csb.AllowUserVariables ||
-                csb.UseAffectedRows)
-            {
-                try
-                {
-                    csb.AllowUserVariables = true;
-                    csb.UseAffectedRows = false;
-
-                    connection.ConnectionString = csb.ConnectionString;
-                }
-                catch (Exception e)
-                {
-                    throw new InvalidOperationException(
-                        @"The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain ""AllowUserVariables=true;UseAffectedRows=false"".",
-                        e);
-                }
-            }
+            MySqlConnectionStringOptionsValidator.Instance.EnsureMandatoryOptions(connection, optionsBuilder.Options);
 
             var extension = (MySqlOptionsExtension)GetOrCreateExtension(optionsBuilder)
                 .WithServerVersion(serverVersion)
                 .WithConnection(connection);
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+            ConfigureWarnings(optionsBuilder);
+            mySqlOptionsAction?.Invoke(new MySqlDbContextOptionsBuilder(optionsBuilder));
+
+            return optionsBuilder;
+        }
+
+
+        /// <summary>
+        ///     Configures the context to connect to a MySQL compatible database.
+        /// </summary>
+        /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
+        /// <param name="dataSource"> A <see cref="DbDataSource" /> which will be used to get database connections. </param>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
+        ///      </para>
+        /// </param>
+        /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
+        /// <returns> The options builder so that further configuration can be chained. </returns>
+        public static DbContextOptionsBuilder UseMySql(
+            this DbContextOptionsBuilder optionsBuilder,
+            DbDataSource dataSource,
+            [NotNull] ServerVersion serverVersion,
+            Action<MySqlDbContextOptionsBuilder> mySqlOptionsAction = null)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+            Check.NotNull(dataSource, nameof(dataSource));
+
+            MySqlConnectionStringOptionsValidator.Instance.EnsureMandatoryOptions(dataSource);
+
+            var extension = (MySqlOptionsExtension)GetOrCreateExtension(optionsBuilder)
+                .WithServerVersion(serverVersion)
+                .WithDataSource(dataSource);
 
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
             ConfigureWarnings(optionsBuilder);
@@ -297,6 +310,38 @@ namespace Microsoft.EntityFrameworkCore
             where TContext : DbContext
             => (DbContextOptionsBuilder<TContext>)UseMySql(
                 (DbContextOptionsBuilder)optionsBuilder, connection, serverVersion, mySqlOptionsAction);
+
+        /// <summary>
+        ///     Configures the context to connect to a MySQL compatible database.
+        /// </summary>
+        /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
+        /// <param name="dataSource"> A <see cref="DbDataSource" /> which will be used to get database connections. </param>
+        /// <typeparam name="TContext"> The type of context to be configured. </typeparam>
+        /// <param name="serverVersion">
+        ///     <para>
+        ///         The version of the database server.
+        ///     </para>
+        ///     <para>
+        ///         Create an object for this parameter by calling the static method
+        ///         <see cref="ServerVersion.Create(System.Version,ServerType)"/>,
+        ///         by calling the static method <see cref="ServerVersion.AutoDetect(string)"/> (which retrieves the server version directly
+        ///         from the database server),
+        ///         by parsing a version string using the static methods
+        ///         <see cref="ServerVersion.Parse(string)"/> or <see cref="ServerVersion.TryParse(string,out ServerVersion)"/>,
+        ///         or by directly instantiating an object from the <see cref="MySqlServerVersion"/> (for MySQL) or
+        ///         <see cref="MariaDbServerVersion"/> (for MariaDB) classes.
+        ///      </para>
+        /// </param>
+        /// <param name="mySqlOptionsAction"> An optional action to allow additional MySQL specific configuration. </param>
+        /// <returns> The options builder so that further configuration can be chained. </returns>
+        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(
+            [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+            [NotNull] DbDataSource dataSource,
+            [NotNull] ServerVersion serverVersion,
+            [CanBeNull] Action<MySqlDbContextOptionsBuilder> mySqlOptionsAction = null)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseMySql(
+                (DbContextOptionsBuilder)optionsBuilder, dataSource, serverVersion, mySqlOptionsAction);
 
         private static MySqlOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.Options.FindExtension<MySqlOptionsExtension>()

--- a/src/EFCore.MySql/Extensions/MySqlDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbContextOptionsBuilderExtensions.cs
@@ -8,10 +8,7 @@ using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
-using MySqlConnector;
-using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -99,8 +96,6 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
             Check.NullButNotEmpty(connectionString, nameof(connectionString));
 
-            MySqlConnectionStringOptionsValidator.Instance.EnsureMandatoryOptions(ref connectionString, optionsBuilder.Options);
-
             var extension = (MySqlOptionsExtension)GetOrCreateExtension(optionsBuilder)
                 .WithServerVersion(serverVersion)
                 .WithConnectionString(connectionString);
@@ -147,8 +142,6 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
             Check.NotNull(connection, nameof(connection));
 
-            MySqlConnectionStringOptionsValidator.Instance.EnsureMandatoryOptions(connection, optionsBuilder.Options);
-
             var extension = (MySqlOptionsExtension)GetOrCreateExtension(optionsBuilder)
                 .WithServerVersion(serverVersion)
                 .WithConnection(connection);
@@ -191,8 +184,6 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
             Check.NotNull(dataSource, nameof(dataSource));
-
-            MySqlConnectionStringOptionsValidator.Instance.EnsureMandatoryOptions(dataSource);
 
             var extension = (MySqlOptionsExtension)GetOrCreateExtension(optionsBuilder)
                 .WithServerVersion(serverVersion)

--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IModificationCommandFactory, MySqlModificationCommandFactory>()
                 .TryAdd<IModificationCommandBatchFactory, MySqlModificationCommandBatchFactory>()
                 .TryAdd<IValueGeneratorSelector, MySqlValueGeneratorSelector>()
-                .TryAdd<IRelationalConnection>(p => p.GetService<IMySqlRelationalConnection>())
+                .TryAdd<IRelationalConnection>(p => p.GetRequiredService<IMySqlRelationalConnection>())
                 .TryAdd<IMigrationsSqlGenerator, MySqlMigrationsSqlGenerator>()
                 .TryAdd<IRelationalDatabaseCreator, MySqlDatabaseCreator>()
                 .TryAdd<IHistoryRepository, MySqlHistoryRepository>()
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, MySqlSqlTranslatingExpressionVisitorFactory>()
                 .TryAdd<IRelationalParameterBasedSqlProcessorFactory, MySqlParameterBasedSqlProcessorFactory>()
                 .TryAdd<ISqlExpressionFactory, MySqlSqlExpressionFactory>()
-                .TryAdd<ISingletonOptions, IMySqlOptions>(p => p.GetService<IMySqlOptions>())
+                .TryAdd<ISingletonOptions, IMySqlOptions>(p => p.GetRequiredService<IMySqlOptions>())
                 //.TryAdd<IValueConverterSelector, MySqlValueConverterSelector>()
                 .TryAdd<IQueryCompilationContextFactory, MySqlQueryCompilationContextFactory>()
                 .TryAdd<IQueryTranslationPostprocessorFactory, MySqlQueryTranslationPostprocessorFactory>()
@@ -140,7 +140,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAddProviderSpecificServices(m => m
                     //.TryAddSingleton<IMySqlValueGeneratorCache, MySqlValueGeneratorCache>()
                     .TryAddSingleton<IMySqlOptions, MySqlOptions>()
-                    //.TryAddSingleton<IMySqlConnectionStringOptionsValidator, MySqlConnectionStringOptionsValidator>()
+                    .TryAddSingleton<IMySqlConnectionStringOptionsValidator, MySqlConnectionStringOptionsValidator>()
                     //.TryAddScoped<IMySqlSequenceValueGeneratorFactory, MySqlSequenceValueGeneratorFactory>()
                     .TryAddScoped<IMySqlUpdateSqlGenerator, MySqlUpdateSqlGenerator>()
                     .TryAddScoped<IMySqlRelationalConnection, MySqlRelationalConnection>());

--- a/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlServiceCollectionExtensions.cs
@@ -27,7 +27,6 @@ using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Migrations;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
-using Pomelo.EntityFrameworkCore.MySql.Storage;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -141,6 +140,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAddProviderSpecificServices(m => m
                     //.TryAddSingleton<IMySqlValueGeneratorCache, MySqlValueGeneratorCache>()
                     .TryAddSingleton<IMySqlOptions, MySqlOptions>()
+                    //.TryAddSingleton<IMySqlConnectionStringOptionsValidator, MySqlConnectionStringOptionsValidator>()
                     //.TryAddScoped<IMySqlSequenceValueGeneratorFactory, MySqlSequenceValueGeneratorFactory>()
                     .TryAddScoped<IMySqlUpdateSqlGenerator, MySqlUpdateSqlGenerator>()
                     .TryAddScoped<IMySqlRelationalConnection, MySqlRelationalConnection>());

--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -11,7 +11,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
     public interface IMySqlOptions : ISingletonOptions
     {
         MySqlConnectionSettings ConnectionSettings { get; }
+
+        /// <remarks>
+        /// If null, there might still be a `DbDataSource` in the ApplicationServiceProvider.
+        /// </remarks>>
         DbDataSource DataSource { get; }
+
         ServerVersion ServerVersion { get; }
         CharSet DefaultCharSet { get; }
         CharSet NationalCharSet { get; }

--- a/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/IMySqlOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -10,6 +11,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
     public interface IMySqlOptions : ISingletonOptions
     {
         MySqlConnectionSettings ConnectionSettings { get; }
+        DbDataSource DataSource { get; }
         ServerVersion ServerVersion { get; }
         CharSet DefaultCharSet { get; }
         CharSet NationalCharSet { get; }

--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -215,17 +215,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             return clone;
         }
 
-        /// <inheritdoc />
-        public override void Validate(IDbContextOptions options)
-        {
-            base.Validate(options);
-
-            MySqlConnectionStringOptionsValidator.Instance.ThrowOnInvalidMandatoryOptions(
-                ConnectionString,
-                Connection,
-                DataSource ?? options.FindExtension<CoreOptionsExtension>()?.ApplicationServiceProvider?.GetService<MySqlDataSource>());
-        }
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
+++ b/src/EFCore.MySql/Infrastructure/Internal/MySqlOptionsExtension.cs
@@ -7,8 +7,11 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Globalization;
 using Microsoft.EntityFrameworkCore;
+using MySqlConnector;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
 {
@@ -29,6 +32,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         public MySqlOptionsExtension([NotNull] MySqlOptionsExtension copyFrom)
             : base(copyFrom)
         {
+            DataSource = copyFrom.DataSource;
             ServerVersion = copyFrom.ServerVersion;
             NoBackslashEscapes = copyFrom.NoBackslashEscapes;
             UpdateSqlModeOnOpen = copyFrom.UpdateSqlModeOnOpen;
@@ -52,6 +56,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
 
         protected override RelationalOptionsExtension Clone()
             => new MySqlOptionsExtension(this);
+
+        /// <summary>
+        ///     The <see cref="DbDataSource" />, or <see langword="null" /> if a connection string or <see cref="DbConnection" /> was used
+        ///     instead of a <see cref="DbDataSource" />.
+        /// </summary>
+        public virtual DbDataSource DataSource { get; private set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -81,6 +91,35 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
         public virtual bool LimitKeyedOrIndexedStringColumnLength { get; private set; }
         public virtual bool StringComparisonTranslations { get; private set; }
         public virtual bool PrimitiveCollectionsSupport { get; private set; }
+
+        /// <summary>
+        ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
+        ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
+        /// </summary>
+        /// <param name="dataSource">The option to change.</param>
+        /// <returns>A new instance with the option changed.</returns>
+        public virtual RelationalOptionsExtension WithDataSource(DbDataSource dataSource)
+        {
+            var clone = (MySqlOptionsExtension)Clone();
+            clone.DataSource = dataSource;
+            return clone;
+        }
+
+        /// <inheritdoc />
+        public override RelationalOptionsExtension WithConnectionString(string connectionString)
+        {
+            var clone = (MySqlOptionsExtension)base.WithConnectionString(connectionString);
+            clone.DataSource = null;
+            return clone;
+        }
+
+        /// <inheritdoc />
+        public override RelationalOptionsExtension WithConnection(DbConnection connection)
+        {
+            var clone = (MySqlOptionsExtension)base.WithConnection(connection);
+            clone.DataSource = null;
+            return clone;
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -176,6 +215,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             return clone;
         }
 
+        /// <inheritdoc />
+        public override void Validate(IDbContextOptions options)
+        {
+            base.Validate(options);
+
+            MySqlConnectionStringOptionsValidator.Instance.ThrowOnInvalidMandatoryOptions(
+                ConnectionString,
+                Connection,
+                DataSource ?? options.FindExtension<CoreOptionsExtension>()?.ApplicationServiceProvider?.GetService<MySqlDataSource>());
+        }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -230,6 +280,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
                 {
                     var hashCode = new HashCode();
                     hashCode.Add(base.GetServiceProviderHashCode());
+                    hashCode.Add(Extension.DataSource?.ConnectionString);
                     hashCode.Add(Extension.ServerVersion);
                     hashCode.Add(Extension.NoBackslashEscapes);
                     hashCode.Add(Extension.UpdateSqlModeOnOpen);
@@ -251,6 +302,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal
             public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
                 => other is ExtensionInfo otherInfo &&
                    base.ShouldUseSameServiceProvider(other) &&
+                   ReferenceEquals(Extension.DataSource, otherInfo.Extension.DataSource) &&
                    Equals(Extension.ServerVersion, otherInfo.Extension.ServerVersion) &&
                    Extension.NoBackslashEscapes == otherInfo.Extension.NoBackslashEscapes &&
                    Extension.UpdateSqlModeOnOpen == otherInfo.Extension.UpdateSqlModeOnOpen &&

--- a/src/EFCore.MySql/Properties/MySqlStrings.Designer.cs
+++ b/src/EFCore.MySql/Properties/MySqlStrings.Designer.cs
@@ -22,6 +22,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
             = new ResourceManager("Pomelo.EntityFrameworkCore.MySql.Properties.MySqlStrings", typeof(MySqlStrings).GetTypeInfo().Assembly);
 
         /// <summary>
+        ///     Using two distinct data sources within a service provider is not supported, and Entity Framework is not building its own internal service provider. Either allow Entity Framework to build the service provider by removing the call to '{useInternalServiceProvider}', or ensure that the same data source is used for all uses of a given service provider passed to '{useInternalServiceProvider}'.
+        /// </summary>
+        public static string TwoDataSourcesInSameServiceProvider(object useInternalServiceProvider)
+            => string.Format(
+                GetString("TwoDataSourcesInSameServiceProvider", nameof(useInternalServiceProvider)),
+                useInternalServiceProvider);
+
+        /// <summary>
         ///     Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with integer, DateTime, and DateTimeOffset properties.
         /// </summary>
         public static string IdentityBadType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyType)

--- a/src/EFCore.MySql/Properties/MySqlStrings.resx
+++ b/src/EFCore.MySql/Properties/MySqlStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="TwoDataSourcesInSameServiceProvider" xml:space="preserve">
+    <value>Using two distinct data sources within a service provider is not supported, and Entity Framework is not building its own internal service provider. Either allow Entity Framework to build the service provider by removing the call to '{useInternalServiceProvider}', or ensure that the same data source is used for all uses of a given service provider passed to '{useInternalServiceProvider}'.</value>
+  </data>
   <data name="IdentityBadType" xml:space="preserve">
     <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with integer, DateTime, and DateTimeOffset properties.</value>
   </data>

--- a/src/EFCore.MySql/Storage/Internal/IMySqlConnectionStringOptionsValidator.cs
+++ b/src/EFCore.MySql/Storage/Internal/IMySqlConnectionStringOptionsValidator.cs
@@ -1,20 +1,16 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using System.Data.Common;
-using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 public interface IMySqlConnectionStringOptionsValidator
 {
-    void EnsureMandatoryOptions([NotNull] ref string connectionString, IDbContextOptions options = null);
-    void EnsureMandatoryOptions([NotNull] DbConnection connection, IDbContextOptions options = null);
-    void EnsureMandatoryOptions([NotNull] DbDataSource dataSource);
+    bool EnsureMandatoryOptions(ref string connectionString);
+    bool EnsureMandatoryOptions(DbConnection connection);
+    bool EnsureMandatoryOptions(DbDataSource dataSource);
 
-    void ThrowOnInvalidMandatoryOptions(
-        string connectionString,
-        DbConnection connection,
-        DbDataSource dataSource);
+    void ThrowException(Exception innerException = null);
 }

--- a/src/EFCore.MySql/Storage/Internal/IMySqlConnectionStringOptionsValidator.cs
+++ b/src/EFCore.MySql/Storage/Internal/IMySqlConnectionStringOptionsValidator.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+
+public interface IMySqlConnectionStringOptionsValidator
+{
+    void EnsureMandatoryOptions([NotNull] ref string connectionString, IDbContextOptions options = null);
+    void EnsureMandatoryOptions([NotNull] DbConnection connection, IDbContextOptions options = null);
+    void EnsureMandatoryOptions([NotNull] DbDataSource dataSource);
+
+    void ThrowOnInvalidMandatoryOptions(
+        string connectionString,
+        DbConnection connection,
+        DbDataSource dataSource);
+}

--- a/src/EFCore.MySql/Storage/Internal/MySqlConnectionStringOptionsValidator.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlConnectionStringOptionsValidator.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using MySqlConnector;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+
+public class MySqlConnectionStringOptionsValidator : IMySqlConnectionStringOptionsValidator
+{
+    public static MySqlConnectionStringOptionsValidator Instance { get; } = new MySqlConnectionStringOptionsValidator();
+
+    public virtual void EnsureMandatoryOptions(ref string connectionString, IDbContextOptions options = null)
+    {
+        if (connectionString is null)
+        {
+            return;
+        }
+
+        if (options is not null)
+        {
+            connectionString = new NamedConnectionStringResolver(options)
+                .ResolveConnectionString(connectionString);
+        }
+
+        var csb = new MySqlConnectionStringBuilder(connectionString);
+
+        if (!ValidateMandatoryOptions(csb))
+        {
+            csb.AllowUserVariables = true;
+            csb.UseAffectedRows = false;
+        }
+
+        connectionString = csb.ConnectionString;
+    }
+
+    public virtual void EnsureMandatoryOptions([NotNull] DbConnection connection, IDbContextOptions options = null)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        var connectionString = options is not null
+            ? connection.ConnectionString is not null
+                ? new NamedConnectionStringResolver(options)
+                    .ResolveConnectionString(connection.ConnectionString)
+                : null
+            : connection.ConnectionString;
+
+        var csb = new MySqlConnectionStringBuilder(connectionString);
+
+        if (!ValidateMandatoryOptions(csb))
+        {
+            try
+            {
+                csb.AllowUserVariables = true;
+                csb.UseAffectedRows = false;
+
+                connection.ConnectionString = csb.ConnectionString;
+                return;
+            }
+            catch (Exception e)
+            {
+                ThrowException(e);
+            }
+        }
+
+        // The connection string could have changed by the NamedConnectionStringResolver call earlier.
+        if (connectionString != connection.ConnectionString)
+        {
+            connection.ConnectionString = connectionString;
+        }
+    }
+
+    public virtual void EnsureMandatoryOptions([NotNull] DbDataSource dataSource)
+    {
+        ArgumentNullException.ThrowIfNull(dataSource);
+
+        var csb = new MySqlConnectionStringBuilder(dataSource.ConnectionString);
+
+        if (!ValidateMandatoryOptions(csb))
+        {
+            // We can't alter the connection string of a DbDataSource/MySqlDataSource as we do for DbConnection/MySqlConnection in cases
+            // where the necessary connection string options have not been set.
+            // We can only throw.
+            ThrowException();
+        }
+    }
+
+    public virtual void ThrowOnInvalidMandatoryOptions(
+        string connectionString,
+        DbConnection connection,
+        DbDataSource dataSource)
+    {
+        bool valid;
+
+        // If we don't have an explicitly-configured data source, try to get one from the application service provider.
+        if (dataSource is not null)
+        {
+            valid = ValidateMandatoryOptions(dataSource.ConnectionString);
+        }
+        else if (connection is not null)
+        {
+            valid = ValidateMandatoryOptions(connection.ConnectionString);
+        }
+        else
+        {
+            valid = ValidateMandatoryOptions(connectionString);
+        }
+
+        if (!valid)
+        {
+            ThrowException();
+        }
+    }
+
+    protected virtual bool ValidateMandatoryOptions(string connectionString)
+        => ValidateMandatoryOptions(new MySqlConnectionStringBuilder(connectionString));
+
+    protected virtual bool ValidateMandatoryOptions(MySqlConnectionStringBuilder csb)
+        => csb.AllowUserVariables &&
+           !csb.UseAffectedRows;
+
+    protected virtual void ThrowException(Exception innerException = null)
+        => throw new InvalidOperationException(
+            @"The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain ""AllowUserVariables=True;UseAffectedRows=False"".",
+            innerException);
+}

--- a/test/EFCore.MySql.FunctionalTests/ExistingConnectionMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/ExistingConnectionMySqlTest.cs
@@ -2,6 +2,8 @@
 using System.Data;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
@@ -119,12 +121,17 @@ public class ExistingConnectionMySqlTest
             {
                 await connection.OpenAsync();
 
+                var options = new DbContextOptionsBuilder<NorthwindContext>()
+                    .UseMySql(connection, AppConfig.ServerVersion)
+                    .Options;
+
+                await using var context = new NorthwindContext(options);
+
                 Assert.Equal(
                     Assert.Throws<InvalidOperationException>(
                         () =>
                         {
-                            new DbContextOptionsBuilder<NorthwindContext>()
-                                .UseMySql(connection, AppConfig.ServerVersion);
+                            context.GetService<IRelationalConnection>();
                         }).Message,
                     @"The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain ""AllowUserVariables=True;UseAffectedRows=False"".");
             }
@@ -175,12 +182,17 @@ public class ExistingConnectionMySqlTest
             {
                 await connection.OpenAsync();
 
+                var options = new DbContextOptionsBuilder<NorthwindContext>()
+                    .UseMySql(connection, AppConfig.ServerVersion)
+                    .Options;
+
+                await using var context = new NorthwindContext(options);
+
                 Assert.Equal(
                     Assert.Throws<InvalidOperationException>(
                         () =>
                         {
-                            new DbContextOptionsBuilder<NorthwindContext>()
-                                .UseMySql(connection, AppConfig.ServerVersion);
+                            context.GetService<IRelationalConnection>();
                         }).Message,
                     @"The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain ""AllowUserVariables=True;UseAffectedRows=False"".");
             }

--- a/test/EFCore.MySql.FunctionalTests/ExistingConnectionMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/ExistingConnectionMySqlTest.cs
@@ -126,7 +126,7 @@ public class ExistingConnectionMySqlTest
                             new DbContextOptionsBuilder<NorthwindContext>()
                                 .UseMySql(connection, AppConfig.ServerVersion);
                         }).Message,
-                    @"The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain ""AllowUserVariables=true;UseAffectedRows=false"".");
+                    @"The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain ""AllowUserVariables=True;UseAffectedRows=False"".");
             }
         }
     }
@@ -182,7 +182,7 @@ public class ExistingConnectionMySqlTest
                             new DbContextOptionsBuilder<NorthwindContext>()
                                 .UseMySql(connection, AppConfig.ServerVersion);
                         }).Message,
-                    @"The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain ""AllowUserVariables=true;UseAffectedRows=false"".");
+                    @"The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain ""AllowUserVariables=True;UseAffectedRows=False"".");
             }
         }
     }

--- a/test/EFCore.MySql.Tests/EFCore.MySql.Tests.csproj
+++ b/test/EFCore.MySql.Tests/EFCore.MySql.Tests.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup Condition="'$(LocalMySqlConnectorRepository)' == ''">
     <PackageReference Include="MySqlConnector" />
+    <PackageReference Include="MySqlConnector.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(LocalEFCoreRepository)' != ''">
@@ -73,6 +74,9 @@
   <ItemGroup Condition="'$(LocalMySqlConnectorRepository)' != ''">
     <Reference Include="MySqlConnector">
       <HintPath>$(LocalMySqlConnectorRepository)\artifacts\bin\MySqlConnector\debug_$(MySqlConnectorTargetFramework)\MySqlConnector.dll</HintPath>
+    </Reference>
+    <Reference Include="MySqlConnector.DependencyInjection">
+      <HintPath>$(LocalMySqlConnectorRepository)\artifacts\bin\MySqlConnector.DependencyInjection\debug_$(MySqlConnectorDependencyInjectionTargetFramework)\MySqlConnector.DependencyInjection.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/test/EFCore.MySql.Tests/MySqlRelationalConnectionTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlRelationalConnectionTest.cs
@@ -75,11 +75,12 @@ public class MySqlRelationalConnectionTest
         using var serviceProvider = serviceCollection.BuildServiceProvider();
 
         using var scope = serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<FakeDbContext>();
 
         Assert.Equal(
             "The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain \"AllowUserVariables=True;UseAffectedRows=False\".",
             Assert.Throws<InvalidOperationException>(
-                    () => scope.ServiceProvider.GetRequiredService<FakeDbContext>())
+                    () => (MySqlRelationalConnection)context.GetService<IRelationalConnection>()!)
                 .Message);
     }
 
@@ -124,12 +125,17 @@ public class MySqlRelationalConnectionTest
 
         using var serviceProvider = serviceCollection.BuildServiceProvider();
 
+        var dataSource = serviceProvider.GetRequiredService<MySqlDataSource>();
+
+        Assert.Equal("Server=FakeHost", dataSource.ConnectionString);
+
         using var scope = serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<FakeDbContext>();
 
         Assert.Equal(
             "The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain \"AllowUserVariables=True;UseAffectedRows=False\".",
             Assert.Throws<InvalidOperationException>(
-                    () => scope.ServiceProvider.GetRequiredService<FakeDbContext>())
+                    () => (MySqlRelationalConnection)context.GetService<IRelationalConnection>()!)
                 .Message);
     }
 
@@ -263,6 +269,7 @@ public class MySqlRelationalConnectionTest
                             TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>(),
                             singletonOptions),
                         new ExceptionDetector()))),
+            new MySqlConnectionStringOptionsValidator(),
             singletonOptions);
     }
 

--- a/test/EFCore.MySql.Tests/MySqlRelationalConnectionTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlRelationalConnectionTest.cs
@@ -1,0 +1,295 @@
+﻿using System;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Transactions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MySqlConnector;
+using Pomelo.EntityFrameworkCore.MySql.Diagnostics.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+using Pomelo.EntityFrameworkCore.MySql.Tests;
+using Pomelo.EntityFrameworkCore.MySql.TestUtilities.FakeProvider;
+using Xunit;
+
+namespace Pomelo.EntityFrameworkCore.MySql;
+
+public class MySqlRelationalConnectionTest
+{
+    [Fact]
+    public void Creates_MySql_Server_connection_string()
+    {
+        using var connection = CreateConnection();
+
+        Assert.IsType<MySqlConnection>(connection.DbConnection);
+    }
+
+    [Fact]
+    public void Uses_DbDataSource_from_DbContextOptions()
+    {
+        using var dataSource = new MySqlDataSourceBuilder("Server=FakeHost;AllowUserVariables=True;UseAffectedRows=False").Build();
+
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection
+            .AddMySqlDataSource("Server=FakeHost")
+            .AddDbContext<FakeDbContext>(o => o.UseMySql(dataSource, AppConfig.ServerVersion));
+
+        using var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        using var scope1 = serviceProvider.CreateScope();
+        var context1 = scope1.ServiceProvider.GetRequiredService<FakeDbContext>();
+        var relationalConnection1 = (MySqlRelationalConnection)context1.GetService<IRelationalConnection>()!;
+        Assert.Same(dataSource, relationalConnection1.DbDataSource);
+
+        var connection1 = context1.GetService<FakeDbContext>().Database.GetDbConnection();
+        Assert.Equal("Server=FakeHost;Allow User Variables=True;Use Affected Rows=False", connection1.ConnectionString);
+
+        using var scope2 = serviceProvider.CreateScope();
+        var context2 = scope2.ServiceProvider.GetRequiredService<FakeDbContext>();
+        var relationalConnection2 = (MySqlRelationalConnection)context2.GetService<IRelationalConnection>()!;
+        Assert.Same(dataSource, relationalConnection2.DbDataSource);
+
+        var connection2 = context2.GetService<FakeDbContext>().Database.GetDbConnection();
+        Assert.Equal("Server=FakeHost;Allow User Variables=True;Use Affected Rows=False", connection2.ConnectionString);
+    }
+
+    [Fact]
+    public void Uses_DbDataSource_from_DbContextOptions_without_mandatory_settings()
+    {
+        using var dataSource = new MySqlDataSourceBuilder("Server=FakeHost").Build();
+
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection
+            .AddMySqlDataSource("Server=FakeHost;Allow User Variables=True;Use Affected Rows=False")
+            .AddDbContext<FakeDbContext>(o => o.UseMySql(dataSource, AppConfig.ServerVersion));
+
+        using var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        using var scope = serviceProvider.CreateScope();
+
+        Assert.Equal(
+            "The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain \"AllowUserVariables=True;UseAffectedRows=False\".",
+            Assert.Throws<InvalidOperationException>(
+                    () => scope.ServiceProvider.GetRequiredService<FakeDbContext>())
+                .Message);
+    }
+
+    [Fact]
+    public void Uses_DbDataSource_from_ApplicationServiceProvider()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection
+            .AddMySqlDataSource("Server=FakeHost;Allow User Variables=True;Use Affected Rows=False")
+            .AddDbContext<FakeDbContext>(o => o.UseMySql(AppConfig.ServerVersion));
+
+        using var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var dataSource = serviceProvider.GetRequiredService<MySqlDataSource>();
+
+        using var scope1 = serviceProvider.CreateScope();
+        var context1 = scope1.ServiceProvider.GetRequiredService<FakeDbContext>();
+        var relationalConnection1 = (MySqlRelationalConnection)context1.GetService<IRelationalConnection>()!;
+        Assert.Same(dataSource, relationalConnection1.DbDataSource);
+
+        var connection1 = context1.GetService<FakeDbContext>().Database.GetDbConnection();
+        Assert.Equal("Server=FakeHost;Allow User Variables=True;Use Affected Rows=False", connection1.ConnectionString);
+
+        using var scope2 = serviceProvider.CreateScope();
+        var context2 = scope2.ServiceProvider.GetRequiredService<FakeDbContext>();
+        var relationalConnection2 = (MySqlRelationalConnection)context2.GetService<IRelationalConnection>()!;
+        Assert.Same(dataSource, relationalConnection2.DbDataSource);
+
+        var connection2 = context2.GetService<FakeDbContext>().Database.GetDbConnection();
+        Assert.Equal("Server=FakeHost;Allow User Variables=True;Use Affected Rows=False", connection2.ConnectionString);
+    }
+
+    [Fact]
+    public void Uses_DbDataSource_from_ApplicationServiceProvider_without_mandatory_settings()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection
+            .AddMySqlDataSource("Server=FakeHost")
+            .AddDbContext<FakeDbContext>(o => o.UseMySql(AppConfig.ServerVersion));
+
+        using var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        using var scope = serviceProvider.CreateScope();
+
+        Assert.Equal(
+            "The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain \"AllowUserVariables=True;UseAffectedRows=False\".",
+            Assert.Throws<InvalidOperationException>(
+                    () => scope.ServiceProvider.GetRequiredService<FakeDbContext>())
+                .Message);
+    }
+
+    [Fact]
+    public void Can_create_master_connection_with_connection_string()
+    {
+        using var connection = CreateConnection();
+        using var master = connection.CreateMasterConnection();
+
+        Assert.Equal(
+            @"Server=localhost;User ID=some_user;Password=some_password;Database=;Pooling=False;Allow User Variables=True;Use Affected Rows=False",
+            master.ConnectionString);
+    }
+
+    // [Fact]
+    // public void Can_create_master_connection_with_connection_string_and_alternate_admin_db()
+    // {
+    //     var options = new DbContextOptionsBuilder()
+    //         .UseMySql(
+    //             @"Server=localhost;Database=MySqlConnectionTest;User ID=some_user;Password=some_password",
+    //             b => b.UseMasterDatabase("template0"))
+    //         .Options;
+    //
+    //     using var connection = CreateConnection(options);
+    //     using var master = connection.CreateMasterConnection();
+    //
+    //     Assert.Equal(
+    //         @"Server=localhost;Database=template0;User ID=some_user;Password=some_password;Pooling=False;Multiplexing=False",
+    //         master.ConnectionString);
+    // }
+
+    // CHECK: Do we need to fix this test?
+    //
+    // [Theory]
+    // [InlineData("false")]
+    // [InlineData("False")]
+    // [InlineData("FALSE")]
+    // public void CurrentAmbientTransaction_returns_null_with_AutoEnlist_set_to_false(string falseValue)
+    // {
+    //     var options = new DbContextOptionsBuilder()
+    //         .UseMySql(
+    //             @"Server=localhost;Database=MySqlConnectionTest;User ID=some_user;Password=some_password;Auto Enlist=" + falseValue,
+    //             AppConfig.ServerVersion)
+    //         .Options;
+    //
+    //     Transaction.Current = new CommittableTransaction();
+    //
+    //     using var connection = CreateConnection(options);
+    //     Assert.Null(connection.CurrentAmbientTransaction);
+    //
+    //     Transaction.Current = null;
+    // }
+
+    [Theory]
+    [InlineData(";Auto Enlist=true")]
+    [InlineData("")] // Auto Enlist is true by default
+    public void CurrentAmbientTransaction_returns_transaction_with_AutoEnlist_enabled(string autoEnlist)
+    {
+        var options = new DbContextOptionsBuilder()
+            .UseMySql(
+                @"Server=localhost;Database=MySqlConnectionTest;User ID=some_user;Password=some_password" + autoEnlist,
+                AppConfig.ServerVersion)
+            .Options;
+
+        var transaction = new CommittableTransaction();
+        Transaction.Current = transaction;
+
+        using var connection = CreateConnection(options);
+        Assert.Equal(transaction, connection.CurrentAmbientTransaction);
+
+        Transaction.Current = null;
+    }
+
+    // INFO: We currently don't implement IMySqlRelationalConnection.CloneWith.
+    //
+    // [ConditionalFact]
+    // public void CloneWith_with_connection_and_connection_string()
+    // {
+    //     var services = MySqlTestHelpers.Instance.CreateContextServices(
+    //         new DbContextOptionsBuilder()
+    //             .UseMySql("Server=localhost;Database=DummyDatabase", AppConfig.ServerVersion)
+    //             .Options);
+    //
+    //     var relationalConnection = (IMySqlRelationalConnection)services.GetRequiredService<IRelationalConnection>();
+    //
+    //     var clone = relationalConnection.CloneWith("Server=localhost;Database=DummyDatabase;Application Name=foo");
+    //
+    //     Assert.Equal("Server=localhost;Database=DummyDatabase;Application Name=foo", clone.ConnectionString);
+    // }
+
+    private static MySqlRelationalConnection CreateConnection(DbContextOptions options = null, DbDataSource dataSource = null)
+    {
+        options ??= new DbContextOptionsBuilder()
+            .UseMySql(@"Server=localhost;User ID=some_user;Password=some_password;Database=MySqlConnectionTest", AppConfig.ServerVersion)
+            .Options;
+
+        foreach (var extension in options.Extensions)
+        {
+            extension.Validate(options);
+        }
+
+        var singletonOptions = new MySqlOptions();
+        singletonOptions.Initialize(options);
+
+        return new MySqlRelationalConnection(
+            new RelationalConnectionDependencies(
+                options,
+                new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
+                    new LoggerFactory(),
+                    new LoggingOptions(),
+                    new DiagnosticListener("FakeDiagnosticListener"),
+                    new MySqlLoggingDefinitions(),
+                    new NullDbContextLogger()),
+                new RelationalConnectionDiagnosticsLogger(
+                    new LoggerFactory(),
+                    new LoggingOptions(),
+                    new DiagnosticListener("FakeDiagnosticListener"),
+                    new MySqlLoggingDefinitions(),
+                    new NullDbContextLogger(),
+                    options),
+                new NamedConnectionStringResolver(options),
+                new RelationalTransactionFactory(
+                    new RelationalTransactionFactoryDependencies(
+                        new RelationalSqlGenerationHelper(
+                            new RelationalSqlGenerationHelperDependencies()))),
+                new CurrentDbContext(new FakeDbContext()),
+                new RelationalCommandBuilderFactory(
+                    new RelationalCommandBuilderDependencies(
+                        new MySqlTypeMappingSource(
+                            TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                            TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>(),
+                            singletonOptions),
+                        new ExceptionDetector()))),
+            singletonOptions);
+    }
+
+    private const string ConnectionString = "Fake Connection String";
+
+    private static IDbContextOptions CreateOptions(
+        RelationalOptionsExtension optionsExtension = null)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder)
+            .AddOrUpdateExtension(
+                optionsExtension
+                ?? new FakeRelationalOptionsExtension().WithConnectionString(ConnectionString));
+
+        return optionsBuilder.Options;
+    }
+
+    private class FakeDbContext : DbContext
+    {
+        public FakeDbContext()
+        {
+        }
+
+        public FakeDbContext(DbContextOptions<FakeDbContext> options)
+            : base(options)
+        {
+        }
+    }
+}

--- a/test/EFCore.MySql.Tests/MySqlRelationalConnectionTest.cs
+++ b/test/EFCore.MySql.Tests/MySqlRelationalConnectionTest.cs
@@ -157,7 +157,7 @@ public class MySqlRelationalConnectionTest
             var context1 = serviceProvider1.GetRequiredService<FakeDbContext>();
 
             var mySqlOptions1 = context1.GetService<IMySqlOptions>();
-            Assert.Same(dataSource1, mySqlOptions1.DataSource);
+            Assert.Null(mySqlOptions1.DataSource);
 
             var relationalConnection1 = (MySqlRelationalConnection)context1.GetService<IRelationalConnection>()!;
             Assert.Same(dataSource1, relationalConnection1.DbDataSource);
@@ -177,7 +177,7 @@ public class MySqlRelationalConnectionTest
             var context2 = serviceProvider2.GetRequiredService<FakeDbContext>();
 
             var mySqlOptions2 = context2.GetService<IMySqlOptions>();
-            Assert.Same(dataSource2, mySqlOptions2.DataSource);
+            Assert.Null(mySqlOptions2.DataSource);
 
             var relationalConnection2 = (MySqlRelationalConnection)context2.GetService<IRelationalConnection>()!;
             Assert.Same(dataSource2, relationalConnection2.DbDataSource);

--- a/test/EFCore.MySql.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
+++ b/test/EFCore.MySql.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Pomelo.EntityFrameworkCore.MySql.TestUtilities.FakeProvider;
+
+public class FakeRelationalOptionsExtension : RelationalOptionsExtension
+{
+    private DbContextOptionsExtensionInfo _info;
+
+    public FakeRelationalOptionsExtension()
+    {
+    }
+
+    protected FakeRelationalOptionsExtension(FakeRelationalOptionsExtension copyFrom)
+        : base(copyFrom)
+    {
+    }
+
+    public override DbContextOptionsExtensionInfo Info
+        => _info ??= new ExtensionInfo(this);
+
+    protected override RelationalOptionsExtension Clone()
+        => new FakeRelationalOptionsExtension(this);
+
+    public override void ApplyServices(IServiceCollection services)
+        => AddEntityFrameworkRelationalDatabase(services);
+
+    public static IServiceCollection AddEntityFrameworkRelationalDatabase(IServiceCollection serviceCollection)
+    {
+        var builder = new EntityFrameworkRelationalServicesBuilder(serviceCollection);
+
+        // Specific test services are available upstream if we need them
+        builder.TryAddCoreServices();
+
+        return serviceCollection;
+    }
+
+    private sealed class ExtensionInfo : RelationalExtensionInfo
+    {
+        public ExtensionInfo(IDbContextOptionsExtension extension)
+            : base(extension)
+        {
+        }
+
+        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Allows setting a `DbDataSource` instance either as part of a `UseMySql()` call or as a service via dependency injection.

Because we cannot alter the connection string of a `DbDataSource`, it needs to be manually populated with the mandatory options of `AllowUserVariables=True;UseAffectedRows=False` for Pomelo.

### `UseMySql()`

```c#
var dataSource = new MySqlDataSource("Server=MyHost;AllowUserVariables=True;UseAffectedRows=False");

// ...

/* [...] */.UseMySql(
    dataSource, // <-- DbDataSource
    serverVersion,
    options => /* [...] */ )
```

### `ServiceCollection`

```c#
var serviceCollection = new ServiceCollection();
serviceCollection
    .AddMySqlDataSource("Server=MyHost;Allow User Variables=True;Use Affected Rows=False") // <-- DbDataSource
    .AddDbContext<MyDbContext>(o => o.UseMySql(serverVersion));
```

The `AddMySqlDataSource()` extension method requires a reference to the `MySqlConnector.DependencyInjection` package.

---

Fixes #1817