### PR TITLE
Allow ExceptIntercept, ExceptInterceptPrecedence for MySql versions >= 8.0.31

### DIFF
--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -75,8 +75,8 @@ namespace Microsoft.EntityFrameworkCore
             public override bool SpatialDistanceFunctionImplementsAndoyer => ServerVersion.Version >= new Version(8, 0, 0);
             public override bool SpatialDistanceSphereFunction => ServerVersion.Version >= new Version(8, 0, 0);
             public override bool SpatialGeographic => ServerVersion.Version >= new Version(8, 0, 0);
-            public override bool ExceptIntercept => false;
-            public override bool ExceptInterceptPrecedence => false;
+            public override bool ExceptIntercept => ServerVersion.Version >= new Version(8, 0, 31);
+            public override bool ExceptInterceptPrecedence => ServerVersion.Version >= new Version(8, 0, 31);
             public override bool JsonDataTypeEmulation => false;
             public override bool ImplicitBoolCheckUsesIndex => ServerVersion.Version >= new Version(8, 0, 0); // Exact version has not been verified yet
             public override bool MySqlBug96947Workaround => ServerVersion.Version >= new Version(5, 7, 0) &&


### PR DESCRIPTION
As of version 8.0.31, MySql supports INTERSECT and EXCEPT. See https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-31.html

This change enables ExceptIntercept and ExceptInterceptPrecedence for versions >= 8.0.31.

The now-enabled tests pass, and it also works properly in my application.

