### PR TITLE
Fix support for model compilation in regards to type mappings

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Common Versions">
-    <EFCoreVersion>8.0.*</EFCoreVersion>
+    <EFCoreVersion>8.0.0</EFCoreVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Dependencies">

--- a/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftDomTranslator.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Query/Internal/MySqlJsonMicrosoftDomTranslator.cs
@@ -186,7 +186,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Query.Internal
                 sqlConstantExpression.TypeMapping is MySqlStringTypeMapping stringTypeMapping &&
                 !stringTypeMapping.IsUnquoted)
             {
-                pathLocation = sqlConstantExpression.ApplyTypeMapping(stringTypeMapping.Clone(true));
+                pathLocation = sqlConstantExpression.ApplyTypeMapping(stringTypeMapping.Clone(unquoted: true));
             }
 
             return pathLocation;

--- a/src/EFCore.MySql.Json.Microsoft/Storage/Internal/MySqlJsonMicrosoftTypeMapping.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Storage/Internal/MySqlJsonMicrosoftTypeMapping.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MySqlConnector;
-using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.Internal
@@ -22,25 +21,32 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter valueConverter,
             [CanBeNull] ValueComparer valueComparer,
-            [NotNull] IMySqlOptions options)
+            bool noBackslashEscapes,
+            bool replaceLineBreaksWithCharFunction)
             : base(
                 storeType,
                 valueConverter,
                 valueComparer,
-                options)
+                noBackslashEscapes,
+                replaceLineBreaksWithCharFunction)
         {
         }
 
         protected MySqlJsonMicrosoftTypeMapping(
             RelationalTypeMappingParameters parameters,
             MySqlDbType mySqlDbType,
-            IMySqlOptions options)
-            : base(parameters, mySqlDbType, options)
+            bool noBackslashEscapes,
+            bool replaceLineBreaksWithCharFunction)
+            : base(
+                parameters,
+                mySqlDbType,
+                noBackslashEscapes,
+                replaceLineBreaksWithCharFunction)
         {
         }
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new MySqlJsonMicrosoftTypeMapping<T>(parameters, MySqlDbType, Options);
+            => new MySqlJsonMicrosoftTypeMapping<T>(parameters, MySqlDbType, NoBackslashEscapes, ReplaceLineBreaksWithCharFunction);
 
         public override Expression GenerateCodeLiteral(object value)
             => value switch

--- a/src/EFCore.MySql.Json.Microsoft/Storage/Internal/MySqlJsonMicrosoftTypeMapping.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Storage/Internal/MySqlJsonMicrosoftTypeMapping.cs
@@ -15,6 +15,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.Internal
 {
     public class MySqlJsonMicrosoftTypeMapping<T> : MySqlJsonTypeMapping<T>
     {
+        public static new MySqlJsonMicrosoftTypeMapping<T> Default { get; } = new("json", null, null, false, true);
+
         // Called via reflection.
         // ReSharper disable once UnusedMember.Global
         public MySqlJsonMicrosoftTypeMapping(
@@ -47,6 +49,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.Internal
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new MySqlJsonMicrosoftTypeMapping<T>(parameters, MySqlDbType, NoBackslashEscapes, ReplaceLineBreaksWithCharFunction);
+
+        protected override RelationalTypeMapping Clone(bool? noBackslashEscapes = null, bool? replaceLineBreaksWithCharFunction = null)
+            => new MySqlJsonMicrosoftTypeMapping<T>(
+                Parameters,
+                MySqlDbType,
+                noBackslashEscapes ?? NoBackslashEscapes,
+                replaceLineBreaksWithCharFunction ?? ReplaceLineBreaksWithCharFunction);
 
         public override Expression GenerateCodeLiteral(object value)
             => value switch

--- a/src/EFCore.MySql.Json.Microsoft/Storage/Internal/MySqlJsonMicrosoftTypeMappingSourcePlugin.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Storage/Internal/MySqlJsonMicrosoftTypeMappingSourcePlugin.cs
@@ -40,7 +40,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.Internal
                     "json",
                     GetValueConverter(clrType),
                     GetValueComparer(clrType),
-                    Options);
+                    Options.NoBackslashEscapes,
+                    Options.ReplaceLineBreaksWithCharFunction);
             }
 
             return null;

--- a/src/EFCore.MySql.Json.Microsoft/Storage/ValueConversion/Internal/MySqlJsonMicrosoftJsonDocumentValueConverter.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Storage/ValueConversion/Internal/MySqlJsonMicrosoftJsonDocumentValueConverter.cs
@@ -18,7 +18,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.ValueConversio
         {
         }
 
-        private static string ConvertToProviderCore(JsonDocument v)
+        public static string ConvertToProviderCore(JsonDocument v)
         {
             using var stream = new MemoryStream();
             using var writer = new Utf8JsonWriter(stream);
@@ -27,7 +27,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.ValueConversio
             return Encoding.UTF8.GetString(stream.ToArray());
         }
 
-        private static JsonDocument ConvertFromProviderCore(string v)
+        public static JsonDocument ConvertFromProviderCore(string v)
             => JsonDocument.Parse(v);
     }
 }

--- a/src/EFCore.MySql.Json.Microsoft/Storage/ValueConversion/Internal/MySqlJsonMicrosoftJsonElementValueConverter.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Storage/ValueConversion/Internal/MySqlJsonMicrosoftJsonElementValueConverter.cs
@@ -15,7 +15,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.ValueConversio
         {
         }
 
-        private static string ConvertToProviderCore(JsonElement v)
+        public static string ConvertToProviderCore(JsonElement v)
         {
             using var stream = new MemoryStream();
             using var writer = new Utf8JsonWriter(stream);
@@ -24,7 +24,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.ValueConversio
             return Encoding.UTF8.GetString(stream.ToArray());
         }
 
-        private static JsonElement ConvertFromProviderCore(string v)
+        public static JsonElement ConvertFromProviderCore(string v)
             => JsonDocument.Parse(v).RootElement;
     }
 }

--- a/src/EFCore.MySql.Json.Microsoft/Storage/ValueConversion/Internal/MySqlJsonMicrosoftPocoValueConverter.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Storage/ValueConversion/Internal/MySqlJsonMicrosoftPocoValueConverter.cs
@@ -16,10 +16,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.ValueConversio
         {
         }
 
-        private static string ConvertToProviderCore(T v)
+        public static string ConvertToProviderCore(T v)
             => JsonSerializer.Serialize(v);
 
-        private static T ConvertFromProviderCore(string v)
+        public static T ConvertFromProviderCore(string v)
             => JsonSerializer.Deserialize<T>(v);
     }
 }

--- a/src/EFCore.MySql.Json.Microsoft/Storage/ValueConversion/Internal/MySqlJsonMicrosoftStringValueConverter.cs
+++ b/src/EFCore.MySql.Json.Microsoft/Storage/ValueConversion/Internal/MySqlJsonMicrosoftStringValueConverter.cs
@@ -18,10 +18,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Microsoft.Storage.ValueConversio
         {
         }
 
-        private static string ConvertToProviderCore(string v)
+        public static string ConvertToProviderCore(string v)
             => ProcessJsonString(v);
 
-        private static string ConvertFromProviderCore(string v)
+        public static string ConvertFromProviderCore(string v)
             => ProcessJsonString(v);
 
         internal static string ProcessJsonString(string v)

--- a/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftDomTranslator.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Query/Internal/MySqlJsonNewtonsoftDomTranslator.cs
@@ -182,7 +182,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Query.Internal
                 sqlConstantExpression.TypeMapping is MySqlStringTypeMapping stringTypeMapping &&
                 !stringTypeMapping.IsUnquoted)
             {
-                pathLocation = sqlConstantExpression.ApplyTypeMapping(stringTypeMapping.Clone(true));
+                pathLocation = sqlConstantExpression.ApplyTypeMapping(stringTypeMapping.Clone(unquoted: true));
             }
 
             return pathLocation;

--- a/src/EFCore.MySql.Json.Newtonsoft/Storage/Internal/MySqlJsonNewtonsoftTypeMapping.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Storage/Internal/MySqlJsonNewtonsoftTypeMapping.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq.Expressions;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -11,7 +10,6 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MySqlConnector;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Storage.Internal
@@ -24,25 +22,28 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter valueConverter,
             [CanBeNull] ValueComparer valueComparer,
-            [NotNull] IMySqlOptions options)
+            bool noBackslashEscapes,
+            bool replaceLineBreaksWithCharFunction)
             : base(
                 storeType,
                 valueConverter,
                 valueComparer,
-                options)
+                noBackslashEscapes,
+                replaceLineBreaksWithCharFunction)
         {
         }
 
         protected MySqlJsonNewtonsoftTypeMapping(
             RelationalTypeMappingParameters parameters,
             MySqlDbType mySqlDbType,
-            IMySqlOptions options)
-            : base(parameters, mySqlDbType, options)
+            bool noBackslashEscapes,
+            bool replaceLineBreaksWithCharFunction)
+            : base(parameters, mySqlDbType, noBackslashEscapes, replaceLineBreaksWithCharFunction)
         {
         }
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new MySqlJsonNewtonsoftTypeMapping<T>(parameters, MySqlDbType, Options);
+            => new MySqlJsonNewtonsoftTypeMapping<T>(parameters, MySqlDbType, NoBackslashEscapes, ReplaceLineBreaksWithCharFunction);
 
         public override Expression GenerateCodeLiteral(object value)
             => value switch

--- a/src/EFCore.MySql.Json.Newtonsoft/Storage/Internal/MySqlJsonNewtonsoftTypeMapping.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Storage/Internal/MySqlJsonNewtonsoftTypeMapping.cs
@@ -16,6 +16,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Storage.Internal
 {
     public class MySqlJsonNewtonsoftTypeMapping<T> : MySqlJsonTypeMapping<T>
     {
+        public static new MySqlJsonNewtonsoftTypeMapping<T> Default { get; } = new("json", null, null, false, true);
+
         // Called via reflection.
         // ReSharper disable once UnusedMember.Global
         public MySqlJsonNewtonsoftTypeMapping(
@@ -44,6 +46,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Storage.Internal
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new MySqlJsonNewtonsoftTypeMapping<T>(parameters, MySqlDbType, NoBackslashEscapes, ReplaceLineBreaksWithCharFunction);
+
+        protected override RelationalTypeMapping Clone(bool? noBackslashEscapes = null, bool? replaceLineBreaksWithCharFunction = null)
+            => new MySqlJsonNewtonsoftTypeMapping<T>(
+                Parameters,
+                MySqlDbType,
+                noBackslashEscapes ?? NoBackslashEscapes,
+                replaceLineBreaksWithCharFunction ?? ReplaceLineBreaksWithCharFunction);
 
         public override Expression GenerateCodeLiteral(object value)
             => value switch

--- a/src/EFCore.MySql.Json.Newtonsoft/Storage/Internal/MySqlJsonNewtonsoftTypeMappingSourcePlugin.cs
+++ b/src/EFCore.MySql.Json.Newtonsoft/Storage/Internal/MySqlJsonNewtonsoftTypeMappingSourcePlugin.cs
@@ -38,7 +38,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Json.Newtonsoft.Storage.Internal
                     "json",
                     GetValueConverter(clrType),
                     GetValueComparer(clrType),
-                    Options);
+                    Options.NoBackslashEscapes,
+                    Options.ReplaceLineBreaksWithCharFunction);
             }
 
             return null;

--- a/src/EFCore.MySql/Design/Internal/MySqlCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlCSharpRuntimeAnnotationCodeGenerator.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal;
+
+public class MySqlCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRuntimeAnnotationCodeGenerator
+{
+    public MySqlCSharpRuntimeAnnotationCodeGenerator(
+        CSharpRuntimeAnnotationCodeGeneratorDependencies dependencies,
+        RelationalCSharpRuntimeAnnotationCodeGeneratorDependencies relationalDependencies)
+        : base(dependencies, relationalDependencies)
+    {
+    }
+
+    public override bool Create(
+        CoreTypeMapping typeMapping,
+        CSharpRuntimeAnnotationCodeGeneratorParameters parameters,
+        ValueComparer valueComparer = null,
+        ValueComparer keyValueComparer = null,
+        ValueComparer providerValueComparer = null)
+    {
+        var result = base.Create(typeMapping, parameters, valueComparer, keyValueComparer, providerValueComparer);
+
+        if (typeMapping is IMySqlCSharpRuntimeAnnotationTypeMappingCodeGenerator extension)
+        {
+            extension.Create(parameters, Dependencies);
+        }
+
+        return result;
+    }
+}

--- a/src/EFCore.MySql/Design/Internal/MySqlDesignTimeServices.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlDesignTimeServices.cs
@@ -3,6 +3,7 @@
 
 using Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,6 +15,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
         {
             serviceCollection.AddEntityFrameworkMySql();
             new EntityFrameworkRelationalDesignServicesBuilder(serviceCollection)
+                .TryAdd<ICSharpRuntimeAnnotationCodeGenerator, MySqlCSharpRuntimeAnnotationCodeGenerator>()
                 .TryAdd<IAnnotationCodeGenerator, MySqlAnnotationCodeGenerator>()
                 .TryAdd<IDatabaseModelFactory, MySqlDatabaseModelFactory>()
                 .TryAdd<IProviderConfigurationCodeGenerator, MySqlCodeGenerator>()

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -1258,7 +1258,7 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
 
                 if (typeMapping is IDefaultValueCompatibilityAware defaultValueCompatibilityAware)
                 {
-                    typeMapping = defaultValueCompatibilityAware.Clone(true);
+                    typeMapping = defaultValueCompatibilityAware.Clone(isDefaultValueCompatible: true);
                 }
 
                 var sqlLiteralDefaultValue = typeMapping.GenerateSqlLiteral(defaultValue);

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonPocoTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonPocoTranslator.cs
@@ -27,7 +27,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
         {
             _typeMappingSource = typeMappingSource;
             _sqlExpressionFactory = sqlExpressionFactory;
-            _unquotedStringTypeMapping = ((MySqlStringTypeMapping)_typeMappingSource.FindMapping(typeof(string))).Clone(true);
+            _unquotedStringTypeMapping = ((MySqlStringTypeMapping)_typeMappingSource.FindMapping(typeof(string))).Clone(unquoted: true);
             _intTypeMapping = _typeMappingSource.FindMapping(typeof(int));
         }
 

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlCodeGenerationMemberAccessTypeMapping.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlCodeGenerationMemberAccessTypeMapping.cs
@@ -11,6 +11,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
     {
         private const string DummyStoreType = "clrOnly";
 
+        public static MySqlCodeGenerationMemberAccessTypeMapping Default { get; } = new();
+
         public MySqlCodeGenerationMemberAccessTypeMapping()
             : base(new RelationalTypeMappingParameters(new CoreTypeMappingParameters(typeof(MySqlCodeGenerationMemberAccess)), DummyStoreType))
         {

--- a/src/EFCore.MySql/Scaffolding/Internal/MySqlCodeGenerationServerVersionCreationTypeMapping.cs
+++ b/src/EFCore.MySql/Scaffolding/Internal/MySqlCodeGenerationServerVersionCreationTypeMapping.cs
@@ -13,6 +13,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Scaffolding.Internal
     {
         private const string DummyStoreType = "clrOnly";
 
+        public static MySqlCodeGenerationServerVersionCreationTypeMapping Default { get; } = new();
+
         public MySqlCodeGenerationServerVersionCreationTypeMapping()
             : base(new RelationalTypeMappingParameters(new CoreTypeMappingParameters(typeof(MySqlCodeGenerationServerVersionCreation)), DummyStoreType))
         {

--- a/src/EFCore.MySql/Storage/Internal/IMySqlCSharpRuntimeAnnotationTypeMappingCodeGenerator.cs
+++ b/src/EFCore.MySql/Storage/Internal/IMySqlCSharpRuntimeAnnotationTypeMappingCodeGenerator.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Design.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
+
+public interface IMySqlCSharpRuntimeAnnotationTypeMappingCodeGenerator
+{
+    void Create(
+        CSharpRuntimeAnnotationCodeGeneratorParameters codeGeneratorParameters,
+        CSharpRuntimeAnnotationCodeGeneratorDependencies codeGeneratorDependencies);
+}

--- a/src/EFCore.MySql/Storage/Internal/MySqlBoolTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlBoolTypeMapping.cs
@@ -16,6 +16,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     /// </summary>
     public class MySqlBoolTypeMapping : BoolTypeMapping
     {
+        public static new MySqlBoolTypeMapping Default { get; } = new("tinyint", size: 1);
+
         public MySqlBoolTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = System.Data.DbType.Boolean,

--- a/src/EFCore.MySql/Storage/Internal/MySqlByteArrayTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlByteArrayTypeMapping.cs
@@ -20,6 +20,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         private readonly int _maxSpecificSize;
 
+        public static new MySqlByteArrayTypeMapping Default { get; } = new();
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTimeOffsetTypeMapping.cs
@@ -19,6 +19,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     {
         private readonly bool _isDefaultValueCompatible;
 
+        public static new MySqlDateTimeOffsetTypeMapping Default { get; } = new("datetime");
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTimeTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTimeTypeMapping.cs
@@ -20,6 +20,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     {
         private readonly bool _isDefaultValueCompatible;
 
+        public static new MySqlDateTimeTypeMapping Default { get; } = new("datetime");
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.MySql/Storage/Internal/MySqlDateTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlDateTypeMapping.cs
@@ -21,6 +21,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     {
         private readonly bool _isDefaultValueCompatible;
 
+        public static MySqlDateTypeMapping Default { get; } = new("date", typeof(DateOnly));
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
@@ -13,6 +13,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     {
         private readonly MySqlGuidFormat _guidFormat;
 
+        public static new MySqlGuidTypeMapping Default { get; } = new(MySqlGuidFormat.Default);
+
         public MySqlGuidTypeMapping(MySqlGuidFormat guidFormat)
             : this(new RelationalTypeMappingParameters(
                     new CoreTypeMappingParameters(

--- a/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlGuidTypeMapping.cs
@@ -2,18 +2,20 @@
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 using MySqlConnector;
-using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {
-    public class MySqlGuidTypeMapping : GuidTypeMapping, IJsonSpecificTypeMapping
+    public class MySqlGuidTypeMapping : GuidTypeMapping, IJsonSpecificTypeMapping, IMySqlCSharpRuntimeAnnotationTypeMappingCodeGenerator
     {
-        private readonly MySqlGuidFormat _guidFormat;
+        public static new MySqlGuidTypeMapping Default { get; } = new(MySqlGuidFormat.Char36);
 
-        public static new MySqlGuidTypeMapping Default { get; } = new(MySqlGuidFormat.Default);
+        public virtual MySqlGuidFormat GuidFormat { get; }
 
         public MySqlGuidTypeMapping(MySqlGuidFormat guidFormat)
             : this(new RelationalTypeMappingParameters(
@@ -33,18 +35,21 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         protected MySqlGuidTypeMapping(RelationalTypeMappingParameters parameters, MySqlGuidFormat guidFormat)
             : base(parameters)
         {
-            _guidFormat = guidFormat;
+            GuidFormat = guidFormat;
         }
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new MySqlGuidTypeMapping(parameters, _guidFormat);
+            => new MySqlGuidTypeMapping(parameters, GuidFormat);
+
+        public virtual RelationalTypeMapping Clone(MySqlGuidFormat guidFormat)
+            => new MySqlGuidTypeMapping(Parameters, guidFormat);
 
         public virtual bool IsCharBasedStoreType
-            => GetStoreType(_guidFormat) == "char";
+            => GetStoreType(GuidFormat) == "char";
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {
-            switch (_guidFormat)
+            switch (GuidFormat)
             {
                 case MySqlGuidFormat.Char36:
                     return $"'{value:D}'";
@@ -55,7 +60,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                 case MySqlGuidFormat.Binary16:
                 case MySqlGuidFormat.TimeSwapBinary16:
                 case MySqlGuidFormat.LittleEndianBinary16:
-                    return "0x" + Convert.ToHexString(GetBytesFromGuid(_guidFormat, (Guid)value));
+                    return "0x" + Convert.ToHexString(GetBytesFromGuid(GuidFormat, (Guid)value));
 
                 case MySqlGuidFormat.None:
                 case MySqlGuidFormat.Default:
@@ -132,5 +137,50 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         /// </summary>
         public virtual RelationalTypeMapping CloneAsJsonCompatible()
             => new MySqlGuidTypeMapping(MySqlGuidFormat.Char36);
+
+        void IMySqlCSharpRuntimeAnnotationTypeMappingCodeGenerator.Create(
+            CSharpRuntimeAnnotationCodeGeneratorParameters codeGeneratorParameters,
+            CSharpRuntimeAnnotationCodeGeneratorDependencies codeGeneratorDependencies)
+        {
+            var defaultTypeMapping = Default;
+            if (defaultTypeMapping == this)
+            {
+                return;
+            }
+
+            var code = codeGeneratorDependencies.CSharpHelper;
+
+            var cloneParameters = new List<string>();
+
+            if (GuidFormat != defaultTypeMapping.GuidFormat)
+            {
+                cloneParameters.Add($"guidFormat: {code.Literal(GuidFormat, true)}");
+            }
+
+            if (cloneParameters.Any())
+            {
+                var mainBuilder = codeGeneratorParameters.MainBuilder;
+
+                mainBuilder.AppendLine(";");
+
+                mainBuilder
+                    .AppendLine($"{codeGeneratorParameters.TargetName}.TypeMapping = (({code.Reference(GetType())}){codeGeneratorParameters.TargetName}.TypeMapping).Clone(")
+                    .IncrementIndent();
+
+                for (var i = 0; i < cloneParameters.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        mainBuilder.AppendLine(",");
+                    }
+
+                    mainBuilder.Append(cloneParameters[i]);
+                }
+
+                mainBuilder
+                    .Append(")")
+                    .DecrementIndent();
+            }
+        }
     }
 }

--- a/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMapping.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MySqlConnector;
-using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {
@@ -19,39 +18,40 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter valueConverter,
             [CanBeNull] ValueComparer valueComparer,
-            [NotNull] IMySqlOptions options)
+            bool noBackslashEscapes,
+            bool replaceLineBreaksWithCharFunction)
             : base(
                 storeType,
                 typeof(T),
                 valueConverter,
                 valueComparer,
-                options)
+                noBackslashEscapes,
+                replaceLineBreaksWithCharFunction)
         {
         }
 
         protected MySqlJsonTypeMapping(
             RelationalTypeMappingParameters parameters,
             MySqlDbType mySqlDbType,
-            IMySqlOptions options)
-            : base(parameters, mySqlDbType, options)
+            bool noBackslashEscapes,
+            bool replaceLineBreaksWithCharFunction)
+            : base(parameters, mySqlDbType, noBackslashEscapes, replaceLineBreaksWithCharFunction)
         {
         }
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new MySqlJsonTypeMapping<T>(parameters, MySqlDbType, Options);
+            => new MySqlJsonTypeMapping<T>(parameters, MySqlDbType, NoBackslashEscapes, ReplaceLineBreaksWithCharFunction);
     }
 
     public abstract class MySqlJsonTypeMapping : MySqlStringTypeMapping
     {
-        [NotNull]
-        protected virtual IMySqlOptions Options { get; }
-
         public MySqlJsonTypeMapping(
             [NotNull] string storeType,
             [NotNull] Type clrType,
             [CanBeNull] ValueConverter valueConverter,
             [CanBeNull] ValueComparer valueComparer,
-            [NotNull] IMySqlOptions options)
+            bool noBackslashEscapes,
+            bool replaceLineBreaksWithCharFunction)
             : base(
                 new RelationalTypeMappingParameters(
                     new CoreTypeMappingParameters(
@@ -61,7 +61,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                     storeType,
                     unicode: true),
                 MySqlDbType.JSON,
-                options,
+                noBackslashEscapes,
+                replaceLineBreaksWithCharFunction,
                 false,
                 false)
         {
@@ -69,17 +70,21 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             {
                 throw new ArgumentException($"The store type '{nameof(storeType)}' must be 'json'.", nameof(storeType));
             }
-
-            Options = options;
         }
 
         protected MySqlJsonTypeMapping(
             RelationalTypeMappingParameters parameters,
             MySqlDbType mySqlDbType,
-            IMySqlOptions options)
-            : base(parameters, mySqlDbType, options, false, false)
+            bool noBackslashEscapes,
+            bool replaceLineBreaksWithCharFunction)
+            : base(
+                parameters,
+                mySqlDbType,
+                noBackslashEscapes,
+                replaceLineBreaksWithCharFunction,
+                isUnquoted: false,
+                forceToString: false)
         {
-            Options = options;
         }
 
         protected override void ConfigureParameter(DbParameter parameter)

--- a/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMappingSourcePlugin.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlJsonTypeMappingSourcePlugin.cs
@@ -43,7 +43,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
                         storeTypeName,
                         GetValueConverter(clrType),
                         GetValueComparer(clrType),
-                        Options)
+                        Options.NoBackslashEscapes,
+                        Options.ReplaceLineBreaksWithCharFunction)
                     : null;
             }
 

--- a/src/EFCore.MySql/Storage/Internal/MySqlTimeTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTimeTypeMapping.cs
@@ -19,6 +19,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     {
         private readonly bool _isDefaultValueCompatible;
 
+        public static MySqlTimeTypeMapping Default { get; } = new("time", typeof(TimeOnly));
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -18,7 +18,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
     {
         // boolean
         private readonly MySqlBoolTypeMapping _bit1 = new MySqlBoolTypeMapping("bit", size: 1);
-        private readonly MySqlBoolTypeMapping _tinyint1 = new MySqlBoolTypeMapping("tinyint", size: 1);
+        private readonly MySqlBoolTypeMapping _tinyint1 = MySqlBoolTypeMapping.Default;
 
         // bit
         private readonly MySqlULongTypeMapping _bit = new MySqlULongTypeMapping("bit");
@@ -40,7 +40,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         // binary
         private readonly RelationalTypeMapping _binary = new MySqlByteArrayTypeMapping(fixedLength: true);
-        private readonly RelationalTypeMapping _varbinary = new MySqlByteArrayTypeMapping();
+        private readonly RelationalTypeMapping _varbinary = MySqlByteArrayTypeMapping.Default;
 
         //
         // String mappings depend on the MySqlOptions.NoBackslashEscapes setting:
@@ -59,14 +59,14 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         private MySqlStringTypeMapping _enum;
 
         // DateTime
-        private readonly MySqlYearTypeMapping _year = new MySqlYearTypeMapping("year");
-        private readonly MySqlDateTypeMapping _dateDateOnly = new MySqlDateTypeMapping("date", typeof(DateOnly));
+        private readonly MySqlYearTypeMapping _year = MySqlYearTypeMapping.Default;
+        private readonly MySqlDateTypeMapping _dateDateOnly = MySqlDateTypeMapping.Default;
         private readonly MySqlDateTypeMapping _dateDateTime = new MySqlDateTypeMapping("date", typeof(DateTime));
-        private readonly MySqlTimeTypeMapping _timeTimeOnly = new MySqlTimeTypeMapping("time", typeof(TimeOnly));
+        private readonly MySqlTimeTypeMapping _timeTimeOnly = MySqlTimeTypeMapping.Default;
         private readonly MySqlTimeTypeMapping _timeTimeSpan = new MySqlTimeTypeMapping("time", typeof(TimeSpan));
-        private readonly MySqlDateTimeTypeMapping _dateTime = new MySqlDateTimeTypeMapping("datetime");
+        private readonly MySqlDateTimeTypeMapping _dateTime = MySqlDateTimeTypeMapping.Default;
         private readonly MySqlDateTimeTypeMapping _timeStamp = new MySqlDateTimeTypeMapping("timestamp");
-        private readonly MySqlDateTimeOffsetTypeMapping _dateTimeOffset = new MySqlDateTimeOffsetTypeMapping("datetime");
+        private readonly MySqlDateTimeOffsetTypeMapping _dateTimeOffset = MySqlDateTimeOffsetTypeMapping.Default;
         private readonly MySqlDateTimeOffsetTypeMapping _timeStampOffset = new MySqlDateTimeOffsetTypeMapping("timestamp");
 
         private readonly RelationalTypeMapping _binaryRowVersion
@@ -91,8 +91,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
         private MySqlJsonTypeMapping<string> _jsonDefaultString;
 
         // Scaffolding type mappings
-        private readonly MySqlCodeGenerationMemberAccessTypeMapping _codeGenerationMemberAccess = new MySqlCodeGenerationMemberAccessTypeMapping();
-        private readonly MySqlCodeGenerationServerVersionCreationTypeMapping _codeGenerationServerVersionCreation = new MySqlCodeGenerationServerVersionCreationTypeMapping();
+        private readonly MySqlCodeGenerationMemberAccessTypeMapping _codeGenerationMemberAccess = MySqlCodeGenerationMemberAccessTypeMapping.Default;
+        private readonly MySqlCodeGenerationServerVersionCreationTypeMapping _codeGenerationServerVersionCreation = MySqlCodeGenerationServerVersionCreationTypeMapping.Default;
 
         private Dictionary<string, RelationalTypeMapping[]> _storeTypeMappings;
         private Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;

--- a/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlTypeMappingSource.cs
@@ -118,23 +118,23 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
             // String mappings depend on the MySqlOptions.NoBackslashEscapes setting:
             //
 
-            _charUnicode = new MySqlStringTypeMapping("char", _options, StoreTypePostfix.Size, fixedLength: true);
-            _varcharUnicode = new MySqlStringTypeMapping("varchar", _options, StoreTypePostfix.Size);
-            _tinytextUnicode = new MySqlStringTypeMapping("tinytext", _options, StoreTypePostfix.None);
-            _textUnicode = new MySqlStringTypeMapping("text", _options, StoreTypePostfix.None);
-            _mediumtextUnicode = new MySqlStringTypeMapping("mediumtext", _options, StoreTypePostfix.None);
-            _longtextUnicode = new MySqlStringTypeMapping("longtext", _options, StoreTypePostfix.None);
+            _charUnicode = new MySqlStringTypeMapping("char", StoreTypePostfix.Size, fixedLength: true, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
+            _varcharUnicode = new MySqlStringTypeMapping("varchar", StoreTypePostfix.Size, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
+            _tinytextUnicode = new MySqlStringTypeMapping("tinytext", StoreTypePostfix.None, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
+            _textUnicode = new MySqlStringTypeMapping("text", StoreTypePostfix.None, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
+            _mediumtextUnicode = new MySqlStringTypeMapping("mediumtext", StoreTypePostfix.None, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
+            _longtextUnicode = new MySqlStringTypeMapping("longtext", StoreTypePostfix.None, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
 
-            _nchar = new MySqlStringTypeMapping("nchar", _options, StoreTypePostfix.Size, fixedLength: true);
-            _nvarchar = new MySqlStringTypeMapping("nvarchar", _options, StoreTypePostfix.Size);
+            _nchar = new MySqlStringTypeMapping("nchar", StoreTypePostfix.Size, fixedLength: true, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
+            _nvarchar = new MySqlStringTypeMapping("nvarchar", StoreTypePostfix.Size, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
 
-            _enum = new MySqlStringTypeMapping("enum", _options, StoreTypePostfix.None);
+            _enum = new MySqlStringTypeMapping("enum", StoreTypePostfix.None, noBackslashEscapes: _options.NoBackslashEscapes, replaceLineBreaksWithCharFunction: _options.ReplaceLineBreaksWithCharFunction);
 
             _guid = MySqlGuidTypeMapping.IsValidGuidFormat(_options.ConnectionSettings.GuidFormat)
                 ? new MySqlGuidTypeMapping(_options.ConnectionSettings.GuidFormat)
                 : null;
 
-            _jsonDefaultString = new MySqlJsonTypeMapping<string>("json", null, null, _options);
+            _jsonDefaultString = new MySqlJsonTypeMapping<string>("json", null, null, _options.NoBackslashEscapes, _options.ReplaceLineBreaksWithCharFunction);
 
             _storeTypeMappings
                 = new Dictionary<string, RelationalTypeMapping[]>(StringComparer.OrdinalIgnoreCase)

--- a/src/EFCore.MySql/Storage/Internal/MySqlYearTypeMapping.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlYearTypeMapping.cs
@@ -10,6 +10,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 {
     public class MySqlYearTypeMapping : MySqlTypeMapping
     {
+        public static MySqlYearTypeMapping Default { get; } = new("year");
+
         public MySqlYearTypeMapping([NotNull] string storeType)
             : base(
                 storeType,


### PR DESCRIPTION
Ensures existence of static `Default` property in all type mappings.

Customizes code generation for the following complex type mappings that encapsulate additional state:
- `MySqlGuidTypeMapping`
- `MySqlStringTypeMapping`
- `MySqlJsonTypeMapping<T>`
- `MySqlJsonMicrosoftTypeMapping<T>`
- `MySqlJsonNewtonsoftTypeMapping<T>`

Fixes issues that could previously lead to exceptions like the following:

`System.InvalidOperationException: The type mapping used is incompatible with a compiled model. The mapping type must have a 'public static readonly MySqlStringTypeMapping MySqlStringTypeMapping.Default' property.`

I have successfully tested the PR against a real-world model, including the afore mentioned complex type mappings.

Fixes #1835