### PR TITLE
Use `AutoEnlist=false` and `Pooling=false` in `AutoDetect()` calls

### DIFF
--- a/src/EFCore.MySql/Infrastructure/ServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/ServerVersion.cs
@@ -71,7 +71,12 @@ namespace Microsoft.EntityFrameworkCore
         public static ServerVersion AutoDetect(string connectionString)
         {
             using var connection = new MySqlConnection(
-                new MySqlConnectionStringBuilder(connectionString) {Database = string.Empty}.ConnectionString);
+                new MySqlConnectionStringBuilder(connectionString)
+                {
+                    Database = string.Empty,
+                    AutoEnlist = false,
+                    Pooling = false,
+                }.ConnectionString);
             connection.Open();
             return Parse(connection.ServerVersion);
         }
@@ -95,7 +100,12 @@ namespace Microsoft.EntityFrameworkCore
             if (connection.State != ConnectionState.Open)
             {
                 using var clonedConnection = connection.CloneWith(
-                    new MySqlConnectionStringBuilder(connection.ConnectionString) {Database = string.Empty}.ConnectionString);
+                    new MySqlConnectionStringBuilder(connection.ConnectionString)
+                    {
+                        Database = string.Empty,
+                        AutoEnlist = false,
+                        Pooling = false,
+                    }.ConnectionString);
                 clonedConnection.Open();
                 serverVersion = clonedConnection.ServerVersion;
             }


### PR DESCRIPTION
Improves the `AutoDetect()` implementation to work with a wider range of circumstances when blindly being used with the same connection string as the `DbContext`.

Fixes #1830