### PR TITLE
Merge ADD COLUMN/MODIFY COLUMN with AUTO_INCREMENT statement with ADD CONSTRAINT PRIMARY KEY statement where necessary, because MySQL requires an AUTO_INCREMENT column to be a key (and making it a key after column creation is already too late).

### DIFF
--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -1171,13 +1171,6 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
                 GenerateComment(operation.Comment, builder);
 
                 // AUTO_INCREMENT has priority over reference definitions.
-                if (onUpdateSql != null && !autoIncrement)
-                {
-                    builder
-                        .Append(" ON UPDATE ")
-                        .Append(onUpdateSql);
-                }
-
                 if (autoIncrement)
                 {
                     builder.Append(" AUTO_INCREMENT");
@@ -1196,6 +1189,12 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
                             model,
                             builder);
                     }
+                }
+                else if (onUpdateSql != null)
+                {
+                    builder
+                        .Append(" ON UPDATE ")
+                        .Append(onUpdateSql);
                 }
             }
             else

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -267,12 +266,6 @@ SELECT ROW_COUNT();",
                         //
                         "CREATE INDEX `NewIndex` ON `People` (`FirstName`(50));"
                     });
-        }
-
-        [ConditionalTheory(Skip = "TODO")]
-        public override Task Add_primary_key_int()
-        {
-            return base.Add_primary_key_int();
         }
 
         [ConditionalTheory(Skip = "TODO")]
@@ -1308,6 +1301,10 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;",
                     Assert.Equal("Persons", table.Name);
                 },
                 withConventions: false);
+
+        // The constraint name for a primary key is always PRIMARY in MySQL.
+        protected override bool AssertConstraintNames
+            => false;
 
         protected virtual string DefaultCollation => ((MySqlTestStore)Fixture.TestStore).DatabaseCollation;
 


### PR DESCRIPTION
For a detailed explanation of this fix, see https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1828#issuecomment-1947454764.

Should be backported to `8.0.0`.

Fixes #1828 