### PR TITLE
Refactor BytesToDateTimeConverter, so it works out-of-the-box with compiled models.

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/BytesToDateTimeConverter.cs
+++ b/src/EFCore.MySql/Storage/Internal/BytesToDateTimeConverter.cs
@@ -13,9 +13,15 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
         public BytesToDateTimeConverter()
             : base(
-                v => DateTime.FromBinary((long)_longToBytes.ConvertFromProvider(v)),
-                v => (byte[])_longToBytes.ConvertToProvider(v.ToBinary()))
+                v => FromBytes(v),
+                v => ToBytes(v))
         {
         }
+
+        public static byte[] ToBytes(DateTime v)
+            => (byte[])_longToBytes.ConvertToProvider(v.ToBinary());
+
+        public static DateTime FromBytes(byte[] v)
+            => DateTime.FromBinary((long)_longToBytes.ConvertFromProvider(v));
     }
 }


### PR DESCRIPTION
Our previous `BytesToDateTimeConverter` implementation used methods calls in its convert to/from expressions that used a variable that was supplied to the convert expression. That is not supported by EF Core's `LinqToCSharpSyntaxTranslator.VisitInvocation()` implementation (would be trivial to implement though), which assumes that an `InvocationExpression` always contains a lambda - which is not the case.

We also accessed a `private static` field, which cannot be referenced from outside the class. Since the compiled model code generator does not create an instance of the value converter in question by default, but instead creates a general value converter that just uses the same expressions that we define in ours, no private fields could be accessed.

The [docs](https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions?tabs=data-annotations#overview) state:

> Conversions are defined using two `Func` expression trees: one from `ModelClrType` to `ProviderClrType` and the other from `ProviderClrType` to `ModelClrType`. Expression trees are used so that they can be compiled into the database access delegate for efficient conversions. **The expression tree may contain a simple call to a conversion method for complex conversions.**

While this seems to be just a _suggestion_, it seems to be a _requirement_ for value converters in compiled models.

Fixes #1846 