### PR TITLE
Improve `QueryBaselineUpdater` to automatically update the correct main or customized file from a `QueryBaseline.txt` file.

### DIFF
--- a/tools/QueryBaselineUpdater/Program.cs
+++ b/tools/QueryBaselineUpdater/Program.cs
@@ -12,48 +12,62 @@ namespace QueryBaselineUpdater
             const string assertSqlPattern = @"\s*Assert(?:ExecuteUpdate)?Sql\(\s*(?:(?:@?(""""""|"")).*?\1)?\);\r?\n";
 
             var queryBaselineFilePath = args[0];
-            var testFilePath = args[1];
+            var testFileBasePath = args[1];
 
-            File.WriteAllText(
-                testFilePath,
-                Regex.Matches(
-                        File.ReadAllText(queryBaselineFilePath),
-                        $@"(?:^|\n)(?<Name>(?:Pomelo|EntityFrameworkCore|Microsoft)[^\r\n]*)\([^\r\n]*\) : (?<Line>\d+)\r?\n(?<AssertSql>{assertSqlPattern})\r?\n(?<Truncated>Output truncated.)?\r?\n--------------------(?=\r?\n)",
-                        RegexOptions.IgnoreCase | RegexOptions.Singleline)
-                    .Select(
-                        match => new
-                        {
-                            Line = int.Parse(match.Groups["Line"].Value),
-                            Name = match.Groups["Name"].Value,
-                            AssertSql = match.Groups["AssertSql"].Value,
-                            Truncated = match.Groups["Truncated"].Success,
-                        })
-                    .GroupBy(t => t.Line)
-                    .Select(g => g.First())
-                    .OrderByDescending(t => t.Line)
-                    .Aggregate(
-                        File.ReadAllText(testFilePath),
-                        (current, next) =>
-                        {
-                            var lines = Regex.Split(current, @"\r?\n");
-                            var before = lines.Take(next.Line - 1);
-                            var remaining = lines.Skip(next.Line - 1);
-                            var replaced = Regex.Split(
+            if (!Directory.Exists(testFileBasePath))
+            {
+                throw new ArgumentException($"Path '{testFileBasePath}' does not exist or is not a directory.");
+            }
+
+            Regex.Matches(
+                    File.ReadAllText(queryBaselineFilePath),
+                    $@"(?:^|\n)(?<Name>(?:Pomelo|EntityFrameworkCore|Microsoft)[^\r\n]*)\([^\r\n]*\) : (?<Line>\d+)\r?\n(?<AssertSql>{assertSqlPattern})\r?\n(?<Truncated>Output truncated.)?\r?\n--------------------(?=\r?\n)",
+                    RegexOptions.IgnoreCase | RegexOptions.Singleline)
+                .Select(
+                    match => new
+                    {
+                        File = Path.Combine(testFileBasePath,
+                            Regex.Replace(
                                 Regex.Replace(
-                                    string.Join(Environment.NewLine, remaining),
-                                    $"^{assertSqlPattern}",
-                                    next.AssertSql,
-                                    RegexOptions.IgnoreCase | RegexOptions.Singleline),
-                                @"\r?\n")
-                                .AsEnumerable();
+                                    Regex.Replace(
+                                        Regex.Replace(match.Groups["Name"].Value, @"^Pomelo\.EntityFrameworkCore\.MySql\.FunctionalTests\.",
+                                            string.Empty), @"\.[^.]+$", string.Empty), @"\.", @"\"), "^.*$", "$0.cs")),
+                        Line = int.Parse(match.Groups["Line"].Value),
+                        Name = match.Groups["Name"].Value,
+                        AssertSql = match.Groups["AssertSql"].Value,
+                        Truncated = match.Groups["Truncated"].Success,
+                    })
+                .GroupBy(m => m.File)
+                .ToList()
+                .ForEach(
+                    file => File.WriteAllText(
+                        file.First().File,
+                        file.GroupBy(t => t.Line)
+                            .Select(g => g.First())
+                            .OrderByDescending(t => t.Line)
+                            .Aggregate(
+                                File.ReadAllText(file.First().File),
+                                (result, current) =>
+                                {
+                                    var lines = Regex.Split(result, @"\r?\n");
+                                    var before = lines.Take(current.Line - 1);
+                                    var remaining = lines.Skip(current.Line - 1);
+                                    var replaced = Regex.Split(
+                                            Regex.Replace(
+                                                string.Join(Environment.NewLine, remaining),
+                                                $"^{assertSqlPattern}",
+                                                current.AssertSql,
+                                                RegexOptions.IgnoreCase | RegexOptions.Singleline),
+                                            @"\r?\n")
+                                        .AsEnumerable();
 
-                            if (next.Truncated)
-                            {
-                                replaced = replaced.Prepend("            #warning TRUNCATED: Add remaining baseline queries.");
-                            }
+                                    if (current.Truncated)
+                                    {
+                                        replaced = replaced.Prepend("            #warning TRUNCATED: Add remaining baseline queries.");
+                                    }
 
-                            return string.Join(Environment.NewLine, before.Concat(replaced));
-                        }));
+                                    return string.Join(Environment.NewLine, before.Concat(replaced));
+                                })));
         }
     }
 }

--- a/tools/QueryBaselineUpdater/Program.cs
+++ b/tools/QueryBaselineUpdater/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -7,10 +8,10 @@ namespace QueryBaselineUpdater
 {
     internal static class Program
     {
-        private static void Main(string[] args)
-        {
-            const string assertSqlPattern = @"\s*Assert(?:ExecuteUpdate)?Sql\(\s*(?:(?:@?(""""""|"")).*?\1)?\);\r?\n";
+        private const string AssertSqlPattern = @"\s*Assert(?:ExecuteUpdate)?Sql\(\s*(?:(?:@?(""""""|"")).*?\1)?\);\r?\n";
 
+        private static int Main(string[] args)
+        {
             var queryBaselineFilePath = args[0];
             var testFileBasePath = args[1];
 
@@ -19,55 +20,130 @@ namespace QueryBaselineUpdater
                 throw new ArgumentException($"Path '{testFileBasePath}' does not exist or is not a directory.");
             }
 
-            Regex.Matches(
-                    File.ReadAllText(queryBaselineFilePath),
-                    $@"(?:^|\n)(?<Name>(?:Pomelo|EntityFrameworkCore|Microsoft)[^\r\n]*)\([^\r\n]*\) : (?<Line>\d+)\r?\n(?<AssertSql>{assertSqlPattern})\r?\n(?<Truncated>Output truncated.)?\r?\n--------------------(?=\r?\n)",
-                    RegexOptions.IgnoreCase | RegexOptions.Singleline)
-                .Select(
-                    match => new
-                    {
-                        File = Path.Combine(testFileBasePath,
-                            Regex.Replace(
-                                Regex.Replace(
-                                    Regex.Replace(
-                                        Regex.Replace(match.Groups["Name"].Value, @"^Pomelo\.EntityFrameworkCore\.MySql\.FunctionalTests\.",
-                                            string.Empty), @"\.[^.]+$", string.Empty), @"\.", @"\"), "^.*$", "$0.cs")),
-                        Line = int.Parse(match.Groups["Line"].Value),
-                        Name = match.Groups["Name"].Value,
-                        AssertSql = match.Groups["AssertSql"].Value,
-                        Truncated = match.Groups["Truncated"].Success,
-                    })
-                .GroupBy(m => m.File)
-                .ToList()
-                .ForEach(
-                    file => File.WriteAllText(
-                        file.First().File,
-                        file.GroupBy(t => t.Line)
-                            .Select(g => g.First())
+            var notFound = new List<string>();
+
+            foreach (var file in Regex.Matches(
+                             File.ReadAllText(queryBaselineFilePath),
+                             $@"(?:^|\n)(?<Id>(?<Name>(?:Pomelo|EntityFrameworkCore|Microsoft)[^\r\n]*)\([^\r\n]*\) : (?<Line>\d+))\r?\n(?<AssertSql>{AssertSqlPattern})\r?\n(?<Truncated>Output truncated.)?\r?\n--------------------(?=\r?\n)",
+                             RegexOptions.IgnoreCase | RegexOptions.Singleline)
+                         .Select(
+                             match => new AssertSqlChunk(
+                                 match.Groups["Id"].Value,
+                                 Path.Combine(
+                                     testFileBasePath,
+                                     Regex.Replace(
+                                         Regex.Replace(
+                                             Regex.Replace(
+                                                 Regex.Replace(
+                                                     match.Groups["Name"].Value,
+                                                     @"^Pomelo\.EntityFrameworkCore\.MySql\.FunctionalTests\.",
+                                                     string.Empty),
+                                                 @"\.[^.]+$",
+                                                 string.Empty),
+                                             @"\.",
+                                             @"\"),
+                                         "^.*$",
+                                         "$0.cs")),
+                                 int.Parse(match.Groups["Line"].Value),
+                                 match.Groups["Name"].Value,
+                                 match.Groups["AssertSql"].Value,
+                                 match.Groups["Truncated"].Success))
+                         .GroupBy(
+                             c => c.File,
+                             (_, cc) => cc
+                                 .GroupBy(t => t.Line)
+                                 .Select(g => g.First())
+                                 .OrderByDescending(t => t.Line)
+                                 .ToArray()))
+            {
+                var filePath = file.First().File;
+
+                // If we didn't find the chunk in the original file, it is possible that the test class is partial and that the chunk exists
+                // in a separate file that has the name `<ClassName>.MySql.cs`.
+                var retryCustomized = new List<string>();
+
+                File.WriteAllText(
+                    filePath,
+                    file.Aggregate(
+                            File.ReadAllText(filePath),
+                            (result, current) => ReplaceChunk(result, current, retryCustomized)));
+
+                if (!retryCustomized.Any())
+                {
+                    continue;
+                }
+
+                var customizedFilePath = Path.Combine(
+                    Path.GetDirectoryName(filePath) ?? string.Empty,
+                    $"{Path.GetFileNameWithoutExtension(filePath)}.MySql{Path.GetExtension(filePath)}");
+
+                if (File.Exists(customizedFilePath))
+                {
+                    File.WriteAllText(
+                        customizedFilePath,
+                        file.Join(
+                                retryCustomized,
+                                f => f.Id,
+                                s => s,
+                                (inner, _) => inner)
                             .OrderByDescending(t => t.Line)
                             .Aggregate(
-                                File.ReadAllText(file.First().File),
-                                (result, current) =>
-                                {
-                                    var lines = Regex.Split(result, @"\r?\n");
-                                    var before = lines.Take(current.Line - 1);
-                                    var remaining = lines.Skip(current.Line - 1);
-                                    var replaced = Regex.Split(
-                                            Regex.Replace(
-                                                string.Join(Environment.NewLine, remaining),
-                                                $"^{assertSqlPattern}",
-                                                current.AssertSql,
-                                                RegexOptions.IgnoreCase | RegexOptions.Singleline),
-                                            @"\r?\n")
-                                        .AsEnumerable();
+                                File.ReadAllText(customizedFilePath),
+                                (result, current) => ReplaceChunk(result, current, notFound)));
+                }
+                else
+                {
+                    notFound.AddRange(retryCustomized);
+                }
+            }
 
-                                    if (current.Truncated)
-                                    {
-                                        replaced = replaced.Prepend("            #warning TRUNCATED: Add remaining baseline queries.");
-                                    }
+            if (notFound.Any())
+            {
+                Console.WriteLine("The following chunks where not found:");
+                Console.WriteLine();
 
-                                    return string.Join(Environment.NewLine, before.Concat(replaced));
-                                })));
+                foreach (var id in notFound)
+                {
+                    Console.WriteLine(id);
+                }
+
+                return -1;
+            }
+
+            return 0;
+        }
+
+        private static string ReplaceChunk(string result, AssertSqlChunk current, List<string> notFound)
+        {
+            var lines = Regex.Split(result, @"\r?\n");
+            var before = lines.Take(current.Line - 1);
+            var remaining = lines.Skip(current.Line - 1);
+            var inputText = string.Join(Environment.NewLine, remaining);
+            var replacedResult = Regex.Replace(
+                inputText,
+                $"^{AssertSqlPattern}",
+                current.AssertSql,
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            if (inputText == replacedResult)
+            {
+                notFound.Add(current.Id);
+                return result;
+            }
+
+            var splitReplaced = Regex.Split(
+                    replacedResult,
+                    @"\r?\n")
+                .AsEnumerable();
+
+            if (current.Truncated)
+            {
+                splitReplaced = splitReplaced.Prepend("            #warning TRUNCATED: Add remaining baseline queries.");
+            }
+
+            return string.Join(Environment.NewLine, before.Concat(splitReplaced));
         }
     }
+
+    public record AssertSqlChunk(string Id, string File, int Line, string Name, string AssertSql, bool Truncated);
 }

--- a/tools/QueryBaselineUpdater/QueryBaselineUpdater.csproj
+++ b/tools/QueryBaselineUpdater/QueryBaselineUpdater.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>$(PomeloTestTargetFramework)</TargetFramework>
     </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The tool parses a `QueryBaseline.txt` file and now finds the correct source code file automatically. It not just supports the default test file (base on namespace and class name) but also a possible customized file (in the format of `<ClassName>.MySql.cs`) that uses a `partial` class.

It updates all files and uses the correct method to test for SQL (`AssertSql()` or `AssertExecuteUpdateSql()`).

In contrast to use of the environment variable [EF_TEST_REWRITE_BASELINES=1](https://learn.microsoft.com/en-us/ef/core/providers/writing-a-provider#bulk-update-of-baselines), this is much more convenient and seems to cover _all_ cases and usages.