### PR TITLE
Workaround SELECT ... ORDER BY (SELECT 1) related bug in Oracle's MySQL implementation, that can lead to completely wrong data being returned.

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
@@ -866,6 +866,28 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             return mySqlBinaryExpression;
         }
 
+        protected override Expression VisitOrdering(OrderingExpression orderingExpression)
+        {
+            // The base implementation translates this case to `(SELECT 1)`.
+            // This leads to a bug in Oracle's MySQL, where completely wrong data is being returned under certain conditions.
+            // This can be reproduced by executing a no-op (or any existing) test of the `ProxyGraphUpdatesMySqlTest+LazyLoading` class (e.g. our own `DummyTest`),
+            // immediately followed by NorthwindSplitIncludeNoTrackingQueryMySqlTest.Include_collection_OrderBy_empty_list_contains(async: False).
+            // As a workaround, we just output `1` instead of `(SELECT 1)` for all database versions and types.
+            if (orderingExpression.Expression is SqlConstantExpression or SqlParameterExpression)
+            {
+                Sql.Append("1");
+
+                if (!orderingExpression.IsAscending)
+                {
+                    Sql.Append(" DESC");
+                }
+
+                return orderingExpression;
+            }
+
+            return base.VisitOrdering(orderingExpression);
+        }
+
         protected virtual Expression VisitJsonTableExpression(MySqlJsonTableExpression jsonTableExpression)
         {
             // if (jsonTableExpression.ColumnInfos is not { Count: > 0 })

--- a/test/EFCore.MySql.FunctionalTests/ProxyGraphUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/ProxyGraphUpdatesMySqlTest.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
+using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 {
@@ -34,6 +35,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         {
             public LazyLoading(ProxyGraphUpdatesWithLazyLoadingMySqlFixture fixture)
                 : base(fixture)
+            {
+            }
+
+            // Used to track down a bug in Oracle's MySQL implementation, related to `SELECT ... ORDER BY (SELECT 1)`.
+            [Fact]
+            public void DummyTest()
             {
             }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindEFPropertyIncludeQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindEFPropertyIncludeQueryMySqlTest.cs
@@ -1076,7 +1076,7 @@ FROM (
     SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`, FALSE AS `c`
     FROM `Customers` AS `c`
     WHERE `c`.`CustomerID` LIKE 'A%'
-    ORDER BY (SELECT 1)
+    ORDER BY 1
     LIMIT 18446744073709551610 OFFSET @__p_1
 ) AS `t`
 LEFT JOIN `Orders` AS `o` ON `t`.`CustomerID` = `o`.`CustomerID`
@@ -2003,7 +2003,7 @@ FROM (
     SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`, TRUE AS `c`
     FROM `Customers` AS `c`
     WHERE `c`.`CustomerID` LIKE 'A%'
-    ORDER BY (SELECT 1)
+    ORDER BY 1
     LIMIT 18446744073709551610 OFFSET @__p_1
 ) AS `t`
 LEFT JOIN `Orders` AS `o` ON `t`.`CustomerID` = `o`.`CustomerID`

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/DebugServices/DebugRelationalCommand.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/DebugServices/DebugRelationalCommand.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.DebugServices;
+
+public class DebugRelationalCommand : RelationalCommand
+{
+    public DebugRelationalCommand(
+        [NotNull] RelationalCommandBuilderDependencies dependencies,
+        [NotNull] string commandText,
+        [NotNull] IReadOnlyList<IRelationalParameter> parameters)
+        : base(dependencies, commandText, parameters)
+    {
+    }
+
+    protected override RelationalDataReader CreateRelationalDataReader()
+        => new DebugRelationalDataReader();
+}

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/DebugServices/DebugRelationalCommandBuilder.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/DebugServices/DebugRelationalCommandBuilder.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.DebugServices;
+
+public class DebugRelationalCommandBuilder : RelationalCommandBuilder
+{
+    public DebugRelationalCommandBuilder([NotNull] RelationalCommandBuilderDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    public override IRelationalCommand Build()
+        => new DebugRelationalCommand(Dependencies, base.Build().CommandText, Parameters);
+}

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/DebugServices/DebugRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/DebugServices/DebugRelationalCommandBuilderFactory.cs
@@ -1,0 +1,15 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.DebugServices;
+
+public class DebugRelationalCommandBuilderFactory : RelationalCommandBuilderFactory
+{
+    public DebugRelationalCommandBuilderFactory([NotNull] RelationalCommandBuilderDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    public override IRelationalCommandBuilder Create()
+        => new DebugRelationalCommandBuilder(Dependencies);
+}

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/DebugServices/DebugRelationalDataReader.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/DebugServices/DebugRelationalDataReader.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities.DebugServices;
+
+public class DebugRelationalDataReader : RelationalDataReader
+{
+    private DebugDbDataReader _dataReaderWrapper;
+
+    public override void Initialize(
+        IRelationalConnection relationalConnection,
+        DbCommand command,
+        DbDataReader reader,
+        Guid commandId,
+        IRelationalCommandDiagnosticsLogger logger)
+    {
+        _dataReaderWrapper?.Dispose();
+        _dataReaderWrapper = new DebugDbDataReader(reader, commandId, logger!.Logger);
+
+        base.Initialize(relationalConnection, command, _dataReaderWrapper, commandId, logger);
+    }
+
+    public override void Dispose()
+    {
+        _dataReaderWrapper.Dispose();
+
+        base.Dispose();
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _dataReaderWrapper.DisposeAsync();
+
+        await base.DisposeAsync();
+    }
+}
+
+public class DebugDbDataReader : DbDataReader, IDisposable
+{
+    private readonly DbDataReader _implementation;
+    private readonly ILogger _logger;
+    private readonly StringBuilder _stringBuilder;
+    private bool _isClosed;
+
+    public DebugDbDataReader(DbDataReader implementation, Guid commandId, ILogger logger)
+    {
+        _implementation = implementation;
+        _logger = logger;
+        _stringBuilder = new StringBuilder();
+
+        _stringBuilder.AppendLine($"DebugRelationalDataReader for Command {commandId}:");
+        _stringBuilder.AppendLine(string.Join("\t", Enumerable.Range(0, _implementation.FieldCount).Select(f => _implementation.GetName(f))));
+    }
+
+    public override bool Read()
+    {
+        var result = _implementation.Read();
+
+        if (result)
+        {
+            _stringBuilder.AppendLine(string.Join("\t", Enumerable.Range(0, _implementation.FieldCount).Select(f => _implementation.GetValue(f)?.ToString())));
+        }
+
+        return result;
+    }
+
+    public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
+    {
+        var result = await _implementation.ReadAsync(cancellationToken);
+
+        if (result)
+        {
+            _stringBuilder.AppendLine(string.Join("\t", Enumerable.Range(0, _implementation.FieldCount).Select(f => _implementation.GetValue(f)?.ToString())));
+        }
+
+        return result;
+    }
+
+    public override void Close()
+    {
+        if (!_isClosed)
+        {
+            _logger.LogInformation(_stringBuilder.ToString());
+            _isClosed = true;
+        }
+
+        _implementation.Close();
+    }
+
+    public override Task CloseAsync()
+    {
+        if (!_isClosed)
+        {
+            _logger.LogInformation(_stringBuilder.ToString());
+            _isClosed = true;
+        }
+
+        return _implementation.CloseAsync();
+    }
+
+    #region Delegated
+
+    void IDisposable.Dispose()
+        => _implementation.Dispose();
+
+    public override ValueTask DisposeAsync()
+        => _implementation.DisposeAsync();
+
+    public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
+        => _implementation.GetFieldValueAsync<T>(ordinal, cancellationToken);
+
+    public override T GetFieldValue<T>(int ordinal)
+        => _implementation.GetFieldValue<T>(ordinal);
+
+    public override Type GetProviderSpecificFieldType(int ordinal)
+        => _implementation.GetProviderSpecificFieldType(ordinal);
+
+    public override object GetProviderSpecificValue(int ordinal)
+        => _implementation.GetProviderSpecificValue(ordinal);
+
+    public override int GetProviderSpecificValues(object[] values)
+        => _implementation.GetProviderSpecificValues(values);
+
+    public override DataTable GetSchemaTable()
+        => _implementation.GetSchemaTable();
+
+    public override Task<DataTable> GetSchemaTableAsync(CancellationToken cancellationToken = new CancellationToken())
+        => _implementation.GetSchemaTableAsync(cancellationToken);
+
+    public override Task<ReadOnlyCollection<DbColumn>> GetColumnSchemaAsync(CancellationToken cancellationToken = new CancellationToken())
+        => _implementation.GetColumnSchemaAsync(cancellationToken);
+
+    public override Stream GetStream(int ordinal)
+        => _implementation.GetStream(ordinal);
+
+    public override TextReader GetTextReader(int ordinal)
+        => _implementation.GetTextReader(ordinal);
+
+    public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
+        => _implementation.IsDBNullAsync(ordinal, cancellationToken);
+
+    public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
+        => _implementation.NextResultAsync(cancellationToken);
+
+    public override int VisibleFieldCount
+        => _implementation.VisibleFieldCount;
+
+    public override bool Equals(object obj)
+        => _implementation.Equals(obj);
+
+    public override int GetHashCode()
+        => _implementation.GetHashCode();
+
+    public override string ToString()
+        => _implementation.ToString();
+
+    public override bool GetBoolean(int ordinal)
+        => _implementation.GetBoolean(ordinal);
+
+    public override byte GetByte(int ordinal)
+        => _implementation.GetByte(ordinal);
+
+    public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        => _implementation.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+
+    public override char GetChar(int ordinal)
+        => _implementation.GetChar(ordinal);
+
+    public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        => _implementation.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
+
+    public override string GetDataTypeName(int ordinal)
+        => _implementation.GetDataTypeName(ordinal);
+
+    public override DateTime GetDateTime(int ordinal)
+        => _implementation.GetDateTime(ordinal);
+
+    public override decimal GetDecimal(int ordinal)
+        => _implementation.GetDecimal(ordinal);
+
+    public override double GetDouble(int ordinal)
+        => _implementation.GetDouble(ordinal);
+
+    public override Type GetFieldType(int ordinal)
+        => _implementation.GetFieldType(ordinal);
+
+    public override float GetFloat(int ordinal)
+        => _implementation.GetFloat(ordinal);
+
+    public override Guid GetGuid(int ordinal)
+        => _implementation.GetGuid(ordinal);
+
+    public override short GetInt16(int ordinal)
+        => _implementation.GetInt16(ordinal);
+
+    public override int GetInt32(int ordinal)
+        => _implementation.GetInt32(ordinal);
+
+    public override long GetInt64(int ordinal)
+        => _implementation.GetInt64(ordinal);
+
+    public override string GetName(int ordinal)
+        => _implementation.GetName(ordinal);
+
+    public override int GetOrdinal(string name)
+        => _implementation.GetOrdinal(name);
+
+    public override string GetString(int ordinal)
+        => _implementation.GetString(ordinal);
+
+    public override object GetValue(int ordinal)
+        => _implementation.GetValue(ordinal);
+
+    public override int GetValues(object[] values)
+        => _implementation.GetValues(values);
+
+    public override bool IsDBNull(int ordinal)
+        => _implementation.IsDBNull(ordinal);
+
+    public override int FieldCount
+        => _implementation.FieldCount;
+
+    public override object this[int ordinal]
+        => _implementation[ordinal];
+
+    public override object this[string name]
+        => _implementation[name];
+
+    public override int RecordsAffected
+        => _implementation.RecordsAffected;
+
+    public override bool HasRows
+        => _implementation.HasRows;
+
+    public override bool IsClosed
+        => _implementation.IsClosed;
+
+    public override bool NextResult()
+        => _implementation.NextResult();
+
+    public override int Depth
+        => _implementation.Depth;
+
+    public override IEnumerator GetEnumerator()
+        => _implementation.GetEnumerator();
+
+    #endregion Delegated
+}


### PR DESCRIPTION
The `QuerySqlGenerator` base implementation translates constant and parameter expressions in an `OrderingExpression` to `(SELECT 1)`.

This leads to a bug in Oracle's MySQL, where completely wrong data is being returned under certain conditions.

As a workaround, we now just output `1` instead of `(SELECT 1)` for all database versions and types.

Fixes #1849 