### PR TITLE
Update to EF Core 8.0.1

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Common Versions">
-    <EFCoreVersion>[8.0.0,8.0.999]</EFCoreVersion>
+    <EFCoreVersion>[8.0.1,8.0.999]</EFCoreVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Dependencies">
@@ -13,16 +13,16 @@
     <PackageReference Update="MySqlConnector.DependencyInjection" Version="2.3.5" />
 
     <PackageReference Update="NetTopologySuite" Version="2.5.0" />
-    <PackageReference Update="System.Text.Json" Version="8.0.0" />
+    <PackageReference Update="System.Text.Json" Version="8.0.1" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
 
     <PackageReference Update="Castle.Core" Version="5.1.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.1" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Update="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "8.0.0",
+      "version": "8.0.1",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/EFCore.MySql.NTS/Query/Internal/MySqlGeometryMethodTranslator.cs
+++ b/src/EFCore.MySql.NTS/Query/Internal/MySqlGeometryMethodTranslator.cs
@@ -127,7 +127,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                                 _sqlExpressionFactory.Constant(1))
                         },
                         method.ReturnType,
-                        _typeMappingSource.FindMapping(method.ReturnType, storeType),
+                        _typeMappingSource.FindMapping(method.ReturnType),
                         false);
                 }
 
@@ -137,7 +137,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                         instance,
                         arguments[0],
                         method.ReturnType,
-                        _typeMappingSource.FindMapping(method.ReturnType, storeType));
+                        _typeMappingSource.FindMapping(method.ReturnType));
                 }
 
                 if (Equals(method, _isWithinDistance))

--- a/src/EFCore.MySql/Design/Internal/MySqlCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlCSharpRuntimeAnnotationCodeGenerator.cs
@@ -1,13 +1,20 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
+using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Storage.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal;
 
+// Used to generate a compiled model. The compiled model is only used at app runtime and not for design-time purposes.
+// Therefore, all annotations that are related to design-time concerns (i.e. databases, tables or columns) are superfluous and should be
+// removed.
+// TOOD: Check behavior for `ValueGenerationStrategy`, `LegacyValueGeneratedOnAdd` and `LegacyValueGeneratedOnAddOrUpdate`.
 public class MySqlCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRuntimeAnnotationCodeGenerator
 {
     public MySqlCSharpRuntimeAnnotationCodeGenerator(
@@ -32,5 +39,167 @@ public class MySqlCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRuntime
         }
 
         return result;
+    }
+
+    public override void Generate(IModel model, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+            annotations.Remove(MySqlAnnotationNames.CharSetDelegation);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.CollationDelegation);
+            annotations.Remove(MySqlAnnotationNames.GuidCollation);
+        }
+
+        base.Generate(model, parameters);
+    }
+
+    public override void Generate(IRelationalModel model, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+            annotations.Remove(MySqlAnnotationNames.CharSetDelegation);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.CollationDelegation);
+            annotations.Remove(MySqlAnnotationNames.GuidCollation);
+
+            annotations.Remove(RelationalAnnotationNames.Collation);
+        }
+
+        base.Generate(model, parameters);
+    }
+
+    public override void Generate(IEntityType entityType, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+            annotations.Remove(MySqlAnnotationNames.CharSetDelegation);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.CollationDelegation);
+            annotations.Remove(MySqlAnnotationNames.StoreOptions);
+
+            annotations.Remove(RelationalAnnotationNames.Collation);
+        }
+
+        base.Generate(entityType, parameters);
+    }
+
+    public override void Generate(ITable table, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+            annotations.Remove(MySqlAnnotationNames.CharSetDelegation);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.CollationDelegation);
+            annotations.Remove(MySqlAnnotationNames.StoreOptions);
+
+            annotations.Remove(RelationalAnnotationNames.Collation);
+        }
+
+        base.Generate(table, parameters);
+    }
+
+    public override void Generate(IProperty property, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.SpatialReferenceSystemId);
+
+            annotations.Remove(RelationalAnnotationNames.Collation);
+
+            if (!annotations.ContainsKey(MySqlAnnotationNames.ValueGenerationStrategy))
+            {
+                annotations[MySqlAnnotationNames.ValueGenerationStrategy] = property.GetValueGenerationStrategy();
+            }
+        }
+
+        base.Generate(property, parameters);
+    }
+
+    public override void Generate(IColumn column, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.SpatialReferenceSystemId);
+            annotations.Remove(MySqlAnnotationNames.ValueGenerationStrategy);
+
+            annotations.Remove(RelationalAnnotationNames.Collation);
+        }
+
+        base.Generate(column, parameters);
+    }
+
+    public override void Generate(IIndex index, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.FullTextIndex);
+            annotations.Remove(MySqlAnnotationNames.FullTextParser);
+            annotations.Remove(MySqlAnnotationNames.IndexPrefixLength);
+            annotations.Remove(MySqlAnnotationNames.SpatialIndex);
+        }
+
+        base.Generate(index, parameters);
+    }
+
+    public override void Generate(ITableIndex index, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.FullTextIndex);
+            annotations.Remove(MySqlAnnotationNames.FullTextParser);
+            annotations.Remove(MySqlAnnotationNames.IndexPrefixLength);
+            annotations.Remove(MySqlAnnotationNames.SpatialIndex);
+        }
+
+        base.Generate(index, parameters);
+    }
+
+    public override void Generate(IKey key, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+
+            annotations.Remove(MySqlAnnotationNames.IndexPrefixLength);
+        }
+
+        base.Generate(key, parameters);
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlEntityTypeExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlEntityTypeExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
@@ -26,7 +27,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The name of the character set. </returns>
         public static string GetCharSet([NotNull] this IReadOnlyEntityType entityType)
-            => entityType[MySqlAnnotationNames.CharSet] as string;
+            => (entityType is RuntimeEntityType)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : entityType[MySqlAnnotationNames.CharSet] as string;
 
         /// <summary>
         /// Sets the MySQL character set on the table associated with this entity. When you only specify the character set, MySQL implicitly
@@ -81,12 +84,14 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The character set delegation modes. </returns>
         public static DelegationModes? GetCharSetDelegation([NotNull] this IReadOnlyEntityType entityType)
-            => ObjectToEnumConverter.GetEnumValue<DelegationModes>(entityType[MySqlAnnotationNames.CharSetDelegation]) ??
-               (entityType[MySqlAnnotationNames.CharSetDelegation] is bool explicitlyDelegateToChildren
-                   ? explicitlyDelegateToChildren
-                       ? DelegationModes.ApplyToAll
-                       : DelegationModes.ApplyToDatabases
-                   : null);
+            => (entityType is RuntimeEntityType)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : ObjectToEnumConverter.GetEnumValue<DelegationModes>(entityType[MySqlAnnotationNames.CharSetDelegation]) ??
+                  (entityType[MySqlAnnotationNames.CharSetDelegation] is bool explicitlyDelegateToChildren
+                      ? explicitlyDelegateToChildren
+                          ? DelegationModes.ApplyToAll
+                          : DelegationModes.ApplyToDatabases
+                      : null);
 
         /// <summary>
         ///     Attempts to set the character set delegation modes for entity/table.
@@ -153,7 +158,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The name of the collation. </returns>
         public static string GetCollation([NotNull] this IReadOnlyEntityType entityType)
-            => entityType[RelationalAnnotationNames.Collation] as string;
+            => (entityType is RuntimeEntityType)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : entityType[RelationalAnnotationNames.Collation] as string;
 
         /// <summary>
         /// Sets the MySQL collation on the table associated with this entity. When you specify the collation, MySQL implicitly sets the
@@ -208,12 +215,14 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The collation delegation modes. </returns>
         public static DelegationModes? GetCollationDelegation([NotNull] this IReadOnlyEntityType entityType)
-            => ObjectToEnumConverter.GetEnumValue<DelegationModes>(entityType[MySqlAnnotationNames.CollationDelegation]) ??
-               (entityType[MySqlAnnotationNames.CollationDelegation] is bool explicitlyDelegateToChildren
-                   ? explicitlyDelegateToChildren
-                       ? DelegationModes.ApplyToAll
-                       : DelegationModes.ApplyToDatabases
-                   : null);
+            => (entityType is RuntimeEntityType)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : ObjectToEnumConverter.GetEnumValue<DelegationModes>(entityType[MySqlAnnotationNames.CollationDelegation]) ??
+                  (entityType[MySqlAnnotationNames.CollationDelegation] is bool explicitlyDelegateToChildren
+                      ? explicitlyDelegateToChildren
+                          ? DelegationModes.ApplyToAll
+                          : DelegationModes.ApplyToDatabases
+                      : null);
 
         /// <summary>
         ///     Attempts to set the collation delegation modes for entity/table.
@@ -280,7 +289,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> A dictionary of table options. </returns>
         public static Dictionary<string, string> GetTableOptions([NotNull] this IReadOnlyEntityType entityType)
-            => DeserializeTableOptions(entityType[MySqlAnnotationNames.StoreOptions] as string);
+            => (entityType is RuntimeEntityType)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : DeserializeTableOptions(entityType[MySqlAnnotationNames.StoreOptions] as string);
 
         /// <summary>
         /// Sets the MySQL table options for the table associated with this entity.

--- a/src/EFCore.MySql/Extensions/MySqlIndexExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlIndexExtensions.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
@@ -19,7 +21,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="index"> The index. </param>
         /// <returns> <see langword="true"/> if the index is full text. </returns>
         public static bool? IsFullText([NotNull] this IIndex index)
-            => (bool?)index[MySqlAnnotationNames.FullTextIndex];
+            => (index is RuntimeIndex)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : (bool?)index[MySqlAnnotationNames.FullTextIndex];
 
         /// <summary>
         ///     Sets a value indicating whether the index is full text.
@@ -58,7 +62,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="index"> The index. </param>
         /// <returns> The name of the full text parser. </returns>
         [CanBeNull] public static string FullTextParser([NotNull] this IIndex index)
-            => (string)index[MySqlAnnotationNames.FullTextParser];
+            => (index is RuntimeIndex)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : (string)index[MySqlAnnotationNames.FullTextParser];
 
         /// <summary>
         ///     Sets a value indicating which full text parser to used.
@@ -98,7 +104,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The prefix lengths.
         /// A value of `0` indicates, that the full length should be used for that column. </returns>
         public static int[] PrefixLength([NotNull] this IIndex index)
-            => (int[])index[MySqlAnnotationNames.IndexPrefixLength];
+            => (index is RuntimeIndex)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : (int[])index[MySqlAnnotationNames.IndexPrefixLength];
 
         /// <summary>
         ///     Sets prefix lengths for the index.
@@ -139,7 +147,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="index"> The index. </param>
         /// <returns> <see langword="true"/> if the index is spartial. </returns>
         public static bool? IsSpatial([NotNull] this IIndex index)
-            => (bool?)index[MySqlAnnotationNames.SpatialIndex];
+            => (index is RuntimeIndex)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : (bool?)index[MySqlAnnotationNames.SpatialIndex];
 
         /// <summary>
         ///     Sets a value indicating whether the index is spartial.

--- a/src/EFCore.MySql/Extensions/MySqlKeyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlKeyExtensions.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
@@ -20,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The prefix lengths.
         /// A value of `0` indicates, that the full length should be used for that column. </returns>
         public static int[] PrefixLength([NotNull] this IKey key)
-            => (int[])key[MySqlAnnotationNames.IndexPrefixLength];
+            => (key is RuntimeKey)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : (int[])key[MySqlAnnotationNames.IndexPrefixLength];
 
         /// <summary>
         ///     Sets prefix lengths for the key.

--- a/src/EFCore.MySql/Extensions/MySqlModelBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlModelBuilderExtensions.cs
@@ -6,7 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -14,6 +13,69 @@ namespace Microsoft.EntityFrameworkCore
 {
     public static class MySqlModelBuilderExtensions
     {
+        #region AutoIncrement
+
+        /// <summary>
+        ///     Configures the model to use the AUTO_INCREMENT feature to generate values for properties
+        ///     marked as <see cref="ValueGenerated.OnAdd" />, when targeting MySQL.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static ModelBuilder AutoIncrementColumns(this ModelBuilder modelBuilder)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+
+            var model = modelBuilder.Model;
+
+            model.SetValueGenerationStrategy(MySqlValueGenerationStrategy.IdentityColumn);
+
+            return modelBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the value generation strategy for the key property, when targeting MySQL.
+        /// </summary>
+        /// <param name="modelBuilder">The builder for the property being configured.</param>
+        /// <param name="valueGenerationStrategy">The value generation strategy.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied, <see langword="null"/> otherwise.
+        /// </returns>
+        public static IConventionModelBuilder HasValueGenerationStrategy(
+            this IConventionModelBuilder modelBuilder,
+            MySqlValueGenerationStrategy? valueGenerationStrategy,
+            bool fromDataAnnotation = false)
+        {
+            if (modelBuilder.CanSetValueGenerationStrategy(valueGenerationStrategy, fromDataAnnotation))
+            {
+                modelBuilder.Metadata.SetValueGenerationStrategy(valueGenerationStrategy, fromDataAnnotation);
+
+                return modelBuilder;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether the given value can be set as the default value generation strategy.
+        /// </summary>
+        /// <param name="modelBuilder"> The model builder. </param>
+        /// <param name="valueGenerationStrategy"> The value generation strategy. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <see langword="true"/> if the given value can be set as the default value generation strategy. </returns>
+        public static bool CanSetValueGenerationStrategy(
+            this IConventionModelBuilder modelBuilder,
+            MySqlValueGenerationStrategy? valueGenerationStrategy,
+            bool fromDataAnnotation = false)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+
+            return modelBuilder.CanSetAnnotation(
+                MySqlAnnotationNames.ValueGenerationStrategy, valueGenerationStrategy, fromDataAnnotation);
+        }
+
+        #endregion Identity
+
         #region CharSet and delegation
 
         /// <summary>

--- a/src/EFCore.MySql/Extensions/MySqlModelExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlModelExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
@@ -74,7 +75,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model. </param>
         /// <returns> The default character set. </returns>
         public static string GetCharSet([NotNull] this IReadOnlyModel model)
-            => model[MySqlAnnotationNames.CharSet] as string;
+            => (model is RuntimeModel)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : model[MySqlAnnotationNames.CharSet] as string;
 
         /// <summary>
         ///     Attempts to set the character set to use as the default for the model/database.
@@ -115,12 +118,14 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model. </param>
         /// <returns> The character set delegation modes. </returns>
         public static DelegationModes? GetCharSetDelegation([NotNull] this IReadOnlyModel model)
-            => ObjectToEnumConverter.GetEnumValue<DelegationModes>(model[MySqlAnnotationNames.CharSetDelegation]) ??
-               (model[MySqlAnnotationNames.CharSetDelegation] is bool explicitlyDelegateToChildren
-                   ? explicitlyDelegateToChildren
-                       ? DelegationModes.ApplyToAll
-                       : DelegationModes.ApplyToDatabases
-                   : null);
+            => (model is RuntimeModel)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : ObjectToEnumConverter.GetEnumValue<DelegationModes>(model[MySqlAnnotationNames.CharSetDelegation]) ??
+                  (model[MySqlAnnotationNames.CharSetDelegation] is bool explicitlyDelegateToChildren
+                      ? explicitlyDelegateToChildren
+                          ? DelegationModes.ApplyToAll
+                          : DelegationModes.ApplyToDatabases
+                      : null);
 
         /// <summary>
         ///     Attempts to set the character set delegation modes for the model/database.
@@ -181,12 +186,14 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model. </param>
         /// <returns> The collation delegation modes. </returns>
         public static DelegationModes? GetCollationDelegation([NotNull] this IReadOnlyModel model)
-            => ObjectToEnumConverter.GetEnumValue<DelegationModes>(model[MySqlAnnotationNames.CollationDelegation]) ??
-               (model[MySqlAnnotationNames.CollationDelegation] is bool explicitlyDelegateToChildren
-                   ? explicitlyDelegateToChildren
-                       ? DelegationModes.ApplyToAll
-                       : DelegationModes.ApplyToDatabases
-                   : null);
+            => (model is RuntimeModel)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : ObjectToEnumConverter.GetEnumValue<DelegationModes>(model[MySqlAnnotationNames.CollationDelegation]) ??
+                  (model[MySqlAnnotationNames.CollationDelegation] is bool explicitlyDelegateToChildren
+                      ? explicitlyDelegateToChildren
+                          ? DelegationModes.ApplyToAll
+                          : DelegationModes.ApplyToDatabases
+                      : null);
 
         /// <summary>
         ///     Attempts to set the collation delegation modes for the model/database.
@@ -251,7 +258,9 @@ namespace Microsoft.EntityFrameworkCore
         ///     collation `ascii_general_ci` will be applied.
         /// </returns>
         public static string GetGuidCollation([NotNull] this IReadOnlyModel model)
-            => model[MySqlAnnotationNames.GuidCollation] as string;
+            => (model is RuntimeModel)
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : model[MySqlAnnotationNames.GuidCollation] as string;
 
         /// <summary>
         ///     Attempts to set the default collation used for char-based <see cref="Guid"/> columns.

--- a/src/EFCore.MySql/Extensions/MySqlModelExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlModelExtensions.cs
@@ -21,17 +21,11 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model. </param>
         /// <returns> The default <see cref="MySqlValueGenerationStrategy" />. </returns>
         public static MySqlValueGenerationStrategy? GetValueGenerationStrategy([NotNull] this IReadOnlyModel model)
-        {
-            // Allow users to use the underlying type value instead of the enum itself.
-            // Workaround for: https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1205
-            if (model[MySqlAnnotationNames.ValueGenerationStrategy] is { } annotation &&
-                ObjectToEnumConverter.GetEnumValue<MySqlValueGenerationStrategy>(annotation) is { } enumValue)
-            {
-                return enumValue;
-            }
-
-            return null;
-        }
+            => model[MySqlAnnotationNames.ValueGenerationStrategy] is { } annotationValue
+                ? ObjectToEnumConverter.GetEnumValue<MySqlValueGenerationStrategy>(annotationValue) is { } enumValue
+                    ? enumValue
+                    : (MySqlValueGenerationStrategy)annotationValue
+                : null;
 
         /// <summary>
         ///     Attempts to set the <see cref="MySqlValueGenerationStrategy" /> to use for properties

--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore
             public override bool JsonDataTypeEmulation => false;
             public override bool ImplicitBoolCheckUsesIndex => ServerVersion.Version >= new Version(8, 0, 0); // Exact version has not been verified yet
             public override bool MySqlBug96947Workaround => ServerVersion.Version >= new Version(5, 7, 0) &&
-                                                            ServerVersion.Version < new Version(8, 0, 25); // Exact version has not been verified yet, but it is 5.7.x and could very well be 5.7.0
+                                                            ServerVersion.Version < new Version(8, 0, 23); // Exact version has not been verified yet, but it is 5.7.x and could very well be 5.7.0
             public override bool MySqlBug104294Workaround => ServerVersion.Version >= new Version(8, 0, 0); // Exact version has not been determined yet
             public override bool FullTextParser => ServerVersion.Version >= new Version(5, 7, 3);
             public override bool InformationSchemaCheckConstraintsTable => ServerVersion.Version >= new Version(8, 0, 16); // MySQL is missing the explicit TABLE_NAME column that MariaDB supports, so always join the TABLE_CONSTRAINTS table when accessing CHECK_CONSTRAINTS for any database server that supports CHECK_CONSTRAINTS.

--- a/src/EFCore.MySql/Metadata/Conventions/MySqlConventionSetBuilder.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/MySqlConventionSetBuilder.cs
@@ -50,6 +50,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGenerationConvention);
             conventionSet.PropertyAnnotationChangedConventions.Add(valueGenerationConvention);
 
+            ReplaceConvention(
+                conventionSet.ModelFinalizedConventions,
+                (RuntimeModelConvention)new MySqlRuntimeModelConvention(Dependencies, RelationalDependencies));
+
             return conventionSet;
         }
 

--- a/src/EFCore.MySql/Metadata/Conventions/MySqlConventionSetBuilder.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/MySqlConventionSetBuilder.cs
@@ -35,6 +35,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             var conventionSet = base.CreateConventionSet();
 
+            conventionSet.Add(new MySqlValueGenerationStrategyConvention(Dependencies, RelationalDependencies));
+
             conventionSet.ModelInitializedConventions.Add(new RelationalMaxIdentifierLengthConvention(64, Dependencies, RelationalDependencies));
 
             conventionSet.EntityTypeAddedConventions.Add(new TableCharSetAttributeConvention(Dependencies));

--- a/src/EFCore.MySql/Metadata/Conventions/MySqlRuntimeModelConvention.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/MySqlRuntimeModelConvention.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Conventions;
+
+/// <summary>
+///     A convention that creates an optimized copy of the mutable model.
+///     The runtime model is only used at app runtime and not for design-time purposes.
+///     Therefore, all annotations that are related to design-time concerns (i.e. databases, tables or columns) are superfluous and should
+///     be removed.
+/// </summary>
+public class MySqlRuntimeModelConvention : RelationalRuntimeModelConvention
+{
+    /// <summary>
+    ///     Creates a new instance of <see cref="MySqlRuntimeModelConvention" />.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing dependencies for this convention.</param>
+    /// <param name="relationalDependencies">Parameter object containing relational dependencies for this convention.</param>
+    public MySqlRuntimeModelConvention(
+        ProviderConventionSetBuilderDependencies dependencies,
+        RelationalConventionSetBuilderDependencies relationalDependencies)
+        : base(dependencies, relationalDependencies)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ProcessModelAnnotations(
+        Dictionary<string, object> annotations,
+        IModel model,
+        RuntimeModel runtimeModel,
+        bool runtime)
+    {
+        base.ProcessModelAnnotations(annotations, model, runtimeModel, runtime);
+
+        if (!runtime)
+        {
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+            annotations.Remove(MySqlAnnotationNames.CharSetDelegation);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.CollationDelegation);
+            annotations.Remove(MySqlAnnotationNames.GuidCollation);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void ProcessEntityTypeAnnotations(
+        Dictionary<string, object> annotations,
+        IEntityType entityType,
+        RuntimeEntityType runtimeEntityType,
+        bool runtime)
+    {
+        base.ProcessEntityTypeAnnotations(annotations, entityType, runtimeEntityType, runtime);
+
+        if (!runtime)
+        {
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+            annotations.Remove(MySqlAnnotationNames.CharSetDelegation);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.CollationDelegation);
+            annotations.Remove(MySqlAnnotationNames.StoreOptions);
+
+            annotations.Remove(RelationalAnnotationNames.Collation);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void ProcessPropertyAnnotations(
+        Dictionary<string, object> annotations,
+        IProperty property,
+        RuntimeProperty runtimeProperty,
+        bool runtime)
+    {
+        base.ProcessPropertyAnnotations(annotations, property, runtimeProperty, runtime);
+
+        if (!runtime)
+        {
+            annotations.Remove(MySqlAnnotationNames.CharSet);
+#pragma warning disable CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.Collation);
+#pragma warning restore CS0618 // Type or member is obsolete
+            annotations.Remove(MySqlAnnotationNames.SpatialReferenceSystemId);
+
+            if (!annotations.ContainsKey(MySqlAnnotationNames.ValueGenerationStrategy))
+            {
+                annotations[MySqlAnnotationNames.ValueGenerationStrategy] = property.GetValueGenerationStrategy();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void ProcessIndexAnnotations(
+        Dictionary<string, object> annotations,
+        IIndex index,
+        RuntimeIndex runtimeIndex,
+        bool runtime)
+    {
+        base.ProcessIndexAnnotations(annotations, index, runtimeIndex, runtime);
+
+        if (!runtime)
+        {
+            annotations.Remove(MySqlAnnotationNames.FullTextIndex);
+            annotations.Remove(MySqlAnnotationNames.FullTextParser);
+            annotations.Remove(MySqlAnnotationNames.IndexPrefixLength);
+            annotations.Remove(MySqlAnnotationNames.SpatialIndex);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void ProcessKeyAnnotations(
+        Dictionary<string, object> annotations,
+        IKey key,
+        RuntimeKey runtimeKey,
+        bool runtime)
+    {
+        base.ProcessKeyAnnotations(annotations, key, runtimeKey, runtime);
+
+        if (!runtime)
+        {
+            annotations.Remove(MySqlAnnotationNames.IndexPrefixLength);
+        }
+    }
+}

--- a/src/EFCore.MySql/Metadata/Conventions/MySqlValueGenerationStrategyConvention.cs
+++ b/src/EFCore.MySql/Metadata/Conventions/MySqlValueGenerationStrategyConvention.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Metadata.Conventions;
+
+/// <summary>
+///     A convention that configures the default model <see cref="MySqlValueGenerationStrategy" /> as
+///     <see cref="MySqlValueGenerationStrategy.IdentityColumn" />.
+/// </summary>
+public class MySqlValueGenerationStrategyConvention : IModelInitializedConvention, IModelFinalizingConvention
+{
+    /// <summary>
+    ///     Creates a new instance of <see cref="MySqlValueGenerationStrategyConvention" />.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing dependencies for this convention.</param>
+    /// <param name="relationalDependencies"> Parameter object containing relational dependencies for this convention.</param>
+    public MySqlValueGenerationStrategyConvention(
+        ProviderConventionSetBuilderDependencies dependencies,
+        RelationalConventionSetBuilderDependencies relationalDependencies)
+    {
+        Dependencies = dependencies;
+        RelationalDependencies = relationalDependencies;
+    }
+
+    /// <summary>
+    ///     Parameter object containing service dependencies.
+    /// </summary>
+    protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
+
+    /// <summary>
+    ///     Relational provider-specific dependencies for this service.
+    /// </summary>
+    protected virtual RelationalConventionSetBuilderDependencies RelationalDependencies { get; }
+
+    /// <inheritdoc />
+    public virtual void ProcessModelInitialized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
+        => modelBuilder.HasValueGenerationStrategy(MySqlValueGenerationStrategy.IdentityColumn);
+
+    /// <inheritdoc />
+    public virtual void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetDeclaredProperties())
+            {
+                MySqlValueGenerationStrategy? strategy = null;
+                var declaringTable = property.GetMappedStoreObjects(StoreObjectType.Table).FirstOrDefault();
+                if (declaringTable.Name != null!)
+                {
+                    strategy = property.GetValueGenerationStrategy(declaringTable, Dependencies.TypeMappingSource);
+                    if (strategy == MySqlValueGenerationStrategy.None &&
+                        !IsStrategyNoneNeeded(property, declaringTable))
+                    {
+                        strategy = null;
+                    }
+                }
+                else
+                {
+                    var declaringView = property.GetMappedStoreObjects(StoreObjectType.View).FirstOrDefault();
+                    if (declaringView.Name != null!)
+                    {
+                        strategy = property.GetValueGenerationStrategy(declaringView, Dependencies.TypeMappingSource);
+                        if (strategy == MySqlValueGenerationStrategy.None &&
+                            !IsStrategyNoneNeeded(property, declaringView))
+                        {
+                            strategy = null;
+                        }
+                    }
+                }
+
+                // Needed for the annotation to show up in the model snapshot.
+                if (strategy != null &&
+                    declaringTable.Name != null)
+                {
+                    property.Builder.HasValueGenerationStrategy(strategy);
+                }
+            }
+        }
+
+        bool IsStrategyNoneNeeded(IReadOnlyProperty property, StoreObjectIdentifier storeObject)
+        {
+            if (property.ValueGenerated == ValueGenerated.OnAdd &&
+                !property.TryGetDefaultValue(storeObject, out _) &&
+                property.GetDefaultValueSql(storeObject) is null &&
+                property.GetComputedColumnSql(storeObject) is null &&
+                property.DeclaringType.Model.GetValueGenerationStrategy() != MySqlValueGenerationStrategy.None)
+            {
+                var providerClrType = (property.GetValueConverter() ??
+                                       (property.FindRelationalTypeMapping(storeObject) ??
+                                        Dependencies.TypeMappingSource.FindMapping((IProperty)property))?.Converter)
+                    ?.ProviderClrType.UnwrapNullableType();
+
+                return providerClrType is not null && (providerClrType.IsInteger());
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.MySql/Migrations/MySqlMigrationsSqlGenerator.cs
@@ -1131,8 +1131,8 @@ DEALLOCATE PREPARE __pomelo_SqlExprExecute;";
                                 $"Error in {table}.{name}: DATETIME does not support values generated " +
                                 $"on Add or Update in server version {_options.ServerVersion}. Try explicitly setting the column type to TIMESTAMP.");
                         }
-
                         goto case "timestamp";
+
                     case "timestamp":
                         operation.DefaultValueSql = $"CURRENT_TIMESTAMP({matchLen})";
                         break;

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlParameterInliningExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlParameterInliningExpressionVisitor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
@@ -25,7 +26,7 @@ public class MySqlParameterInliningExpressionVisitor : ExpressionVisitor
     private IReadOnlyDictionary<string, object> _parametersValues;
     private bool _canCache;
 
-    private bool _inJsonTableSourceParameterCall;
+    private bool _shouldInlineParameters;
 
     public MySqlParameterInliningExpressionVisitor(
         IRelationalTypeMappingSource typeMappingSource,
@@ -43,6 +44,7 @@ public class MySqlParameterInliningExpressionVisitor : ExpressionVisitor
 
         _parametersValues = parametersValues;
         _canCache = true;
+        _shouldInlineParameters = false;
 
         var result = Visit(expression);
 
@@ -55,6 +57,7 @@ public class MySqlParameterInliningExpressionVisitor : ExpressionVisitor
         => extensionExpression switch
         {
             MySqlJsonTableExpression jsonTableExpression => VisitJsonTable(jsonTableExpression),
+            SelectExpression selectExpression => VisitSelect(selectExpression),
             SqlParameterExpression sqlParameterExpression => VisitSqlParameter(sqlParameterExpression),
             ShapedQueryExpression shapedQueryExpression => shapedQueryExpression.Update(
                 Visit(shapedQueryExpression.QueryExpression),
@@ -62,36 +65,65 @@ public class MySqlParameterInliningExpressionVisitor : ExpressionVisitor
             _ => base.VisitExtension(extensionExpression)
         };
 
-    protected virtual Expression VisitJsonTable(MySqlJsonTableExpression jsonTableExpression)
-    {
-        var parentInJsonTableSourceParameterCall = _inJsonTableSourceParameterCall;
-        _inJsonTableSourceParameterCall = true;
-        var jsonExpression = (SqlExpression)Visit(jsonTableExpression.JsonExpression);
-        _inJsonTableSourceParameterCall = parentInJsonTableSourceParameterCall;
+    protected virtual Expression VisitSelect(SelectExpression selectExpression)
+        => NewInlineParametersScope(
+            inlineParameters: false,
+            () => base.VisitExtension(selectExpression));
+        // => NewInlineParametersScope(
+        //     inlineParameters: false,
+        //     () => selectExpression.Offset is not null
+        //         ? selectExpression.Update(
+        //             selectExpression.Projection,
+        //             selectExpression.Tables,
+        //             selectExpression.Predicate,
+        //             selectExpression.GroupBy,
+        //             selectExpression.Having,
+        //             selectExpression.Orderings,
+        //             selectExpression.Limit,
+        //             NewInlineParametersScope(
+        //                 inlineParameters: true,
+        //                 () => (SqlExpression)Visit(selectExpression.Offset)))
+        //         : base.VisitExtension(selectExpression));
 
-        return jsonTableExpression.Update(
-            jsonExpression,
+    // For test simplicity, we currently inline parameters even for non MySQL database engines (even though it should not be necessary
+    // for e.g. MariaDB).
+    // TODO: Use inlined parameters only if JsonTableImplementationUsingParameterAsSourceWithoutEngineCrash is true.
+    protected virtual Expression VisitJsonTable(MySqlJsonTableExpression jsonTableExpression)
+        => jsonTableExpression.Update(
+            NewInlineParametersScope(
+                inlineParameters: true,
+                () => (SqlExpression)Visit(jsonTableExpression.JsonExpression)),
             jsonTableExpression.Path,
             jsonTableExpression.ColumnInfos);
-    }
 
     protected virtual Expression VisitSqlParameter(SqlParameterExpression sqlParameterExpression)
     {
-        // For test simplicity, we currently inline parameters even for non MySQL database engines (even though it should not be necessary
-        // for e.g. MariaDB).
-        // TODO: Use inlined parameters only if JsonTableImplementationUsingParameterAsSourceWithoutEngineCrash is true.
-        if (_inJsonTableSourceParameterCall /*&&
-            !_options.ServerVersion.Supports.JsonTableImplementationUsingParameterAsSourceWithoutEngineCrash*/)
+        if (!_shouldInlineParameters)
         {
-            _canCache = false;
-
-            return new MySqlInlinedParameterExpression(
-                sqlParameterExpression,
-                _sqlExpressionFactory.Constant(
-                    _parametersValues[sqlParameterExpression.Name],
-                    sqlParameterExpression.TypeMapping));
+            return sqlParameterExpression;
         }
 
-        return sqlParameterExpression;
+        _canCache = false;
+
+        return new MySqlInlinedParameterExpression(
+            sqlParameterExpression,
+            _sqlExpressionFactory.Constant(
+                _parametersValues[sqlParameterExpression.Name],
+                sqlParameterExpression.TypeMapping));
+    }
+
+    protected virtual T NewInlineParametersScope<T>(bool inlineParameters, Func<T> func)
+    {
+        var parentShouldInlineParameters = _shouldInlineParameters;
+        _shouldInlineParameters = inlineParameters;
+
+        try
+        {
+            return func();
+        }
+        finally
+        {
+            _shouldInlineParameters = parentShouldInlineParameters;
+        }
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/BadDataJsonDeserializationMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BadDataJsonDeserializationMySqlTest.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Pomelo.EntityFrameworkCore.MySql.Tests;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests;
+
+public class BadDataJsonDeserializationMySqlTest : BadDataJsonDeserializationTestBase
+{
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => base.OnConfiguring(optionsBuilder.UseMySql(AppConfig.ServerVersion, b => b.UseNetTopologySuite()));
+}

--- a/test/EFCore.MySql.FunctionalTests/Query/PrimitiveCollectionsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/PrimitiveCollectionsQueryMySqlTest.cs
@@ -1658,6 +1658,36 @@ WHERE `p`.`Id` IN (2, 999)
         AssertSql();
     }
 
+    public override async Task Nested_contains_with_Lists_and_no_inferred_type_mapping(bool async)
+    {
+        await base.Nested_contains_with_Lists_and_no_inferred_type_mapping(async);
+
+        AssertSql(
+"""
+SELECT `p`.`Id`, `p`.`Bool`, `p`.`Bools`, `p`.`DateTime`, `p`.`DateTimes`, `p`.`Enum`, `p`.`Enums`, `p`.`Int`, `p`.`Ints`, `p`.`NullableInt`, `p`.`NullableInts`, `p`.`NullableString`, `p`.`NullableStrings`, `p`.`String`, `p`.`Strings`
+FROM `PrimitiveCollectionsEntity` AS `p`
+WHERE CASE
+    WHEN `p`.`Int` IN (1, 2, 3) THEN 'one'
+    ELSE 'two'
+END IN ('one', 'two', 'three')
+""");
+    }
+
+    public override async Task Nested_contains_with_arrays_and_no_inferred_type_mapping(bool async)
+    {
+        await base.Nested_contains_with_arrays_and_no_inferred_type_mapping(async);
+
+        AssertSql(
+"""
+SELECT `p`.`Id`, `p`.`Bool`, `p`.`Bools`, `p`.`DateTime`, `p`.`DateTimes`, `p`.`Enum`, `p`.`Enums`, `p`.`Int`, `p`.`Ints`, `p`.`NullableInt`, `p`.`NullableInts`, `p`.`NullableString`, `p`.`NullableStrings`, `p`.`String`, `p`.`Strings`
+FROM `PrimitiveCollectionsEntity` AS `p`
+WHERE CASE
+    WHEN `p`.`Int` IN (1, 2, 3) THEN 'one'
+    ELSE 'two'
+END IN ('one', 'two', 'three')
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.MySql.FunctionalTests/Query/TPCGearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/TPCGearsOfWarQueryMySqlTest.cs
@@ -13532,6 +13532,88 @@ WHERE NOT EXISTS (
 """);
     }
 
+    public override async Task Nav_expansion_inside_Contains_argument(bool async)
+    {
+        await base.Nav_expansion_inside_Contains_argument(async);
+
+        AssertSql(
+"""
+SELECT `t`.`Nickname`, `t`.`SquadId`, `t`.`AssignedCityName`, `t`.`CityOfBirthName`, `t`.`FullName`, `t`.`HasSoulPatch`, `t`.`LeaderNickname`, `t`.`LeaderSquadId`, `t`.`Rank`, `t`.`Discriminator`
+FROM (
+    SELECT `g`.`Nickname`, `g`.`SquadId`, `g`.`AssignedCityName`, `g`.`CityOfBirthName`, `g`.`FullName`, `g`.`HasSoulPatch`, `g`.`LeaderNickname`, `g`.`LeaderSquadId`, `g`.`Rank`, 'Gear' AS `Discriminator`
+    FROM `Gears` AS `g`
+    UNION ALL
+    SELECT `o`.`Nickname`, `o`.`SquadId`, `o`.`AssignedCityName`, `o`.`CityOfBirthName`, `o`.`FullName`, `o`.`HasSoulPatch`, `o`.`LeaderNickname`, `o`.`LeaderSquadId`, `o`.`Rank`, 'Officer' AS `Discriminator`
+    FROM `Officers` AS `o`
+) AS `t`
+WHERE CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM `Weapons` AS `w`
+        WHERE `t`.`FullName` = `w`.`OwnerFullName`) THEN 1
+    ELSE 0
+END IN (1, -1)
+""");
+    }
+
+    public override async Task Nav_expansion_with_member_pushdown_inside_Contains_argument(bool async)
+    {
+        await base.Nav_expansion_with_member_pushdown_inside_Contains_argument(async);
+
+        AssertSql(
+"""
+SELECT `t`.`Nickname`, `t`.`SquadId`, `t`.`AssignedCityName`, `t`.`CityOfBirthName`, `t`.`FullName`, `t`.`HasSoulPatch`, `t`.`LeaderNickname`, `t`.`LeaderSquadId`, `t`.`Rank`, `t`.`Discriminator`
+FROM (
+    SELECT `g`.`Nickname`, `g`.`SquadId`, `g`.`AssignedCityName`, `g`.`CityOfBirthName`, `g`.`FullName`, `g`.`HasSoulPatch`, `g`.`LeaderNickname`, `g`.`LeaderSquadId`, `g`.`Rank`, 'Gear' AS `Discriminator`
+    FROM `Gears` AS `g`
+    UNION ALL
+    SELECT `o`.`Nickname`, `o`.`SquadId`, `o`.`AssignedCityName`, `o`.`CityOfBirthName`, `o`.`FullName`, `o`.`HasSoulPatch`, `o`.`LeaderNickname`, `o`.`LeaderSquadId`, `o`.`Rank`, 'Officer' AS `Discriminator`
+    FROM `Officers` AS `o`
+) AS `t`
+WHERE (
+    SELECT `w`.`Name`
+    FROM `Weapons` AS `w`
+    WHERE `t`.`FullName` = `w`.`OwnerFullName`
+    ORDER BY `w`.`Id`
+    LIMIT 1) IN ('Marcus'' Lancer', 'Dom''s Gnasher')
+""");
+    }
+
+    public override async Task Subquery_inside_Take_argument(bool async)
+    {
+        await base.Subquery_inside_Take_argument(async);
+
+        AssertSql("");
+    }
+
+    public override async Task Nav_expansion_inside_Skip_correlated_to_source(bool async)
+    {
+        await base.Nav_expansion_inside_Skip_correlated_to_source(async);
+
+        AssertSql("");
+    }
+
+    public override async Task Nav_expansion_inside_Take_correlated_to_source(bool async)
+    {
+        await base.Nav_expansion_inside_Take_correlated_to_source(async);
+
+        AssertSql("");
+    }
+
+    public override async Task Nav_expansion_with_member_pushdown_inside_Take_correlated_to_source(bool async)
+    {
+        await base.Nav_expansion_with_member_pushdown_inside_Take_correlated_to_source(async);
+
+        AssertSql("");
+    }
+
+    public override async Task Nav_expansion_inside_ElementAt_correlated_to_source(bool async)
+    {
+        await base.Nav_expansion_inside_ElementAt_correlated_to_source(async);
+
+        AssertSql("");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlNorthwindTestStoreFactory.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlNorthwindTestStoreFactory.cs
@@ -8,8 +8,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
         public const string DefaultName = "Northwind";
 
         public static new MySqlNorthwindTestStoreFactory Instance => InstanceCi;
-        public static MySqlNorthwindTestStoreFactory InstanceCi { get; } = new MySqlNorthwindTestStoreFactory(databaseCollation: AppConfig.ServerVersion.DefaultUtf8CiCollation);
-        public static MySqlNorthwindTestStoreFactory InstanceCs { get; } = new MySqlNorthwindTestStoreFactory(databaseCollation: AppConfig.ServerVersion.DefaultUtf8CsCollation);
+        public static new MySqlNorthwindTestStoreFactory InstanceCi { get; } = new MySqlNorthwindTestStoreFactory(databaseCollation: AppConfig.ServerVersion.DefaultUtf8CiCollation);
+        public static new MySqlNorthwindTestStoreFactory InstanceCs { get; } = new MySqlNorthwindTestStoreFactory(databaseCollation: AppConfig.ServerVersion.DefaultUtf8CsCollation);
         public static new MySqlNorthwindTestStoreFactory NoBackslashEscapesInstance { get; } = new MySqlNorthwindTestStoreFactory(true);
 
         protected MySqlNorthwindTestStoreFactory(bool noBackslashEscapes = false, string databaseCollation = null)

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlNorthwindTestStoreFactory.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlNorthwindTestStoreFactory.cs
@@ -5,7 +5,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
 {
     public class MySqlNorthwindTestStoreFactory : MySqlTestStoreFactory
     {
-        public const string DefaultName = "Northwind";
+        public const string DefaultNamePrefix = "Northwind";
 
         public static new MySqlNorthwindTestStoreFactory Instance => InstanceCi;
         public static new MySqlNorthwindTestStoreFactory InstanceCi { get; } = new MySqlNorthwindTestStoreFactory(databaseCollation: AppConfig.ServerVersion.DefaultUtf8CiCollation);
@@ -18,6 +18,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
         }
 
         public override TestStore GetOrCreate(string storeName)
-            => MySqlTestStore.GetOrCreate(storeName ?? DefaultName, "Northwind.sql", noBackslashEscapes: NoBackslashEscapes, databaseCollation: DatabaseCollation);
+            => MySqlTestStore.GetOrCreate(storeName ?? $"{DefaultNamePrefix}__{DatabaseCollation}", "Northwind.sql", noBackslashEscapes: NoBackslashEscapes, databaseCollation: DatabaseCollation);
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStoreFactory.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStoreFactory.cs
@@ -1,12 +1,16 @@
 ﻿using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using MySqlConnector;
+using Pomelo.EntityFrameworkCore.MySql.Tests;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
 {
     public class MySqlTestStoreFactory : RelationalTestStoreFactory
     {
-        public static MySqlTestStoreFactory Instance { get; } = new MySqlTestStoreFactory();
+        public static MySqlTestStoreFactory Instance => InstanceCi;
+        public static MySqlTestStoreFactory InstanceCi { get; } = new MySqlTestStoreFactory(databaseCollation: AppConfig.ServerVersion.DefaultUtf8CiCollation);
+        public static MySqlTestStoreFactory InstanceCs { get; } = new MySqlTestStoreFactory(databaseCollation: AppConfig.ServerVersion.DefaultUtf8CsCollation);
+
         public static MySqlTestStoreFactory NoBackslashEscapesInstance { get; } = new MySqlTestStoreFactory(noBackslashEscapes: true);
         public static MySqlTestStoreFactory GuidBinary16Instance { get; } = new MySqlTestStoreFactory(guidFormat: MySqlGuidFormat.Binary16);
 

--- a/test/EFCore.MySql.FunctionalTests/TransactionMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/TransactionMySqlTest.cs
@@ -15,9 +15,8 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         {
         }
 
-        protected override bool SnapshotSupported => false;
+        protected override bool SnapshotSupported => true;
         protected override bool AmbientTransactionsSupported => true;
-        protected override bool DirtyReadsOccur => false;
 
         protected override DbContext CreateContextWithConnectionString()
         {


### PR DESCRIPTION
Updates our references and test suite to EF Core `8.0.1`.

It also contain the following fixes:

- Improved NetTopologySuite source type mapping which now handles NTS type inheritance in the order of most specific (was supported before) to least specific (was not supported before).
- Contains fixes in regards to the model, runtime model and compiled model.
- Contains multiple fixes regarding identity/auto_increment columns.
- Corrects version range for [MySQL bug 96947](https://bugs.mysql.com/bug.php?id=96947) workaround.
- Improves test framework and adjusts tests.

Addresses #1746