### PR TITLE
Stop using `MySqlValueGenerationStrategy.ComputedColumn` annotations for `RowVersion` and fix computed columns.

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 // We explicitly check for RowVersion when generation migrations. We therefore handle RowVersion separately from other cases
                 // of using CURRENT_TIMESTAMP etc. and we don't generate a MySqlValueGenerationStrategy.ComputedColumn annotation.
-                if (IsCompatibleComputedColumn(property) &&
+                if (IsCompatibleComputedColumn(property, storeObject, typeMappingSource) &&
                     !property.IsConcurrencyToken)
                 {
                     return MySqlValueGenerationStrategy.ComputedColumn;
@@ -428,20 +428,35 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> <see langword="true"/> if compatible. </returns>
         public static bool IsCompatibleComputedColumn(IReadOnlyProperty property)
         {
-            var type = property.ClrType;
+            var valueConverter = GetConverter(property);
+            var type = (valueConverter?.ProviderClrType ?? property.ClrType).UnwrapNullableType();
 
             // RowVersion uses byte[] and the BytesToDateTimeConverter.
-            return (type == typeof(DateTime) || type == typeof(DateTimeOffset)) && !HasConverter(property)
-                   || type == typeof(byte[]) && !HasExternalConverter(property);
+            return type == typeof(DateTime) ||
+                   type == typeof(DateTimeOffset) ||
+                   type == typeof(byte[]) && valueConverter is BytesToDateTimeConverter;
         }
 
-        private static bool HasConverter(IReadOnlyProperty property)
-            => GetConverter(property) != null;
-
-        private static bool HasExternalConverter(IReadOnlyProperty property)
+        private static bool IsCompatibleComputedColumn(
+            IReadOnlyProperty property,
+            in StoreObjectIdentifier storeObject,
+            ITypeMappingSource typeMappingSource)
         {
-            var converter = GetConverter(property);
-            return converter != null && !(converter is BytesToDateTimeConverter);
+            if (storeObject.StoreObjectType != StoreObjectType.Table)
+            {
+                return false;
+            }
+
+            var valueConverter = property.GetValueConverter() ??
+                                 (property.FindRelationalTypeMapping(storeObject) ??
+                                  typeMappingSource?.FindMapping((IProperty)property))?.Converter;
+
+            var type = (valueConverter?.ProviderClrType ?? property.ClrType).UnwrapNullableType();
+
+            // RowVersion uses byte[] and the BytesToDateTimeConverter.
+            return type == typeof(DateTime) ||
+                   type == typeof(DateTimeOffset) ||
+                   type == typeof(byte[]) && valueConverter is BytesToDateTimeConverter;
         }
 
         private static ValueConverter GetConverter(IReadOnlyProperty property)

--- a/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlPropertyExtensions.cs
@@ -64,7 +64,10 @@ namespace Microsoft.EntityFrameworkCore
 
             if (property.ValueGenerated == ValueGenerated.OnAddOrUpdate)
             {
-                if (IsCompatibleComputedColumn(property))
+                // We explicitly check for RowVersion when generation migrations. We therefore handle RowVersion separately from other cases
+                // of using CURRENT_TIMESTAMP etc. and we don't generate a MySqlValueGenerationStrategy.ComputedColumn annotation.
+                if (IsCompatibleComputedColumn(property) &&
+                    !property.IsConcurrencyToken)
                 {
                     return MySqlValueGenerationStrategy.ComputedColumn;
                 }
@@ -144,7 +147,10 @@ namespace Microsoft.EntityFrameworkCore
 
             if (property.ValueGenerated == ValueGenerated.OnAddOrUpdate)
             {
-                if (IsCompatibleComputedColumn(property))
+                // We explicitly check for RowVersion when generation migrations. We therefore handle RowVersion separately from other cases
+                // of using CURRENT_TIMESTAMP etc. and we don't generate a MySqlValueGenerationStrategy.ComputedColumn annotation.
+                if (IsCompatibleComputedColumn(property) &&
+                    !property.IsConcurrencyToken)
                 {
                     return MySqlValueGenerationStrategy.ComputedColumn;
                 }

--- a/test/EFCore.MySql.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBasePrincipalDerivedDependentBasebyteEntityType.cs
+++ b/test/EFCore.MySql.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBasePrincipalDerivedDependentBasebyteEntityType.cs
@@ -140,7 +140,7 @@ namespace TestNamespace
                 converter: new ValueConverter<byte[], DateTime>(
                     (Byte[] v) => BytesToDateTimeConverter.FromBytes(v),
                     (DateTime v) => BytesToDateTimeConverter.ToBytes(v)));
-            rowid.AddAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
+            rowid.AddAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.None);
 
             var key = runtimeEntityType.AddKey(
                 new[] { derivedsId, derivedsAlternateId, principalsId, principalsAlternateId });


### PR DESCRIPTION
We don't need to use `MySqlValueGenerationStrategy.ComputedColumn` annotations for `RowVersion` columns, as we already explicitly check for columns being used as `RowVersion` during migration generation.

Also fixes issues related to computed columns with nullable data types and/or value converters.
Also fixes issues related to computed columns that are of type `byte[]`.
Also fixes an issue that could lead to an `AlterColumn` migration operation being generated for every migration.
Also fixes an issue that could lead to an exception being thrown when generating the `Down()` method of a migration, with a similar message to the following:

`System.ArgumentException: Computed value generation cannot be used for the property 'RowVersion' on entity type 'IssueConsoleTemplate.IceCream (Dictionary<string, object>)' because the property type is 'DateTime?'. Computed value ge
neration can only be used with DateTime and DateTimeOffset properties.`

Fixes #1774 (among other things)