### PR TITLE
Allow easier injection of customized `MySqlRelationalConnection` implementations from user code

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -175,14 +175,19 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
             optionsBuilderInfrastructure.AddOrUpdateExtension(masterMySqlOptions);
 
-            return new MySqlRelationalConnection(
+            return CreateMasterConnectionCore(optionsBuilder, _mySqlConnectionStringOptionsValidator);
+        }
+
+        protected virtual IMySqlRelationalConnection CreateMasterConnectionCore(
+            DbContextOptionsBuilder optionsBuilder,
+            IMySqlConnectionStringOptionsValidator mySqlConnectionStringOptionsValidator)
+            => new MySqlRelationalConnection(
                 Dependencies with { ContextOptions = optionsBuilder.Options },
-                _mySqlConnectionStringOptionsValidator,
+                mySqlConnectionStringOptionsValidator,
                 dataSource: null)
             {
                 IsMasterConnection = true
             };
-        }
 
         protected virtual MySqlConnectionStringBuilder AddConnectionStringOptions(MySqlConnectionStringBuilder builder)
         {


### PR DESCRIPTION
If users want to replace the default `MySqlRelationalConnection` instance with with a customized derived one of their own (e.g. by using `.ReplaceService<IMySqlRelationalConnection, MyCustomMySqlRelationalConnection>()`), they had difficulties returning their customized implementation from the `CreateMasterConnection()` method.

This PR enables users to override `CreateMasterConnectionCore()` instead, to allow them to create and return their custom instance in a way that is as simple as possible.