### PR TITLE
Push packages from `*-maint` branches to nightly feeds as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,7 +319,7 @@ jobs:
           $officialBuild = '${{ github.ref }}' -match '(?<=^refs/tags/)\d+\.\d+\.\d+.*$'
           $officialVersion = $Matches.0
           $wipBuild = '${{ github.ref }}' -match '^refs/heads/.*-wip$'
-          $ciBuildOnly = $wipBuild -or ('${{ github.ref }}' -match '^refs/heads/(?:master|release/.*)$')
+          $ciBuildOnly = $wipBuild -or ('${{ github.ref }}' -match '^refs/heads/(?:master|main|.+-maint|release/.+)$')
           $continuousIntegrationTimestamp = Get-Date -Format yyyyMMddHHmmss
           $buildSha = '${{ github.sha }}'.SubString(0, 7);
           $pack = $officialBuild -or $ciBuildOnly


### PR DESCRIPTION
We had missed until now to push packages from our `*-maint` branches to our nightly build feeds.

Fixes https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1865#issuecomment-1984003759