### PR TITLE
[PORT] Push packages from `*-maint` branches to nightly feeds as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,7 +318,7 @@ jobs:
           $officialBuild = '${{ github.ref }}' -match '(?<=^refs/tags/)\d+\.\d+\.\d+.*$'
           $officialVersion = $Matches.0
           $wipBuild = '${{ github.ref }}' -match '^refs/heads/.*-wip$'
-          $ciBuildOnly = $wipBuild -or ('${{ github.ref }}' -match '^refs/heads/(?:main|master|release/.*)$')
+          $ciBuildOnly = $wipBuild -or ('${{ github.ref }}' -match '^refs/heads/(?:main|.+-maint|release/.+)$')
           $continuousIntegrationTimestamp = Get-Date -Format yyyyMMddHHmmss
           $buildSha = '${{ github.sha }}'.SubString(0, 7);
           $pack = $officialBuild -or $ciBuildOnly


### PR DESCRIPTION
Ports #1867 to 9.0.

Fixes https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1865#issuecomment-1984003759