### PR TITLE
Revert "Workaround SELECT ... ORDER BY (SELECT 1) related bug in Oracle's MySQL implementation, that can lead to completely wrong data being returned. (#1850)"

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
@@ -866,28 +866,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             return mySqlBinaryExpression;
         }
 
-        protected override Expression VisitOrdering(OrderingExpression orderingExpression)
-        {
-            // The base implementation translates this case to `(SELECT 1)`.
-            // This leads to a bug in Oracle's MySQL, where completely wrong data is being returned under certain conditions.
-            // This can be reproduced by executing a no-op (or any existing) test of the `ProxyGraphUpdatesMySqlTest+LazyLoading` class (e.g. our own `DummyTest`),
-            // immediately followed by NorthwindSplitIncludeNoTrackingQueryMySqlTest.Include_collection_OrderBy_empty_list_contains(async: False).
-            // As a workaround, we just output `1` instead of `(SELECT 1)` for all database versions and types.
-            if (orderingExpression.Expression is SqlConstantExpression or SqlParameterExpression)
-            {
-                Sql.Append("1");
-
-                if (!orderingExpression.IsAscending)
-                {
-                    Sql.Append(" DESC");
-                }
-
-                return orderingExpression;
-            }
-
-            return base.VisitOrdering(orderingExpression);
-        }
-
         protected virtual Expression VisitJsonTableExpression(MySqlJsonTableExpression jsonTableExpression)
         {
             // if (jsonTableExpression.ColumnInfos is not { Count: > 0 })

--- a/test/EFCore.MySql.FunctionalTests/ProxyGraphUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/ProxyGraphUpdatesMySqlTest.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
-using Xunit;
 
 namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 {
@@ -35,12 +34,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
         {
             public LazyLoading(ProxyGraphUpdatesWithLazyLoadingMySqlFixture fixture)
                 : base(fixture)
-            {
-            }
-
-            // Used to track down a bug in Oracle's MySQL implementation, related to `SELECT ... ORDER BY (SELECT 1)`.
-            [Fact]
-            public void DummyTest()
             {
             }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindEFPropertyIncludeQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindEFPropertyIncludeQueryMySqlTest.cs
@@ -1076,7 +1076,7 @@ FROM (
     SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`, FALSE AS `c`
     FROM `Customers` AS `c`
     WHERE `c`.`CustomerID` LIKE 'A%'
-    ORDER BY 1
+    ORDER BY (SELECT 1)
     LIMIT 18446744073709551610 OFFSET @__p_1
 ) AS `c0`
 LEFT JOIN `Orders` AS `o` ON `c0`.`CustomerID` = `o`.`CustomerID`
@@ -2003,7 +2003,7 @@ FROM (
     SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`, TRUE AS `c`
     FROM `Customers` AS `c`
     WHERE `c`.`CustomerID` LIKE 'A%'
-    ORDER BY 1
+    ORDER BY (SELECT 1)
     LIMIT 18446744073709551610 OFFSET @__p_1
 ) AS `c0`
 LEFT JOIN `Orders` AS `o` ON `c0`.`CustomerID` = `o`.`CustomerID`

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQueryMySqlTest.cs
@@ -64,10 +64,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                 elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.OrderDetails)));
         }
 
-        // Used to track down a bug in Oracle's MySQL implementation, related to `SELECT ... ORDER BY (SELECT 1)`.
-        public override Task Include_collection_OrderBy_empty_list_contains(bool async)
-            => base.Include_collection_OrderBy_empty_list_contains(async);
-
         [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/issues/21202")]
         public override Task Include_collection_skip_no_order_by(bool async)
         {


### PR DESCRIPTION
Reverts #1850.

`ORDER BY (SELECT 1)` is _not_ equivalent to `ORDER BY 1`.
See https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1849#issuecomment-1986516151 for more information.

Fixes https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1849#issuecomment-1986248220