### PR TITLE
Add missing and convenient `EF.Functions.DateDiff` translations

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
+    // TODO: Change method return types for units of `SECOND` and smaller from `int` to `long`.
+
     /// <summary>
     ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
     ///     The methods on this class are accessed via <see cref="EF.Functions" />.
@@ -18,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateTime` value <paramref name="dateTime"/> from the time zone given by <paramref name="fromTimeZone"/> to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value.
-        ///     Corresponds to `CONVERT_TZ(dateTime, fromTimeZone, toTimeZone)`.
+        ///     Corresponds to ``CONVERT_TZ(dateTime, fromTimeZone, toTimeZone)``.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateTime">The `DateTime` value to convert.</param>
@@ -34,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateOnly` value <paramref name="dateOnly"/> from the time zone given by <paramref name="fromTimeZone"/> to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value.
-        ///     Corresponds to `CONVERT_TZ(dateTime, fromTimeZone, toTimeZone)`..
+        ///     Corresponds to ``CONVERT_TZ(dateTime, fromTimeZone, toTimeZone)`.`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateOnly">The `DateOnly` value to convert.</param>
@@ -50,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateTime?` value <paramref name="dateTime"/> from the time zone given by <paramref name="fromTimeZone"/> to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value.
-        ///     Corresponds to `CONVERT_TZ(dateTime, fromTimeZone, toTimeZone)`.
+        ///     Corresponds to ``CONVERT_TZ(dateTime, fromTimeZone, toTimeZone)``.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateTime">The `DateTime?` value to convert.</param>
@@ -66,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateOnly?` value <paramref name="dateOnly"/> from the time zone given by <paramref name="fromTimeZone"/> to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value.
-        ///     Corresponds to `CONVERT_TZ(dateTime, fromTimeZone, toTimeZone)`..
+        ///     Corresponds to ``CONVERT_TZ(dateTime, fromTimeZone, toTimeZone)`.`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateOnly">The `DateOnly?` value to convert.</param>
@@ -82,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateTime` value <paramref name="dateTime"/> from `@@session.time_zone` to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value.
-        ///     Corresponds to `CONVERT_TZ(dateTime, @@session.time_zone, toTimeZone)`.
+        ///     Corresponds to ``CONVERT_TZ(dateTime, @@session.time_zone, toTimeZone)``.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateTime">The `DateTime` value to convert.</param>
@@ -96,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateTimeOffset` value <paramref name="dateTimeOffset"/> from `+00:00`/UTC to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value as a `DateTime`.
-        ///     Corresponds to `CONVERT_TZ(dateTime, '+00:00', toTimeZone)`.
+        ///     Corresponds to ``CONVERT_TZ(dateTime, '+00:00', toTimeZone)``.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateTimeOffset">The `DateTimeOffset` value to convert.</param>
@@ -110,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateOnly` value <paramref name="dateOnly"/> from `@@session.time_zone` to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value.
-        ///     Corresponds to `CONVERT_TZ(dateTime, @@session.time_zone, toTimeZone)`.
+        ///     Corresponds to ``CONVERT_TZ(dateTime, @@session.time_zone, toTimeZone)``.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateOnly">The `DateOnly` value to convert.</param>
@@ -124,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateTime?` value <paramref name="dateTime"/> from `@@session.time_zone` to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value.
-        ///     Corresponds to `CONVERT_TZ(dateTime, @@session.time_zone, toTimeZone)`.
+        ///     Corresponds to ``CONVERT_TZ(dateTime, @@session.time_zone, toTimeZone)``.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateTime">The `DateTime?` value to convert.</param>
@@ -138,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateTimeOffset?` value <paramref name="dateTimeOffset"/> from `+00:00`/UTC to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value as a `DateTime`.
-        ///     Corresponds to `CONVERT_TZ(dateTime, '+00:00', toTimeZone)`.
+        ///     Corresponds to ``CONVERT_TZ(dateTime, '+00:00', toTimeZone)``.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateTimeOffset">The `DateTimeOffset?` value to convert.</param>
@@ -152,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Converts the `DateOnly?` value <paramref name="dateOnly"/> from `@@session.time_zone` to the time zone given by <paramref name="toTimeZone"/> and returns the resulting value.
-        ///     Corresponds to `CONVERT_TZ(dateTime, @@session.time_zone, toTimeZone)`.
+        ///     Corresponds to ``CONVERT_TZ(dateTime, @@session.time_zone, toTimeZone)``.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="dateOnly">The `DateOnly?` value to convert.</param>
@@ -166,9 +168,11 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion ConvertTimeZone
 
+        #region DateDiffYear
+
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(YEAR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -182,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(YEAR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -196,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(YEAR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -210,7 +214,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(YEAR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -224,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(YEAR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -238,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(YEAR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(YEAR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -250,9 +254,101 @@ namespace Microsoft.EntityFrameworkCore
             DateOnly? endDate)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffYear)));
 
+        #endregion DateDiffYear
+
+        #region DateDiffQuarter
+
+        /// <summary>
+        ///     Counts the number of quarter boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(QUARTER,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of quarter boundaries crossed between the dates.</returns>
+        public static int DateDiffQuarter(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffQuarter)));
+
+        /// <summary>
+        ///     Counts the number of quarter boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(QUARTER,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of quarter boundaries crossed between the dates.</returns>
+        public static int? DateDiffQuarter(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffQuarter)));
+
+        /// <summary>
+        ///     Counts the number of quarter boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(QUARTER,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of quarter boundaries crossed between the dates.</returns>
+        public static int DateDiffQuarter(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffQuarter)));
+
+        /// <summary>
+        ///     Counts the number of quarter boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(QUARTER,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of quarter boundaries crossed between the dates.</returns>
+        public static int? DateDiffQuarter(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffQuarter)));
+
+        /// <summary>
+        ///     Counts the number of quarter boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(QUARTER,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of quarter boundaries crossed between the dates.</returns>
+        public static int DateDiffQuarter(
+            [CanBeNull] this DbFunctions _,
+            DateOnly startDate,
+            DateOnly endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffQuarter)));
+
+        /// <summary>
+        ///     Counts the number of quarter boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(QUARTER,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of quarter boundaries crossed between the dates.</returns>
+        public static int? DateDiffQuarter(
+            [CanBeNull] this DbFunctions _,
+            DateOnly? startDate,
+            DateOnly? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffQuarter)));
+
+        #endregion DateDiffQuarter
+
+        #region DateDiffMonth
+
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MONTH,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -266,7 +362,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MONTH,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -280,7 +376,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MONTH,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -294,7 +390,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MONTH,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -308,7 +404,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MONTH,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -322,7 +418,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of month boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MONTH,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MONTH,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -334,9 +430,101 @@ namespace Microsoft.EntityFrameworkCore
             DateOnly? endDate)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMonth)));
 
+        #endregion DateDiffMonth
+
+        #region DateDiffWeek
+
+        /// <summary>
+        ///     Counts the number of week boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(WEEK,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of week boundaries crossed between the dates.</returns>
+        public static int DateDiffWeek(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffWeek)));
+
+        /// <summary>
+        ///     Counts the number of week boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(WEEK,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of week boundaries crossed between the dates.</returns>
+        public static int? DateDiffWeek(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffWeek)));
+
+        /// <summary>
+        ///     Counts the number of week boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(WEEK,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of week boundaries crossed between the dates.</returns>
+        public static int DateDiffWeek(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffWeek)));
+
+        /// <summary>
+        ///     Counts the number of week boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(WEEK,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of week boundaries crossed between the dates.</returns>
+        public static int? DateDiffWeek(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffWeek)));
+
+        /// <summary>
+        ///     Counts the number of week boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(WEEK,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of week boundaries crossed between the dates.</returns>
+        public static int DateDiffWeek(
+            [CanBeNull] this DbFunctions _,
+            DateOnly startDate,
+            DateOnly endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffWeek)));
+
+        /// <summary>
+        ///     Counts the number of week boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(WEEK,startDate,endDate)`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of week boundaries crossed between the dates.</returns>
+        public static int? DateDiffWeek(
+            [CanBeNull] this DbFunctions _,
+            DateOnly? startDate,
+            DateOnly? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffWeek)));
+
+        #endregion DateDiffWeek
+
+        #region DateDiffDay
+
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(DAY,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -350,7 +538,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(DAY,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -364,7 +552,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(DAY,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -378,7 +566,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(DAY,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -392,7 +580,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(DAY,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -406,7 +594,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of day boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(DAY,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(DAY,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -418,9 +606,13 @@ namespace Microsoft.EntityFrameworkCore
             DateOnly? endDate)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffDay)));
 
+        #endregion DateDiffDay
+
+        #region DateDiffHour
+
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(HOUR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -434,7 +626,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(HOUR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -448,7 +640,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(HOUR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -462,7 +654,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(HOUR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -476,7 +668,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(HOUR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -490,7 +682,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of hour boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(HOUR,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(HOUR,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -502,9 +694,13 @@ namespace Microsoft.EntityFrameworkCore
             DateOnly? endDate)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffHour)));
 
+        #endregion DateDiffHour
+
+        #region DateDiffMinute
+
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MINUTE,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -518,7 +714,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MINUTE,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -532,7 +728,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MINUTE,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -546,7 +742,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MINUTE,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -560,7 +756,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MINUTE,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -574,7 +770,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MINUTE,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MINUTE,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -586,9 +782,13 @@ namespace Microsoft.EntityFrameworkCore
             DateOnly? endDate)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMinute)));
 
+        #endregion DateDiffMinute
+
+        #region DateDiffSecond
+
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(SECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -602,7 +802,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(SECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -616,7 +816,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(SECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -630,7 +830,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(SECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -644,7 +844,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(SECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -658,7 +858,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of second boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(SECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(SECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -669,10 +869,102 @@ namespace Microsoft.EntityFrameworkCore
             DateOnly? startDate,
             DateOnly? endDate)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffSecond)));
+
+        #endregion DateDiffSecond
+
+        #region DateDiffMillisecond
+
+        /// <summary>
+        ///     Counts the number of millisecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) DIV 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of millisecond boundaries crossed between the dates.</returns>
+        public static int DateDiffMillisecond(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMillisecond)));
+
+        /// <summary>
+        ///     Counts the number of millisecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) DIV 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of millisecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffMillisecond(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMillisecond)));
+
+        /// <summary>
+        ///     Counts the number of millisecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) DIV 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of millisecond boundaries crossed between the dates.</returns>
+        public static int DateDiffMillisecond(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMillisecond)));
+
+        /// <summary>
+        ///     Counts the number of millisecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) DIV 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of millisecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffMillisecond(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMillisecond)));
+
+        /// <summary>
+        ///     Counts the number of millisecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) DIV 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of millisecond boundaries crossed between the dates.</returns>
+        public static int DateDiffMillisecond(
+            [CanBeNull] this DbFunctions _,
+            DateOnly startDate,
+            DateOnly endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMillisecond)));
+
+        /// <summary>
+        ///     Counts the number of millisecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) DIV 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of millisecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffMillisecond(
+            [CanBeNull] this DbFunctions _,
+            DateOnly? startDate,
+            DateOnly? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMillisecond)));
+
+        #endregion DateDiffMillisecond
+
+        #region DateDiffMicrosecond
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -686,7 +978,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -700,7 +992,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -714,7 +1006,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -728,7 +1020,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -742,7 +1034,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Counts the number of microsecond boundaries crossed between the startDate and endDate.
-        ///     Corresponds to TIMESTAMPDIFF(MICROSECOND,startDate,endDate).
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate)`.
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="startDate">Starting date for the calculation.</param>
@@ -753,6 +1045,186 @@ namespace Microsoft.EntityFrameworkCore
             DateOnly? startDate,
             DateOnly? endDate)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMicrosecond)));
+
+        #endregion DateDiffMicrosecond
+
+        #region DateDiffTick
+
+        /// <summary>
+        ///     Counts the number of tick boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 10`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of tick boundaries crossed between the dates.</returns>
+        public static int DateDiffTick(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffTick)));
+
+        /// <summary>
+        ///     Counts the number of tick boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 10`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of tick boundaries crossed between the dates.</returns>
+        public static int? DateDiffTick(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffTick)));
+
+        /// <summary>
+        ///     Counts the number of tick boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 10`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of tick boundaries crossed between the dates.</returns>
+        public static int DateDiffTick(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffTick)));
+
+        /// <summary>
+        ///     Counts the number of tick boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 10`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of tick boundaries crossed between the dates.</returns>
+        public static int? DateDiffTick(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffTick)));
+
+        /// <summary>
+        ///     Counts the number of tick boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 10`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of tick boundaries crossed between the dates.</returns>
+        public static int DateDiffTick(
+            [CanBeNull] this DbFunctions _,
+            DateOnly startDate,
+            DateOnly endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffTick)));
+
+        /// <summary>
+        ///     Counts the number of tick boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 10`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of tick boundaries crossed between the dates.</returns>
+        public static int? DateDiffTick(
+            [CanBeNull] this DbFunctions _,
+            DateOnly? startDate,
+            DateOnly? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffTick)));
+
+        #endregion DateDiffTick
+
+        #region DateDiffNanosecond
+
+        /// <summary>
+        ///     Counts the number of nanosecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of nanosecond boundaries crossed between the dates.</returns>
+        public static int DateDiffNanosecond(
+            [CanBeNull] this DbFunctions _,
+            DateTime startDate,
+            DateTime endDate)
+         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffNanosecond)));
+
+        /// <summary>
+        ///     Counts the number of nanosecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of nanosecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffNanosecond(
+            [CanBeNull] this DbFunctions _,
+            DateTime? startDate,
+            DateTime? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffNanosecond)));
+
+        /// <summary>
+        ///     Counts the number of nanosecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of nanosecond boundaries crossed between the dates.</returns>
+        public static int DateDiffNanosecond(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset startDate,
+            DateTimeOffset endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffNanosecond)));
+
+        /// <summary>
+        ///     Counts the number of nanosecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of nanosecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffNanosecond(
+            [CanBeNull] this DbFunctions _,
+            DateTimeOffset? startDate,
+            DateTimeOffset? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffNanosecond)));
+
+        /// <summary>
+        ///     Counts the number of nanosecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of nanosecond boundaries crossed between the dates.</returns>
+        public static int DateDiffNanosecond(
+            [CanBeNull] this DbFunctions _,
+            DateOnly startDate,
+            DateOnly endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffNanosecond)));
+
+        /// <summary>
+        ///     Counts the number of nanosecond boundaries crossed between the startDate and endDate.
+        ///     Corresponds to `TIMESTAMPDIFF(MICROSECOND,startDate,endDate) * 1000`.
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startDate">Starting date for the calculation.</param>
+        /// <param name="endDate">Ending date for the calculation.</param>
+        /// <returns>Number of nanosecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffNanosecond(
+            [CanBeNull] this DbFunctions _,
+            DateOnly? startDate,
+            DateOnly? endDate)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffNanosecond)));
+
+        #endregion DateDiffNanosecond
+
+        #region Like
 
         /// <summary>
         ///     <para>
@@ -802,6 +1274,10 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] string escapeCharacter)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Like)));
 
+        #endregion Like
+
+        #region Match
+
         /// <summary>
         ///     <para>
         ///         An implementation of the SQL MATCH operation for Full Text search.
@@ -889,6 +1365,10 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] string pattern,
             MySqlMatchSearchMode searchMode)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Match)));
+
+        #endregion Match
+
+        #region Misc
 
         /// <summary>
         ///     <para>
@@ -966,5 +1446,7 @@ namespace Microsoft.EntityFrameworkCore
             this DbFunctions _,
             float degrees)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Radians)));
+
+        #endregion Misc
     }
 }

--- a/src/EFCore.MySql/Query/Internal/MySqlDateDiffFunctionsTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlDateDiffFunctionsTranslator.cs
@@ -26,42 +26,83 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffYear), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "YEAR" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffYear), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "YEAR" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffYear), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "YEAR" },
+
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffQuarter), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "QUARTER" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffQuarter), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "QUARTER" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffQuarter), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "QUARTER" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffQuarter), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "QUARTER" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffQuarter), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "QUARTER" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffQuarter), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "QUARTER" },
+
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMonth), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "MONTH" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMonth), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "MONTH" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMonth), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "MONTH" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMonth), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "MONTH" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMonth), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "MONTH" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMonth), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "MONTH" },
+
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffWeek), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "WEEK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffWeek), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "WEEK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffWeek), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "WEEK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffWeek), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "WEEK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffWeek), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "WEEK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffWeek), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "WEEK" },
+
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffDay), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "DAY" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffDay), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "DAY" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffDay), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "DAY" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffDay), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "DAY" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffDay), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "DAY" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffDay), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "DAY" },
+
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffHour), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "HOUR" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffHour), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "HOUR" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffHour), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "HOUR" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffHour), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "HOUR" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffHour), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "HOUR" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffHour), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "HOUR" },
+
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMinute), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "MINUTE" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMinute), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "MINUTE" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMinute), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "MINUTE" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMinute), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "MINUTE" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMinute), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "MINUTE" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMinute), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "MINUTE" },
+
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffSecond), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "SECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffSecond), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "SECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffSecond), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "SECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffSecond), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "SECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffSecond), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "SECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffSecond), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "SECOND" },
+
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMillisecond), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "MILLISECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMillisecond), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "MILLISECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMillisecond), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "MILLISECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMillisecond), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "MILLISECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMillisecond), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "MILLISECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMillisecond), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "MILLISECOND" },
+
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "MICROSECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "MICROSECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "MICROSECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "MICROSECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "MICROSECOND" },
                 { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffMicrosecond), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "MICROSECOND" },
+
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffTick), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "TICK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffTick), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "TICK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffTick), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "TICK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffTick), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "TICK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffTick), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "TICK" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffTick), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "TICK" },
+
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffNanosecond), new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }), "NANOSECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffNanosecond), new[] { typeof(DbFunctions), typeof(DateTime?), typeof(DateTime?) }), "NANOSECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffNanosecond), new[] { typeof(DbFunctions), typeof(DateTimeOffset), typeof(DateTimeOffset) }), "NANOSECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffNanosecond), new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }), "NANOSECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffNanosecond), new[] { typeof(DbFunctions), typeof(DateOnly), typeof(DateOnly) }), "NANOSECOND" },
+                { typeof(MySqlDbFunctionsExtensions).GetRuntimeMethod(nameof(MySqlDbFunctionsExtensions.DateDiffNanosecond), new[] { typeof(DbFunctions), typeof(DateOnly?), typeof(DateOnly?) }), "NANOSECOND" },
             };
 
         private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
@@ -86,18 +127,32 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 startDate = _sqlExpressionFactory.ApplyTypeMapping(startDate, typeMapping);
                 endDate = _sqlExpressionFactory.ApplyTypeMapping(endDate, typeMapping);
 
-                return _sqlExpressionFactory.NullableFunction(
+                var actualDatePart = datePart is "MILLISECOND"
+                                              or "TICK"
+                                              or "NANOSECOND"
+                    ? "MICROSECOND"
+                    : datePart;
+
+                var timeStampDiffExpression = _sqlExpressionFactory.NullableFunction(
                     "TIMESTAMPDIFF",
                     new[]
                     {
-                        _sqlExpressionFactory.Fragment(datePart),
+                        _sqlExpressionFactory.Fragment(actualDatePart),
                         startDate,
                         endDate
                     },
                     typeof(int),
                     typeMapping: null,
                     onlyNullWhenAnyNullPropagatingArgumentIsNull: true,
-                    argumentsPropagateNullability: new []{false, true, true});
+                    argumentsPropagateNullability: new[] { false, true, true });
+
+                return datePart switch
+                {
+                    "MILLISECOND" => _sqlExpressionFactory.MySqlIntegerDivide(timeStampDiffExpression, _sqlExpressionFactory.Constant(1_000)),
+                    "TICK" => _sqlExpressionFactory.Multiply(timeStampDiffExpression, _sqlExpressionFactory.Constant(10)),
+                    "NANOSECOND" => _sqlExpressionFactory.Multiply(timeStampDiffExpression, _sqlExpressionFactory.Constant(1_000)),
+                    _ => timeStampDiffExpression
+                };
             }
 
             return null;

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindDbFunctionsQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindDbFunctionsQueryMySqlTest.MySql.cs
@@ -25,6 +25,40 @@ WHERE TIMESTAMPDIFF(YEAR, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
         }
 
         [ConditionalFact]
+        public virtual void DateDiff_Quarter()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffQuarter(c.OrderDate, DateTime.Now) == 0);
+
+                Assert.Equal(0, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `o`
+WHERE TIMESTAMPDIFF(QUARTER, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Week()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(c => EF.Functions.DateDiffWeek(c.OrderDate, DateTime.Now) == 0);
+
+                Assert.Equal(0, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `o`
+WHERE TIMESTAMPDIFF(WEEK, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+            }
+        }
+
+        [ConditionalFact]
         public virtual void DateDiff_Month()
         {
             using (var context = CreateContext())
@@ -110,6 +144,23 @@ WHERE TIMESTAMPDIFF(SECOND, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
         }
 
         [ConditionalFact]
+        public virtual void DateDiff_Millisecond()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(o => EF.Functions.DateDiffMillisecond(DateTime.Now, DateTime.Now.AddSeconds(1)) == 0);
+
+                Assert.Equal(0, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `o`
+WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL CAST(1.0 AS signed) second))) DIV (1000) = 0");
+            }
+        }
+
+        [ConditionalFact]
         public virtual void DateDiff_Microsecond()
         {
             using (var context = CreateContext())
@@ -123,6 +174,40 @@ WHERE TIMESTAMPDIFF(SECOND, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
 WHERE TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL CAST(1.0 AS signed) second)) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Tick()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(o => EF.Functions.DateDiffTick(DateTime.Now, DateTime.Now.AddSeconds(1)) == 0);
+
+                Assert.Equal(0, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `o`
+WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL CAST(1.0 AS signed) second)) * 10) = 0");
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateDiff_Nanosecond()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Orders
+                    .Count(o => EF.Functions.DateDiffNanosecond(DateTime.Now, DateTime.Now.AddSeconds(1)) == 0);
+
+                Assert.Equal(0, count);
+
+                AssertSql(
+                    @"SELECT COUNT(*)
+FROM `Orders` AS `o`
+WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL CAST(1.0 AS signed) second)) * 1000) = 0");
             }
         }
 


### PR DESCRIPTION
Adds the following translations that are directly supported by MySQL compatible databases:
- `DateDiffQuarter`
- `DateDiffWeek`

Add the following convenience translations:
- `DateDiffMillisecond`
- `DateDiffTick`
- `DateDiffNanosecond`

#1875 will change the return type (at least of the second group) in the future from `int` to `long`.

Fixes #1837 (in part)