### PR TITLE
Use JSON_VALUE() for scalar JSON values if available or workaround weird JSON_EXTRACT() behavior in regards to `null` otherwise

### DIFF
--- a/src/EFCore.MySql/Query/Expressions/Internal/MySqlJsonTraversalExpression.cs
+++ b/src/EFCore.MySql/Query/Expressions/Internal/MySqlJsonTraversalExpression.cs
@@ -39,7 +39,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal
             bool returnsText,
             [NotNull] Type type,
             [CanBeNull] RelationalTypeMapping typeMapping)
-            : this(expression, new SqlExpression[0], returnsText, type, typeMapping)
+            : this(expression, new SqlExpression[0], returnsText, type.UnwrapNullableType(), typeMapping)
         {
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindFunctionsQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindFunctionsQueryMySqlTest.MySql.cs
@@ -813,7 +813,7 @@ WHERE (LOCATE(CONVERT(LCASE('nt') USING utf8mb4) COLLATE utf8mb4_bin, LCASE(`c`.
 
             AssertSql(
 $"""
-SELECT LOG(7.0, CAST(`o`.`Discount` AS double))
+SELECT LOG(7.0, {MySqlTestHelpers.CastAsDouble("`o`.`Discount`")})
 FROM `Order Details` AS `o`
 WHERE ((`o`.`OrderID` = 11077) AND (`o`.`Discount` > 0)) AND (LOG(7.0, {MySqlTestHelpers.CastAsDouble("`o`.`Discount`")}) < -1.0)
 """);


### PR DESCRIPTION
We will use `JSON_VALUE()` for scalar JSON values from now on, because it seems to handle `null` values correctly.

`JSON_EXTRACT()` will return a **string** with the contents of `null` for a JSON `null` value instead of a SQL `NULL` value (see [Bug #85755: JSON containing null value is extracted as a string "null"](https://bugs.mysql.com/bug.php?id=85755)).

So when we have to depend on `JSON_EXTRACT()`, we have to explicitly check for that specific case to ensure that the expected value is returned.

Fixes #1897