### PR TITLE
Mark cloned connections as owned

### DIFF
--- a/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
+++ b/src/EFCore.MySql/Storage/Internal/MySqlRelationalConnection.cs
@@ -165,10 +165,10 @@ namespace Pomelo.EntityFrameworkCore.MySql.Storage.Internal
 
             // Apply modified connection string.
             var masterMySqlOptions = _dataSource is not null
-                ? mySqlOptions.WithConnection(((MySqlConnection)CreateDbConnection()).CloneWith(masterConnectionString))
+                ? mySqlOptions.WithConnection(((MySqlConnection)CreateDbConnection()).CloneWith(masterConnectionString), owned: true)
                 : mySqlOptions.Connection is null
                     ? mySqlOptions.WithConnectionString(masterConnectionString)
-                    : mySqlOptions.WithConnection(DbConnection.CloneWith(masterConnectionString));
+                    : mySqlOptions.WithConnection(DbConnection.CloneWith(masterConnectionString), owned: true);
 
             var optionsBuilder = new DbContextOptionsBuilder();
             var optionsBuilderInfrastructure = (IDbContextOptionsBuilderInfrastructure)optionsBuilder;


### PR DESCRIPTION
Hi, I found out that when using DataSource, the produced connections are never disposed. Than can be solved by marking it as `owned: true`.