### PR TITLE
Correctly escape escape characters in `String.Contains()`, `String.StartsWith()` and `String.EndsWith()` translations if pattern doesn't contain wildcards.

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
@@ -1240,7 +1240,9 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="matchExpression">The property of entity that is to be matched.</param>
-        /// <param name="pattern">The pattern which may involve wildcards %,_,[,],^.</param>
+        /// <param name="pattern">
+        ///     The pattern which may involve the wildcards `%` and `_`. The character `\` is used to escape wildcards and itself.
+        /// </param>
         /// <returns>true if there is a match.</returns>
         public static bool Like<T>(
             [CanBeNull] this DbFunctions _,
@@ -1261,10 +1263,10 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="_">The DbFunctions instance.</param>
         /// <param name="matchExpression">The property of entity that is to be matched.</param>
-        /// <param name="pattern">The pattern which may involve wildcards %,_,[,],^.</param>
+        /// <param name="pattern">The pattern which may involve the wildcards `%` and `_`.</param>
         /// <param name="escapeCharacter">
-        ///     The escape character (as a single character string) to use in front of %,_,[,],^
-        ///     if they are not used as wildcards.
+        ///     The escape character (as a single character string) to use in front of `%` and `_` (if they are not used as wildcards), and
+        ///     itself.
         /// </param>
         /// <returns>true if there is a match.</returns>
         public static bool Like<T>(

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindDbFunctionsQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindDbFunctionsQueryMySqlTest.MySql.cs
@@ -370,5 +370,101 @@ FROM `Customers` AS `c`
 WHERE `c`.`CustomerID` = 'VINET'
 LIMIT 1");
         }
+
+        [ConditionalFact]
+        public virtual void Contains_with_escape_char()
+        {
+            using var context = CreateContext();
+            var count = context.Customers.Count(c => c.CompanyName.Replace("/", @"\").Contains(@"\"));
+
+            Assert.Equal(1, count);
+
+            AssertSql(
+"""
+SELECT COUNT(*)
+FROM `Customers` AS `c`
+WHERE REPLACE(`c`.`CompanyName`, '/', '\\') LIKE '%\\\\%'
+""");
+        }
+
+        [ConditionalFact]
+        public virtual void Contains_with_wild_char()
+        {
+            using var context = CreateContext();
+            var count = context.Customers.Count(c => c.CompanyName.Replace("/", "%").Contains("%"));
+
+            Assert.Equal(1, count);
+
+            AssertSql(
+"""
+SELECT COUNT(*)
+FROM `Customers` AS `c`
+WHERE REPLACE(`c`.`CompanyName`, '/', '%') LIKE '%\\%%'
+""");
+        }
+
+        [ConditionalFact]
+        public virtual void StartsWith_with_escape_char()
+        {
+            using var context = CreateContext();
+            var count = context.Customers.Count(c => c.CompanyName.Replace("A", @"\").StartsWith(@"\"));
+
+            Assert.Equal(4, count);
+
+            AssertSql(
+"""
+SELECT COUNT(*)
+FROM `Customers` AS `c`
+WHERE REPLACE(`c`.`CompanyName`, 'A', '\\') LIKE '\\\\%'
+""");
+        }
+
+        [ConditionalFact]
+        public virtual void StartsWith_with_wild_char()
+        {
+            using var context = CreateContext();
+            var count = context.Customers.Count(c => c.CompanyName.Replace("A", @"%").StartsWith(@"%"));
+
+            Assert.Equal(4, count);
+
+            AssertSql(
+"""
+SELECT COUNT(*)
+FROM `Customers` AS `c`
+WHERE REPLACE(`c`.`CompanyName`, 'A', '%') LIKE '\\%%'
+""");
+        }
+
+        [ConditionalFact]
+        public virtual void EndsWith_with_escape_char()
+        {
+            using var context = CreateContext();
+            var count = context.Customers.Count(c => c.CompanyName.Replace("a", @"\").EndsWith(@"\"));
+
+            Assert.Equal(7, count);
+
+            AssertSql(
+"""
+SELECT COUNT(*)
+FROM `Customers` AS `c`
+WHERE REPLACE(`c`.`CompanyName`, 'a', '\\') LIKE '%\\\\'
+""");
+        }
+
+        [ConditionalFact]
+        public virtual void EndsWith_with_wild_char()
+        {
+            using var context = CreateContext();
+            var count = context.Customers.Count(c => c.CompanyName.Replace("a", @"%").EndsWith(@"%"));
+
+            Assert.Equal(7, count);
+
+            AssertSql(
+"""
+SELECT COUNT(*)
+FROM `Customers` AS `c`
+WHERE REPLACE(`c`.`CompanyName`, 'a', '%') LIKE '%\\%'
+""");
+        }
     }
 }


### PR DESCRIPTION
The `String.Contains()`, `String.StartsWith()` and `String.EndsWith()` translations only escaped the `\` escape char correctly, if the pattern also contained at least one wildcard character (`%` or `_`).

Now, escape characters are always escaped (or at least as long as `NO_BACKSLASH_ESCAPES` is not used; this would probably break our current implementations).

Fixes #1943