### PR TITLE
Set `TranslateParameterizedCollectionsToConstants()` as a default option.

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbContextOptionsBuilderExtensions.cs
@@ -60,7 +60,11 @@ namespace Microsoft.EntityFrameworkCore
 
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
             ConfigureWarnings(optionsBuilder);
-            mySqlOptionsAction?.Invoke(new MySqlDbContextOptionsBuilder(optionsBuilder));
+
+            var mySqlDbContextOptionsBuilder = new MySqlDbContextOptionsBuilder(optionsBuilder)
+                .TranslateParameterizedCollectionsToConstants();
+
+            mySqlOptionsAction?.Invoke(mySqlDbContextOptionsBuilder);
 
             return optionsBuilder;
         }
@@ -102,7 +106,11 @@ namespace Microsoft.EntityFrameworkCore
 
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
             ConfigureWarnings(optionsBuilder);
-            mySqlOptionsAction?.Invoke(new MySqlDbContextOptionsBuilder(optionsBuilder));
+
+            var mySqlDbContextOptionsBuilder = new MySqlDbContextOptionsBuilder(optionsBuilder)
+                .TranslateParameterizedCollectionsToConstants();
+
+            mySqlOptionsAction?.Invoke(mySqlDbContextOptionsBuilder);
 
             return optionsBuilder;
         }
@@ -148,7 +156,11 @@ namespace Microsoft.EntityFrameworkCore
 
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
             ConfigureWarnings(optionsBuilder);
-            mySqlOptionsAction?.Invoke(new MySqlDbContextOptionsBuilder(optionsBuilder));
+
+            var mySqlDbContextOptionsBuilder = new MySqlDbContextOptionsBuilder(optionsBuilder)
+                .TranslateParameterizedCollectionsToConstants();
+
+            mySqlOptionsAction?.Invoke(mySqlDbContextOptionsBuilder);
 
             return optionsBuilder;
         }
@@ -191,7 +203,11 @@ namespace Microsoft.EntityFrameworkCore
 
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
             ConfigureWarnings(optionsBuilder);
-            mySqlOptionsAction?.Invoke(new MySqlDbContextOptionsBuilder(optionsBuilder));
+
+            var mySqlDbContextOptionsBuilder = new MySqlDbContextOptionsBuilder(optionsBuilder)
+                .TranslateParameterizedCollectionsToConstants();
+
+            mySqlOptionsAction?.Invoke(mySqlDbContextOptionsBuilder);
 
             return optionsBuilder;
         }

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStore.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestStore.cs
@@ -109,6 +109,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
         public static MySqlDbContextOptionsBuilder AddOptions(MySqlDbContextOptionsBuilder builder)
         {
             return builder
+                // Our UseMySql() methods explicitly set TranslateParameterizedCollectionsToConstants() as the default, which is not the
+                // default that the EF Core tests expect.
+                .TranslateParameterizedCollectionsToParameters()
                 .UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery)
                 .CommandTimeout(GetCommandTimeout())
                 .ExecutionStrategy(d => new TestMySqlRetryingExecutionStrategy(d));


### PR DESCRIPTION
We set `TranslateParameterizedCollectionsToConstants()` as a default option, so that the query behavior does not break between `8.0` and `9.0`.

Fixes #1955