### PR TITLE
[BACKPORT] Remove explicit reference to `System.Text.Json` package from `Pomelo.EntityFrameworkCore.MySql.Json.Microsoft` package

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -13,7 +13,6 @@
     <PackageReference Update="MySqlConnector.DependencyInjection" Version="2.3.5" />
 
     <PackageReference Update="NetTopologySuite" Version="2.5.0" />
-    <PackageReference Update="System.Text.Json" Version="8.0.3" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
 
     <PackageReference Update="Castle.Core" Version="5.1.1" />

--- a/src/EFCore.MySql.Json.Microsoft/EFCore.MySql.Json.Microsoft.csproj
+++ b/src/EFCore.MySql.Json.Microsoft/EFCore.MySql.Json.Microsoft.csproj
@@ -30,10 +30,6 @@
     <ProjectReference Include="..\EFCore.MySql\EFCore.MySql.csproj" PrivateAssets="contentfiles;build" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(LocalMySqlConnectorRepository)' == ''">
     <PackageReference Include="MySqlConnector" />
   </ItemGroup>


### PR DESCRIPTION
Backports #1906 to 8.0.

Closes #1905