### PR TITLE
Add HasCharSet method for ComplexPropertyBuilder

### DIFF
--- a/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.MySql/Design/Internal/MySqlAnnotationCodeGenerator.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Pomelo.EntityFrameworkCore.MySql.Metadata.Internal;
 
@@ -78,6 +79,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
             = typeof(MySqlPropertyBuilderExtensions).GetRequiredRuntimeMethod(
                 nameof(MySqlPropertyBuilderExtensions.HasCharSet),
                 typeof(PropertyBuilder),
+                typeof(string));
+
+        private static readonly MethodInfo _complexTypePropertyHasCharSetMethodInfo
+            = typeof(MySqlComplexTypePropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(MySqlComplexTypePropertyBuilderExtensions.HasCharSet),
+                typeof(ComplexTypePropertyBuilder),
                 typeof(string));
 
         public MySqlAnnotationCodeGenerator([JetBrains.Annotations.NotNull] AnnotationCodeGeneratorDependencies dependencies)
@@ -262,6 +269,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Design.Internal
             switch (annotation.Name)
             {
                 case MySqlAnnotationNames.CharSet when annotation.Value is string { Length: > 0 } charSet:
+                    if (property.DeclaringType is IComplexType)
+                    {
+                        return new MethodCallCodeFragment(
+                            _complexTypePropertyHasCharSetMethodInfo,
+                            charSet);
+                    }
+
                     return new MethodCallCodeFragment(
                         _propertyHasCharSetMethodInfo,
                         charSet);

--- a/src/EFCore.MySql/Extensions/MySqlComplexTypePropertyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlComplexTypePropertyBuilderExtensions.cs
@@ -13,8 +13,6 @@ namespace Microsoft.EntityFrameworkCore
     /// </summary>
     public static class MySqlComplexTypePropertyBuilderExtensions
     {
-        #region Computed
-
         /// <summary>
         /// Configures the charset for the property's column.
         /// </summary>
@@ -43,8 +41,5 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this ComplexTypePropertyBuilder<TProperty> propertyBuilder,
             string charSet)
             => (ComplexTypePropertyBuilder<TProperty>)HasCharSet((ComplexTypePropertyBuilder)propertyBuilder, charSet);
-
-
-        #endregion Computed
     }
 }

--- a/src/EFCore.MySql/Extensions/MySqlComplexTypePropertyBuilderExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlComplexTypePropertyBuilderExtensions.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Pomelo Foundation. All rights reserved.
+// Licensed under the MIT. See LICENSE in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     MySQL specific extension methods for <see cref="ComplexTypePropertyBuilder" />.
+    /// </summary>
+    public static class MySqlComplexTypePropertyBuilderExtensions
+    {
+        #region Computed
+
+        /// <summary>
+        /// Configures the charset for the property's column.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="charSet">The name of the charset to configure for the property's column.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static ComplexTypePropertyBuilder HasCharSet(
+            [NotNull] this ComplexTypePropertyBuilder propertyBuilder,
+            string charSet)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            var property = propertyBuilder.Metadata;
+            property.SetCharSet(charSet);
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        /// Configures the charset for the property's column.
+        /// </summary>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="charSet">The name of the charset to configure for the property's column.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static ComplexTypePropertyBuilder<TProperty> HasCharSet<TProperty>(
+            [NotNull] this ComplexTypePropertyBuilder<TProperty> propertyBuilder,
+            string charSet)
+            => (ComplexTypePropertyBuilder<TProperty>)HasCharSet((ComplexTypePropertyBuilder)propertyBuilder, charSet);
+
+
+        #endregion Computed
+    }
+}

--- a/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MigrationsMySqlTest.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -1229,17 +1230,24 @@ $@"ALTER TABLE `IceCream` MODIFY COLUMN `Brand` longtext COLLATE {NonDefaultColl
                             e.Property<string>("Name");
                             e.Property<string>("Brand")
                                 .HasCharSet(NonDefaultCharSet);
+
+                            e.ComplexProperty<Dictionary<string, object>>("ComplexProperty")
+                                .Property<string>("Brand")
+                                .HasCharSet(NonDefaultCharSet);
                         }),
                 result =>
                 {
                     var table = Assert.Single(result.Tables);
                     var nameColumn = Assert.Single(table.Columns.Where(c => c.Name == "Name"));
                     var brandColumn = Assert.Single(table.Columns.Where(c => c.Name == "Brand"));
+                    var complexBrandColumn = Assert.Single(table.Columns.Where(c => c.Name == "ComplexProperty_Brand"));
 
                     Assert.Null(nameColumn[MySqlAnnotationNames.CharSet]);
                     Assert.Null(nameColumn.Collation);
                     Assert.Equal(NonDefaultCharSet, brandColumn[MySqlAnnotationNames.CharSet]);
                     Assert.NotEqual(DefaultCollation, brandColumn.Collation);
+                    Assert.Equal(NonDefaultCharSet, complexBrandColumn[MySqlAnnotationNames.CharSet]);
+                    Assert.NotEqual(DefaultCollation, complexBrandColumn.Collation);
                 });
 
             AssertSql(
@@ -1249,6 +1257,7 @@ $@"ALTER TABLE `IceCream` MODIFY COLUMN `Brand` longtext COLLATE {NonDefaultColl
     `IceCreamId` int NOT NULL AUTO_INCREMENT,
     `Brand` longtext CHARACTER SET {NonDefaultCharSet} NULL,
     `Name` longtext COLLATE {DefaultCollation} NULL,
+    `ComplexProperty_Brand` longtext CHARACTER SET {NonDefaultCharSet} NULL,
     CONSTRAINT `PK_IceCream` PRIMARY KEY (`IceCreamId`)
 ) COLLATE={DefaultCollation};");
         }


### PR DESCRIPTION
Hi, this aims to fix an invalid snapshot generated when setting the charset on a `ComplexProperty` property.

```
Snapshot.cs(443,71): error CS1503: Argument 1: cannot convert from 'Microsoft.EntityFrameworkCore.Metadata.Builders.ComplexTypePropertyBuilder<string>' to 'Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder'
```

```cs
b.ComplexProperty<Dictionary<string, object>>("Figure", "...Entity.Figure#File", b1 =>
{
    b1.IsRequired();

    b1.Property<string>("Path")
        .IsRequired()
        .HasMaxLength(256)
        .HasColumnType("varchar(256)")
        .HasColumnName("FigurePath");

        MySqlPropertyBuilderExtensions.HasCharSet(b1.Property<string>("Path"), "utf8mb4");
});
```