### PR TITLE
Fix issue where using `DateTime.UtcNow` and `DateTime.Now` will lose precision when used inside of a query

### DIFF
--- a/src/EFCore.MySql/Query/Internal/MySqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlDateTimeMemberTranslator.cs
@@ -101,13 +101,13 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                             declaringType == typeof(DateTimeOffset)
                                 ? "UTC_TIMESTAMP"
                                 : "CURRENT_TIMESTAMP",
-                            Array.Empty<SqlExpression>(),
+                            new [] { _sqlExpressionFactory.Constant(6)},
                             returnType);
 
                     case nameof(DateTime.UtcNow):
                         return _sqlExpressionFactory.NonNullableFunction(
                             "UTC_TIMESTAMP",
-                            Array.Empty<SqlExpression>(),
+                            new [] { _sqlExpressionFactory.Constant(6)},
                             returnType);
 
                     case nameof(DateTime.Today):

--- a/src/EFCore.MySql/Query/Internal/MySqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlDateTimeMemberTranslator.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Utilities;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
@@ -26,10 +27,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                 { nameof(DateTime.Millisecond), ("microsecond", 1000) },
             };
         private readonly MySqlSqlExpressionFactory _sqlExpressionFactory;
+        private readonly IMySqlOptions _mySqlOptions;
 
-        public MySqlDateTimeMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public MySqlDateTimeMemberTranslator(ISqlExpressionFactory sqlExpressionFactory, IMySqlOptions mySqlOptions)
         {
             _sqlExpressionFactory = (MySqlSqlExpressionFactory)sqlExpressionFactory;
+            _mySqlOptions = mySqlOptions;
         }
 
         public virtual SqlExpression Translate(
@@ -101,13 +104,17 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
                             declaringType == typeof(DateTimeOffset)
                                 ? "UTC_TIMESTAMP"
                                 : "CURRENT_TIMESTAMP",
-                            new [] { _sqlExpressionFactory.Constant(6)},
+                            _mySqlOptions.ServerVersion.Supports.DateTime6 ?
+                                new [] { _sqlExpressionFactory.Constant(6)} :
+                                Array.Empty<SqlExpression>(),
                             returnType);
 
                     case nameof(DateTime.UtcNow):
                         return _sqlExpressionFactory.NonNullableFunction(
                             "UTC_TIMESTAMP",
-                            new [] { _sqlExpressionFactory.Constant(6)},
+                            _mySqlOptions.ServerVersion.Supports.DateTime6 ?
+                                new [] { _sqlExpressionFactory.Constant(6)} :
+                                ArraySegment<SqlExpression>.Empty,
                             returnType);
 
                     case nameof(DateTime.Today):

--- a/src/EFCore.MySql/Query/Internal/MySqlMemberTranslatorProvider.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlMemberTranslatorProvider.cs
@@ -3,19 +3,20 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 {
     public class MySqlMemberTranslatorProvider : RelationalMemberTranslatorProvider
     {
-        public MySqlMemberTranslatorProvider([NotNull] RelationalMemberTranslatorProviderDependencies dependencies)
+        public MySqlMemberTranslatorProvider([NotNull] RelationalMemberTranslatorProviderDependencies dependencies, IMySqlOptions mySqlOptions)
             : base(dependencies)
         {
             var sqlExpressionFactory = (MySqlSqlExpressionFactory)dependencies.SqlExpressionFactory;
 
             AddTranslators(
                 new IMemberTranslator[] {
-                    new MySqlDateTimeMemberTranslator(sqlExpressionFactory),
+                    new MySqlDateTimeMemberTranslator(sqlExpressionFactory, mySqlOptions),
                     new MySqlStringMemberTranslator(sqlExpressionFactory),
                     new MySqlTimeSpanMemberTranslator(sqlExpressionFactory),
                 });

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindDbFunctionsQueryMySqlTest.MySql.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindDbFunctionsQueryMySqlTest.MySql.cs
@@ -20,7 +20,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(YEAR, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+WHERE TIMESTAMPDIFF(YEAR, `o`.`OrderDate`, CURRENT_TIMESTAMP(6)) = 0");
             }
         }
 
@@ -37,7 +37,7 @@ WHERE TIMESTAMPDIFF(YEAR, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(QUARTER, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+WHERE TIMESTAMPDIFF(QUARTER, `o`.`OrderDate`, CURRENT_TIMESTAMP(6)) = 0");
             }
         }
 
@@ -54,7 +54,7 @@ WHERE TIMESTAMPDIFF(QUARTER, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(WEEK, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+WHERE TIMESTAMPDIFF(WEEK, `o`.`OrderDate`, CURRENT_TIMESTAMP(6)) = 0");
             }
         }
 
@@ -71,7 +71,7 @@ WHERE TIMESTAMPDIFF(WEEK, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(MONTH, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+WHERE TIMESTAMPDIFF(MONTH, `o`.`OrderDate`, CURRENT_TIMESTAMP(6)) = 0");
             }
         }
 
@@ -88,7 +88,7 @@ WHERE TIMESTAMPDIFF(MONTH, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(DAY, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+WHERE TIMESTAMPDIFF(DAY, `o`.`OrderDate`, CURRENT_TIMESTAMP(6)) = 0");
             }
         }
 
@@ -105,7 +105,7 @@ WHERE TIMESTAMPDIFF(DAY, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(HOUR, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+WHERE TIMESTAMPDIFF(HOUR, `o`.`OrderDate`, CURRENT_TIMESTAMP(6)) = 0");
             }
         }
 
@@ -122,7 +122,7 @@ WHERE TIMESTAMPDIFF(HOUR, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(MINUTE, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+WHERE TIMESTAMPDIFF(MINUTE, `o`.`OrderDate`, CURRENT_TIMESTAMP(6)) = 0");
             }
         }
 
@@ -139,7 +139,7 @@ WHERE TIMESTAMPDIFF(MINUTE, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(SECOND, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
+WHERE TIMESTAMPDIFF(SECOND, `o`.`OrderDate`, CURRENT_TIMESTAMP(6)) = 0");
             }
         }
 
@@ -156,7 +156,7 @@ WHERE TIMESTAMPDIFF(SECOND, `o`.`OrderDate`, CURRENT_TIMESTAMP()) = 0");
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL CAST(1.0 AS signed) second))) DIV (1000) = 0");
+WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(6), DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL CAST(1.0 AS signed) second))) DIV (1000) = 0");
             }
         }
 
@@ -173,7 +173,7 @@ WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAM
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL CAST(1.0 AS signed) second)) = 0");
+WHERE TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(6), DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL CAST(1.0 AS signed) second)) = 0");
             }
         }
 
@@ -190,7 +190,7 @@ WHERE TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL CAST(1.0 AS signed) second)) * 10) = 0");
+WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(6), DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL CAST(1.0 AS signed) second)) * 10) = 0");
             }
         }
 
@@ -207,7 +207,7 @@ WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAM
                 AssertSql(
                     @"SELECT COUNT(*)
 FROM `Orders` AS `o`
-WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(), DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL CAST(1.0 AS signed) second)) * 1000) = 0");
+WHERE (TIMESTAMPDIFF(MICROSECOND, CURRENT_TIMESTAMP(6), DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL CAST(1.0 AS signed) second)) * 1000) = 0");
             }
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindWhereQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindWhereQueryMySqlTest.cs
@@ -33,7 +33,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
 
 SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE CURRENT_TIMESTAMP() <> @__myDatetime_0");
+WHERE CURRENT_TIMESTAMP(6) <> @__myDatetime_0");
         }
 
         [ConditionalTheory]
@@ -46,7 +46,7 @@ WHERE CURRENT_TIMESTAMP() <> @__myDatetime_0");
 
 SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE UTC_TIMESTAMP() <> @__myDatetime_0");
+WHERE UTC_TIMESTAMP(6) <> @__myDatetime_0");
         }
 
         [ConditionalTheory]
@@ -57,7 +57,7 @@ WHERE UTC_TIMESTAMP() <> @__myDatetime_0");
             AssertSql(
                 @"SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
 FROM `Employees` AS `e`
-WHERE CONVERT(CURRENT_TIMESTAMP(), date) = CURDATE()");
+WHERE CONVERT(CURRENT_TIMESTAMP(6), date) = CURDATE()");
         }
 
         [ConditionalTheory]

--- a/test/EFCore.MySql.FunctionalTests/Query/TPCGearsOfWarQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/TPCGearsOfWarQueryMySqlTest.cs
@@ -3845,7 +3845,7 @@ LEFT JOIN `Weapons` AS `w` ON `w`.`SynergyWithId` IS NOT NULL
 """
 SELECT `m`.`Id`, `m`.`CodeName`, `m`.`Date`, `m`.`Difficulty`, `m`.`Duration`, `m`.`Rating`, `m`.`Time`, `m`.`Timeline`
 FROM `Missions` AS `m`
-WHERE `m`.`Timeline` <> UTC_TIMESTAMP()
+WHERE `m`.`Timeline` <> UTC_TIMESTAMP(6)
 """);
     }
 
@@ -3857,7 +3857,7 @@ WHERE `m`.`Timeline` <> UTC_TIMESTAMP()
 """
 SELECT `m`.`Id`, `m`.`CodeName`, `m`.`Date`, `m`.`Difficulty`, `m`.`Duration`, `m`.`Rating`, `m`.`Time`, `m`.`Timeline`
 FROM `Missions` AS `m`
-WHERE `m`.`Timeline` <> UTC_TIMESTAMP()
+WHERE `m`.`Timeline` <> UTC_TIMESTAMP(6)
 """);
     }
 
@@ -9523,7 +9523,7 @@ FROM `LocustCommanders` AS `l0`
 
         AssertSql(
 """
-SELECT `m`.`Timeline` > UTC_TIMESTAMP()
+SELECT `m`.`Timeline` > UTC_TIMESTAMP(6)
 FROM `Missions` AS `m`
 """);
     }

--- a/test/EFCore.MySql.IntegrationTests/Tests/Models/ExpressionTest.cs
+++ b/test/EFCore.MySql.IntegrationTests/Tests/Models/ExpressionTest.cs
@@ -153,17 +153,20 @@ namespace Pomelo.EntityFrameworkCore.MySql.IntegrationTests.Tests.Models
             await _db.Database.ExecuteSqlRawAsync($"SET @@session.time_zone = '{utcOffsetStr}'");
 #pragma warning restore EF1002
 
+            var utcNow = DateTime.UtcNow;
+            var now = DateTime.Now;
             var result = await _db.DataTypesSimple.Select(m =>
                 new {
                     m.Id,
-                    DateTime.Now,
-                    DateTime.UtcNow
-                }).FirstOrDefaultAsync(m => m.Id == _simple.Id);
+                    Now = now,
+                    UtcNow = utcNow,
+                }).FirstOrDefaultAsync(m => m.Id == _simple.Id && m.UtcNow < DateTime.UtcNow && m.Now < DateTime.Now);
 
             _db.Database.CloseConnection();
 
-            Assert.InRange(result.Now, DateTime.Now - TimeSpan.FromSeconds(5), DateTime.Now + TimeSpan.FromSeconds(5));
-            Assert.InRange(result.UtcNow, DateTime.UtcNow - TimeSpan.FromSeconds(5), DateTime.UtcNow + TimeSpan.FromSeconds(5));
+            Assert.NotNull(result);
+            Assert.Equal(result.Now, DateTime.Now, precision: TimeSpan.FromSeconds(10));
+            Assert.Equal(result.UtcNow, DateTime.UtcNow, precision: TimeSpan.FromSeconds(10));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1987

Hope this helps out!

