### PR TITLE
Prepare RC release

### DIFF
--- a/Development.props.sample
+++ b/Development.props.sample
@@ -16,7 +16,7 @@
       referenced by Microsoft.AspNetCore.Identity.EntityFrameworkCore
       (e.g. "6.0.0.0").
 
-      To achive that, run the following command in your EntityFrameworkCore
+      To achieve that, run the following command in your EntityFrameworkCore
       base directory:
 
       dotnet build "/p:AssemblyVersion=6.0.0.0"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,8 @@
 <Project>
   <PropertyGroup Label="Common Versions">
+    <!-- We shoud try: [9.0.0,9.1.0-0)
+         `-0` is the smallest possible prerelease version according to SemVer2.
+    -->
     <EFCoreVersion>[9.0.0,9.0.999]</EFCoreVersion>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Release | Branch                                                                
 
 ### Supported Database Servers and Versions
 
-`Pomelo.EntityFrameworkCore.MySql` is tested against all actively maintained versions of `MySQL` and `MariaDB`. Older versions (e.g. MySQL 5.7) and other server implementations (e.g. Amazon Aurora) are usually compatible to a high degree as well, but are not tested as part of our CI. You can find the versions a release was tested against within its [release](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/releases) notes.
+`Pomelo.EntityFrameworkCore.MySql` is tested against all actively maintained versions of `MySQL` and `MariaDB`. Older versions (e.g. MySQL 5.7) and other server implementations (e.g. Amazon Aurora) are usually compatible to a high degree as well, but are not tested as part of our CI. You can find a list of the versions, a release was tested against, within its [release](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/releases) notes.
 
 Currently tested versions are:
 

--- a/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore
     public class MariaDbServerVersion : ServerVersion
     {
         public static readonly string MariaDbTypeIdentifier = nameof(ServerType.MariaDb).ToLowerInvariant();
-        public static readonly ServerVersion LatestSupportedServerVersion = new MariaDbServerVersion(new Version(11, 3, 2));
+        public static readonly ServerVersion LatestSupportedServerVersion = new MariaDbServerVersion(new Version(11, 6, 2));
 
         public override ServerVersionSupport Supports { get; }
 

--- a/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MySqlServerVersion.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore
     public class MySqlServerVersion : ServerVersion
     {
         public static readonly string MySqlTypeIdentifier = nameof(ServerType.MySql).ToLowerInvariant();
-        public static readonly ServerVersion LatestSupportedServerVersion = new MySqlServerVersion(new Version(8, 0, 36));
+        public static readonly ServerVersion LatestSupportedServerVersion = new MySqlServerVersion(new Version(8, 4, 3));
 
         public override ServerVersionSupport Supports { get; }
 

--- a/src/EFCore.MySql/Query/Internal/MySqlQueryCompilationContext.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQueryCompilationContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -10,13 +11,27 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
     {
         public MySqlQueryCompilationContext(
             [NotNull] QueryCompilationContextDependencies dependencies,
-            [NotNull] RelationalQueryCompilationContextDependencies relationalDependencies, bool async)
+            [NotNull] RelationalQueryCompilationContextDependencies relationalDependencies,
+            bool async)
             : base(dependencies, relationalDependencies, async)
+        {
+        }
+
+        public MySqlQueryCompilationContext(
+            [NotNull] QueryCompilationContextDependencies dependencies,
+            [NotNull] RelationalQueryCompilationContextDependencies relationalDependencies,
+            bool async,
+            bool precompiling,
+            IReadOnlySet<string> nonNullableReferenceTypeParameters)
+            : base(dependencies, relationalDependencies, async, precompiling, nonNullableReferenceTypeParameters)
         {
         }
 
         public override bool IsBuffering
             => base.IsBuffering ||
                QuerySplittingBehavior == Microsoft.EntityFrameworkCore.QuerySplittingBehavior.SplitQuery;
+
+        /// <inheritdoc />
+        public override bool SupportsPrecompiledQuery => false;
     }
 }

--- a/src/EFCore.MySql/Query/Internal/MySqlQueryCompilationContextFactory.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQueryCompilationContextFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Pomelo Foundation. All rights reserved.
 // Licensed under the MIT. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -25,5 +26,9 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal
 
         public virtual QueryCompilationContext Create(bool async)
             => new MySqlQueryCompilationContext(_dependencies, _relationalDependencies, async);
+
+        public virtual QueryCompilationContext CreatePrecompiled(bool async, IReadOnlySet<string> nonNullableReferenceTypeParameters)
+            => new MySqlQueryCompilationContext(
+                _dependencies, _relationalDependencies, async, precompiling: true, nonNullableReferenceTypeParameters);
     }
 }

--- a/test/EFCore.MySql.FunctionalTests/MySqlComplianceTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/MySqlComplianceTest.cs
@@ -38,7 +38,6 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
             // TODO: 9.0
             typeof(AdHocComplexTypeQueryTestBase),
             typeof(AdHocPrecompiledQueryRelationalTestBase),
-            typeof(JsonQueryRelationalTestBase<>),
             typeof(PrecompiledQueryRelationalTestBase),
             typeof(PrecompiledSqlPregenerationQueryRelationalTestBase),
 
@@ -48,6 +47,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests
 
             // We have our own JSON support for now
             typeof(AdHocJsonQueryTestBase),
+            typeof(JsonQueryRelationalTestBase<>),
             typeof(JsonQueryTestBase<>),
             typeof(JsonTypesRelationalTestBase),
             typeof(JsonTypesTestBase),

--- a/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestHelpers.cs
+++ b/test/EFCore.MySql.FunctionalTests/TestUtilities/MySqlTestHelpers.cs
@@ -128,10 +128,11 @@ namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities
 
         public static bool HasPrimitiveCollectionsSupport<TContext>(SharedStoreFixtureBase<TContext> fixture)
             where TContext : DbContext
-        {
-            return AppConfig.ServerVersion.Supports.JsonTable &&
-                   fixture.CreateOptions().GetExtension<MySqlOptionsExtension>().PrimitiveCollectionsSupport;
-        }
+            => HasPrimitiveCollectionsSupport(fixture.CreateOptions());
+
+        public static bool HasPrimitiveCollectionsSupport(DbContextOptions options)
+            => AppConfig.ServerVersion.Supports.JsonTable &&
+               options.GetExtension<MySqlOptionsExtension>().PrimitiveCollectionsSupport;
 
         /// <summary>
         /// Same implementation as EF Core base class, except that it can generate code for Task returning test without a `bool async`


### PR DESCRIPTION
This does just some minor cleanup. We are mainly using it (and the following RC release) to ensure that our release pipeline still works as expected, before the GA release.