### PR TITLE
Do not force json to use JSON functions

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonDbFunctionsTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlJsonDbFunctionsTranslator.cs
@@ -145,13 +145,7 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal
 
             return result;
 
-            SqlExpression Json(SqlExpression e) => _sqlExpressionFactory.ApplyTypeMapping(EnsureJson(e), _sqlExpressionFactory.FindMapping(e.Type, "json"));
-
-            static SqlExpression EnsureJson(SqlExpression e)
-                => e.TypeMapping is MySqlJsonTypeMapping ||
-                   e is MySqlJsonTraversalExpression
-                    ? e
-                    : throw new InvalidOperationException("The JSON method requires a JSON parameter but none was found.");
+            SqlExpression Json(SqlExpression e) => _sqlExpressionFactory.ApplyTypeMapping(e, _sqlExpressionFactory.FindMapping(e.Type, "json"));
 
             static SqlExpression RemoveConvert(SqlExpression e)
             {


### PR DESCRIPTION
We are using scaffolding to create our database classes. Sadly, the scaffold does not support json on the json field, instead opting for string.

This change will let the user use JSON functions more freely

