### PR TITLE
Add test for ExecuteUpdate SetProperty ordering

### DIFF
--- a/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.BulkUpdates;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -1474,6 +1475,28 @@ INNER JOIN `Orders` AS `o0` ON `o`.`OrderID` = `o0`.`OrderID`
 WHERE `p`.`Discontinued` AND (`o0`.`OrderDate` > TIMESTAMP '1990-01-01 00:00:00')
 """);
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_Where_set_ordering_is_preserved(bool async)
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            Fixture.CreateContext, Fixture.UseTransaction,
+            async context =>
+            {
+                var updated = await context.Set<Customer>().ExecuteUpdateAsync(
+                    setters => setters
+                        .SetProperty(c => c.ContactName, "X")
+                        .SetProperty(c => c.ContactTitle, c => c.ContactName + "Y"));
+                Assert.True(updated > 0);
+                Assert.Equal(updated, await context.Set<Customer>().CountAsync(c => c.ContactTitle == "XY"));
+
+                updated = await context.Set<Customer>().ExecuteUpdateAsync(
+                    setters => setters
+                        .SetProperty(c => c.City, "Y")
+                        .SetProperty(c => c.ContactName, c => c.City + "X"));
+                Assert.True(updated > 0);
+                Assert.Equal(updated, await context.Set<Customer>().CountAsync(c => c.ContactName == "YX"));
+            });
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
## Summary

- Add `Update_Where_set_ordering_is_preserved` test to `NorthwindBulkUpdatesMySqlTest` to verify that the upstream EF Core fix ([dotnet/efcore#35361](https://github.com/dotnet/efcore/issues/35361)) correctly preserves `SetProperty` ordering for MySQL's left-to-right SET clause evaluation.
- Test code follows @roji's [suggestion](https://github.com/dotnet/efcore/issues/35361#issuecomment-2556914129).

## Note

This test is expected to fail on EF Core 9, since the fix ([dotnet/efcore#35257](https://github.com/dotnet/efcore/pull/35257)) is only included in EF Core 10. As @lauxjpn [mentioned](https://github.com/dotnet/efcore/issues/35361#issuecomment-2556914129), this test is intended to be merged when the project upgrades to EF Core 10.

Fixes #1975